### PR TITLE
Add Jupyter notebook skill

### DIFF
--- a/skills/jupyter.md
+++ b/skills/jupyter.md
@@ -10,185 +10,43 @@ triggers:
 
 # Jupyter Notebook Guide
 
-## Programmatic Notebook Modification
+Notebooks are JSON files. Cells are in `nb['cells']`, each has `source` (list of strings) and `cell_type` ('code', 'markdown', or 'raw').
 
-When modifying Jupyter notebooks programmatically, use Python's JSON library since notebooks are JSON files:
-
+## Modifying Notebooks
 ```python
 import json
-
-# Load the notebook
 with open('notebook.ipynb') as f:
     nb = json.load(f)
-
-# Cells are in nb['cells'], each has 'source' (list of strings) and 'cell_type'
-# cell_type can be 'code', 'markdown', or 'raw'
-cell = nb['cells'][cell_index]
-source_lines = cell['source']
-
-# Modify source_lines as needed, then save
+# Modify nb['cells'][i]['source'], then:
 with open('notebook.ipynb', 'w') as f:
     json.dump(nb, f, indent=1)
 ```
 
-## Creating a New Notebook
-
-```python
-import json
-
-notebook = {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": ["# My Notebook\n"]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": None,
-            "metadata": {},
-            "outputs": [],
-            "source": ["print('Hello, World!')\n"]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "name": "python",
-            "version": "3.10.0"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
-}
-
-with open('new_notebook.ipynb', 'w') as f:
-    json.dump(notebook, f, indent=1)
-```
-
-## Executing Notebooks
-
-Execute a notebook and update it in place:
-
+## Executing & Converting
 ```bash
-jupyter nbconvert --to notebook --execute --inplace notebook.ipynb
+jupyter nbconvert --to notebook --execute --inplace notebook.ipynb  # Execute in place
+jupyter nbconvert --to html notebook.ipynb      # Convert to HTML
+jupyter nbconvert --to script notebook.ipynb    # Convert to Python
+jupyter nbconvert --to markdown notebook.ipynb  # Convert to Markdown
 ```
 
-Execute and convert to other formats:
-
-```bash
-# Convert to HTML
-jupyter nbconvert --to html notebook.ipynb
-
-# Convert to PDF (requires pandoc and LaTeX)
-jupyter nbconvert --to pdf notebook.ipynb
-
-# Convert to Python script
-jupyter nbconvert --to script notebook.ipynb
-
-# Convert to Markdown
-jupyter nbconvert --to markdown notebook.ipynb
-```
-
-## Finding Code in Notebooks
-
-Quick search using grep:
-
+## Finding Code
 ```bash
 grep -n "search_term" notebook.ipynb
 ```
 
-Programmatic search through cells:
-
+## Cell Structure
 ```python
-import json
-
-with open('notebook.ipynb') as f:
-    nb = json.load(f)
-
-for i, cell in enumerate(nb['cells']):
-    source = ''.join(cell['source'])
-    if 'search_term' in source:
-        print(f"Found in cell {i} ({cell['cell_type']})")
+# Code cell
+{"cell_type": "code", "execution_count": None, "metadata": {}, "outputs": [], "source": ["code\n"]}
+# Markdown cell
+{"cell_type": "markdown", "metadata": {}, "source": ["# Title\n"]}
 ```
 
-## Installing Jupyter
-
-```bash
-pip install jupyter notebook
-
-# Or with JupyterLab
-pip install jupyterlab
-```
-
-## Running Jupyter
-
-```bash
-# Start Jupyter Notebook server
-jupyter notebook
-
-# Start JupyterLab
-jupyter lab
-
-# Run in background with no browser
-jupyter notebook --no-browser --port=8888 &
-```
-
-## Common Cell Operations
-
-### Add a new cell
-
+## Clear Outputs
 ```python
-import json
-
-with open('notebook.ipynb') as f:
-    nb = json.load(f)
-
-new_cell = {
-    "cell_type": "code",
-    "execution_count": None,
-    "metadata": {},
-    "outputs": [],
-    "source": ["# New code cell\n"]
-}
-
-nb['cells'].append(new_cell)
-
-with open('notebook.ipynb', 'w') as f:
-    json.dump(nb, f, indent=1)
-```
-
-### Delete a cell
-
-```python
-import json
-
-with open('notebook.ipynb') as f:
-    nb = json.load(f)
-
-del nb['cells'][cell_index]
-
-with open('notebook.ipynb', 'w') as f:
-    json.dump(nb, f, indent=1)
-```
-
-### Clear all outputs
-
-```python
-import json
-
-with open('notebook.ipynb') as f:
-    nb = json.load(f)
-
 for cell in nb['cells']:
     if cell['cell_type'] == 'code':
         cell['outputs'] = []
         cell['execution_count'] = None
-
-with open('notebook.ipynb', 'w') as f:
-    json.dump(nb, f, indent=1)
 ```

