### PR TITLE
Be explicit about what frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To contribute a skill:
 
 **General Skills**: No frontmatter needed
 
-**Keyword-Triggered Skills**: Required frontmatter
+**Keyword-Triggered Skills**: Frontmatter required to specify triggers
 ```yaml
 ---
 triggers:


### PR DESCRIPTION
This PR proposes a small tweak to be explicit about what/why frontmatter is necessary for keyword skills. Just seems to me it reads better.