### PR TITLE
Add gh run watch guidance for GitHub Actions monitoring

### DIFF
--- a/skills/github.md
+++ b/skills/github.md
@@ -15,7 +15,10 @@ the GitHub API.
 You can use `curl` with the `GITHUB_TOKEN` to interact with GitHub's API.
 ALWAYS use the GitHub API for operations instead of a web browser.
 ALWAYS use the `create_pr` tool to open a pull request
-If the user asks you to check GitHub Actions status, first try `gh run watch` (https://cli.github.com/manual/gh_run_watch) to monitor workflow runs (make sure you set a larger timeout for your bash command so CI can finish), and only fallback to basic API calls if that fails.
+If the user asks you to check GitHub Actions status, first try to use `gh` to work with workflows, and only fallback to basic API calls if that fails.
+Examples:
+- `gh run watch` (https://cli.github.com/manual/gh_run_watch) to monitor workflow runs
+- `gh pr checks 200 --watch --interval 10` to check until completed.
 </IMPORTANT>
 
 If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`

--- a/skills/github.md
+++ b/skills/github.md
@@ -15,6 +15,7 @@ the GitHub API.
 You can use `curl` with the `GITHUB_TOKEN` to interact with GitHub's API.
 ALWAYS use the GitHub API for operations instead of a web browser.
 ALWAYS use the `create_pr` tool to open a pull request
+If the user asks you to check GitHub Actions status, first try to use `gh run watch` (https://cli.github.com/manual/gh_run_watch) to monitor workflow runs, and only fallback to basic API calls if it is not successful.
 </IMPORTANT>
 
 If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`

--- a/skills/github.md
+++ b/skills/github.md
@@ -15,7 +15,7 @@ the GitHub API.
 You can use `curl` with the `GITHUB_TOKEN` to interact with GitHub's API.
 ALWAYS use the GitHub API for operations instead of a web browser.
 ALWAYS use the `create_pr` tool to open a pull request
-If the user asks you to check GitHub Actions status, first try to use `gh run watch` (https://cli.github.com/manual/gh_run_watch) to monitor workflow runs, and only fallback to basic API calls if it is not successful.
+If the user asks you to check GitHub Actions status, first try `gh run watch` (https://cli.github.com/manual/gh_run_watch) to monitor workflow runs (make sure you set a larger timeout for your bash command so CI can finish), and only fallback to basic API calls if that fails.
 </IMPORTANT>
 
 If you encounter authentication issues when pushing to GitHub (such as password prompts or permission errors), the old token may have expired. In such case, update the remote URL to include the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git`


### PR DESCRIPTION
## Summary
This PR updates the GitHub skills documentation to instruct agents to prioritize using `gh run watch` for monitoring GitHub Actions workflow runs.

## Changes
- Added guidance in `skills/github.md` to use `gh run watch` (https://cli.github.com/manual/gh_run_watch) as the primary method for checking GitHub Actions status
- Agents will fallback to basic API calls only if `gh run watch` is not successful

## Context
This change relates to issue #1285 which aims to improve OpenHands' capacity at monitoring async actions like GitHub CI runs. The `gh` CLI tool is well-known to LLMs and provides a better interface for monitoring workflow runs than polling with basic API calls.

## Benefits
- **Better async monitoring**: `gh run watch` is specifically designed for watching workflow runs until completion
- **Familiar tool**: LLMs have good knowledge of the GitHub CLI
- **Graceful fallback**: Still supports basic API calls as a backup method

Closes #1285 (partial - addresses the GitHub CI monitoring aspect)

Co-authored-by: openhands <openhands@all-hands.dev>

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7ab89709081c4e91b273700a0ecbd614)