--- a/skills/jupyter.md
+++ b/skills/jupyter.md
@@ -1,0 +1,194 @@
+---
+name: jupyter
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers:
+- ipynb
+- jupyter
+---
+
+# Jupyter Notebook Guide
+
+## Programmatic Notebook Modification
+
+When modifying Jupyter notebooks programmatically, use Python's JSON library since notebooks are JSON files:
+
+```python
+import json
+
+# Load the notebook
+with open('notebook.ipynb') as f:
+    nb = json.load(f)
+
+# Cells are in nb['cells'], each has 'source' (list of strings) and 'cell_type'
+# cell_type can be 'code', 'markdown', or 'raw'
+cell = nb['cells'][cell_index]
+source_lines = cell['source']
+
+# Modify source_lines as needed, then save
+with open('notebook.ipynb', 'w') as f:
+    json.dump(nb, f, indent=1)
+```
+
+## Creating a New Notebook
+
+```python
+import json
+
+notebook = {
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": ["# My Notebook\n"]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {},
+            "outputs": [],
+            "source": ["print('Hello, World!')\n"]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "name": "python",
+            "version": "3.10.0"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}
+
+with open('new_notebook.ipynb', 'w') as f:
+    json.dump(notebook, f, indent=1)
+```
+
+## Executing Notebooks
+
+Execute a notebook and update it in place:
+
+```bash
+jupyter nbconvert --to notebook --execute --inplace notebook.ipynb
+```
+
+Execute and convert to other formats:
+
+```bash
+# Convert to HTML
+jupyter nbconvert --to html notebook.ipynb
+
+# Convert to PDF (requires pandoc and LaTeX)
+jupyter nbconvert --to pdf notebook.ipynb
+
+# Convert to Python script
+jupyter nbconvert --to script notebook.ipynb
+
+# Convert to Markdown
+jupyter nbconvert --to markdown notebook.ipynb
+```
+
+## Finding Code in Notebooks
+
+Quick search using grep:
+
+```bash
+grep -n "search_term" notebook.ipynb
+```
+
+Programmatic search through cells:
+
+```python
+import json
+
+with open('notebook.ipynb') as f:
+    nb = json.load(f)
+
+for i, cell in enumerate(nb['cells']):
+    source = ''.join(cell['source'])
+    if 'search_term' in source:
+        print(f"Found in cell {i} ({cell['cell_type']})")
+```
+
+## Installing Jupyter
+
+```bash
+pip install jupyter notebook
+
+# Or with JupyterLab
+pip install jupyterlab
+```
+
+## Running Jupyter
+
+```bash
+# Start Jupyter Notebook server
+jupyter notebook
+
+# Start JupyterLab
+jupyter lab
+
+# Run in background with no browser
+jupyter notebook --no-browser --port=8888 &
+```
+
+## Common Cell Operations
+
+### Add a new cell
+
+```python
+import json
+
+with open('notebook.ipynb') as f:
+    nb = json.load(f)
+
+new_cell = {
+    "cell_type": "code",
+    "execution_count": None,
+    "metadata": {},
+    "outputs": [],
+    "source": ["# New code cell\n"]
+}
+
+nb['cells'].append(new_cell)
+
+with open('notebook.ipynb', 'w') as f:
+    json.dump(nb, f, indent=1)
+```
+
+### Delete a cell
+
+```python
+import json
+
+with open('notebook.ipynb') as f:
+    nb = json.load(f)
+
+del nb['cells'][cell_index]
+
+with open('notebook.ipynb', 'w') as f:
+    json.dump(nb, f, indent=1)
+```
+
+### Clear all outputs
+
+```python
+import json
+
+with open('notebook.ipynb') as f:
+    nb = json.load(f)
+
+for cell in nb['cells']:
+    if cell['cell_type'] == 'code':
+        cell['outputs'] = []
+        cell['execution_count'] = None
+
+with open('notebook.ipynb', 'w') as f:
+    json.dump(nb, f, indent=1)
+```


### PR DESCRIPTION
## Summary

Add a new knowledge skill for working with Jupyter notebooks, triggered by `ipynb` or `jupyter` keywords.

## Changes

This PR adds `skills/jupyter.md` which provides guidance on:

- **Programmatic notebook modification** - Loading, modifying, and saving `.ipynb` files using Python's JSON library
- **Creating new notebooks** - Full template with cells, metadata, and kernel info
- **Executing notebooks** - Using `jupyter nbconvert` with `--execute --inplace`
- **Converting to other formats** - HTML, PDF, Python script, Markdown
- **Finding code in notebooks** - Both grep-based and programmatic search
- **Installing Jupyter** - pip commands for notebook and JupyterLab
- **Running Jupyter** - Starting servers, including background mode
- **Common cell operations** - Adding cells, deleting cells, clearing outputs

## Testing

The skill follows the same YAML frontmatter format as other skills in the repository (type: knowledge, agent: CodeActAgent) and has been verified to match the structure of existing skills like `docker.md` and `github.md`.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)