### PR TITLE
Convert to agentskills format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Public registry of **Skills** for [OpenHands](https://github.com/OpenHands/OpenHands) - reusable guidelines that customize agent behavior.
 Check the [documentation](https://docs.openhands.dev/overview/skills) for more information.
 
-> **Note**: Skills were previously called Skills. The `.openhands/skills/` folder path still works for backward compatibility.
+> **Note**: Skills were previously called Microagents. The `.openhands/microagents/` folder path still works for backward compatibility.
 
 ## What are Skills?
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Public registry of **Skills** for [OpenHands](https://github.com/OpenHands/OpenHands) - reusable guidelines that customize agent behavior.
 Check the [documentation](https://docs.openhands.dev/overview/skills) for more information.
 
-> **Note**: Skills were previously called Microagents. The `.openhands/microagents/` folder path still works for backward compatibility.
+> **Note**: Skills were previously called Skills. The `.openhands/skills/` folder path still works for backward compatibility.
 
 ## What are Skills?
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -151,7 +151,7 @@ You can see an example of a repo agent in [the agent for the OpenHands repo itse
 
 1. Create your agent file in the appropriate directory:
    - `skills/` for expertise (public, shareable)
-   - Note: Repository-specific agents should remain in their respective repositories' `.openhands/skills/` (V1) or `.openhands/skills/` (V0) directory
+   - Note: Repository-specific agents should remain in their respective repositories' `.openhands/skills/` (V1) or `.openhands/microagents/` (V0) directory
 2. Test thoroughly
 3. Submit a pull request to OpenHands
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -63,7 +63,7 @@ your-repository/
 
 When OpenHands works with a repository, it:
 
-1. Loads repository-specific instructions from `.openhands/skills/repo.md` (V0) or `.openhands/skills/` (V1) if present
+1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` (V1) if present
 2. Loads relevant knowledge agents based on keywords in conversations
 
 **Note**: V1 also supports loading from `.openhands/skills/` for backward compatibility.

--- a/skills/README.md
+++ b/skills/README.md
@@ -10,7 +10,7 @@ Skills are specialized prompts that enhance OpenHands with domain-specific knowl
 
 This directory (`OpenHands/skills/`) contains shareable skills that will be used in V1 conversations. For V0 conversations, the system continues to use skills from the same underlying files.
 
-## Sources of Skills/Skills
+## Sources of Skills
 
 OpenHands loads skills (V1) or skills (V0) from two sources:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -66,7 +66,7 @@ When OpenHands works with a repository, it:
 1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` (V1) if present
 2. Loads relevant knowledge agents based on keywords in conversations
 
-**Note**: V1 also supports loading from `.openhands/skills/` for backward compatibility.
+**Note**: V1 also supports loading from `.openhands/microagents/` for backward compatibility.
 
 ## Types of Skills
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -14,7 +14,7 @@ This directory (`OpenHands/skills/`) contains shareable skills that will be used
 
 OpenHands loads skills (V1) or skills (V0) from two sources:
 
-### 1. Shareable Skills/Skills (Public)
+### 1. Shareable Skills (Public)
 
 This directory (`OpenHands/skills/`) contains shareable skills (V1) or skills (V0) that are:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -94,7 +94,7 @@ You can see an example of a knowledge-based agent in [OpenHands's github skill](
 
 Repository agents provide repository-specific knowledge and guidelines. They are:
 
-- Loaded from `.openhands/skills/repo.md` (V0) or `.openhands/skills/` directory (V1)
+- Loaded from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` directory (V1)
 - V1 also supports `.openhands/skills/` for backward compatibility
 - Specific to individual repositories
 - Automatically activated for their repository

--- a/skills/README.md
+++ b/skills/README.md
@@ -70,7 +70,7 @@ When OpenHands works with a repository, it:
 
 ## Types of Skills/Skills
 
-Most skills/skills use markdown files with YAML frontmatter. For repository agents (repo.md), the frontmatter is optional - if not provided, the file will be loaded with default settings as a repository agent.
+Most skills use markdown files with YAML frontmatter. For repository agents (repo.md), the frontmatter is optional - if not provided, the file will be loaded with default settings as a repository agent.
 
 ### 1. Knowledge Agents
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,7 +39,7 @@ OpenHands/skills/
 
 ### 2. Repository Instructions (Private)
 
-Each repository can have its own instructions in `.openhands/skills/` (V0) or `.openhands/skills/` (V1). These instructions are:
+Each repository can have its own instructions in `.openhands/microagents/` (V0) or `.openhands/skills/` (V1). These instructions are:
 
 - Private to that repository
 - Automatically loaded when working with that repository

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,24 +4,24 @@ Skills are specialized prompts that enhance OpenHands with domain-specific knowl
 
 ## Terminology Note
 
-**Version 0 (V0)**: The term "microagents" continues to be used for V0 conversations. V0 is the current stable version of OpenHands.
+**Version 0 (V0)**: The term "skills" continues to be used for V0 conversations. V0 is the current stable version of OpenHands.
 
 **Version 1 (V1)**: The term "skills" is used for V1 conversations. V1 UI and app server have not yet been released, but the codebase has been updated to use "skills" terminology in preparation for the V1 release.
 
-This directory (`OpenHands/skills/`) contains shareable skills that will be used in V1 conversations. For V0 conversations, the system continues to use microagents from the same underlying files.
+This directory (`OpenHands/skills/`) contains shareable skills that will be used in V1 conversations. For V0 conversations, the system continues to use skills from the same underlying files.
 
-## Sources of Skills/Microagents
+## Sources of Skills/Skills
 
-OpenHands loads skills (V1) or microagents (V0) from two sources:
+OpenHands loads skills (V1) or skills (V0) from two sources:
 
-### 1. Shareable Skills/Microagents (Public)
+### 1. Shareable Skills/Skills (Public)
 
-This directory (`OpenHands/skills/`) contains shareable skills (V1) or microagents (V0) that are:
+This directory (`OpenHands/skills/`) contains shareable skills (V1) or skills (V0) that are:
 
 - Available to all OpenHands users
 - Maintained in the OpenHands repository
 - Perfect for reusable knowledge and common workflows
-- Used as "skills" in V1 conversations and "microagents" in V0 conversations
+- Used as "skills" in V1 conversations and "skills" in V0 conversations
 
 Directory structure:
 
@@ -31,7 +31,7 @@ OpenHands/skills/
 │   ├── git.md         # Git operations
 │   ├── testing.md     # Testing practices
 │   └── docker.md      # Docker guidelines
-└── # These skills/microagents are always loaded
+└── # These skills/skills are always loaded
     ├── pr_review.md   # PR review process
     ├── bug_fix.md     # Bug fixing workflow
     └── feature.md     # Feature implementation
@@ -39,12 +39,12 @@ OpenHands/skills/
 
 ### 2. Repository Instructions (Private)
 
-Each repository can have its own instructions in `.openhands/microagents/` (V0) or `.openhands/skills/` (V1). These instructions are:
+Each repository can have its own instructions in `.openhands/skills/` (V0) or `.openhands/skills/` (V1). These instructions are:
 
 - Private to that repository
 - Automatically loaded when working with that repository
 - Perfect for repository-specific guidelines and team practices
-- V1 supports both `.openhands/skills/` (preferred) and `.openhands/microagents/` (backward compatibility)
+- V1 supports both `.openhands/skills/` (preferred) and `.openhands/skills/` (backward compatibility)
 
 Example repository structure:
 
@@ -54,7 +54,7 @@ your-repository/
     ├── skills/        # V1: Preferred location for repository-specific skills
     │   └── repo.md    # Repository-specific instructions
     │   └── ...        # Private skills that are only available inside this
-    └── microagents/   # V0: Current location (also supported in V1 for backward compatibility)
+    └── skills/   # V0: Current location (also supported in V1 for backward compatibility)
         └── repo.md    # Repository-specific instructions
         └── ...        # Private micro-agents that are only available inside this repo
 ```
@@ -63,14 +63,14 @@ your-repository/
 
 When OpenHands works with a repository, it:
 
-1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` (V1) if present
+1. Loads repository-specific instructions from `.openhands/skills/repo.md` (V0) or `.openhands/skills/` (V1) if present
 2. Loads relevant knowledge agents based on keywords in conversations
 
-**Note**: V1 also supports loading from `.openhands/microagents/` for backward compatibility.
+**Note**: V1 also supports loading from `.openhands/skills/` for backward compatibility.
 
-## Types of Skills/Microagents
+## Types of Skills/Skills
 
-Most skills/microagents use markdown files with YAML frontmatter. For repository agents (repo.md), the frontmatter is optional - if not provided, the file will be loaded with default settings as a repository agent.
+Most skills/skills use markdown files with YAML frontmatter. For repository agents (repo.md), the frontmatter is optional - if not provided, the file will be loaded with default settings as a repository agent.
 
 ### 1. Knowledge Agents
 
@@ -94,8 +94,8 @@ You can see an example of a knowledge-based agent in [OpenHands's github skill](
 
 Repository agents provide repository-specific knowledge and guidelines. They are:
 
-- Loaded from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` directory (V1)
-- V1 also supports `.openhands/microagents/` for backward compatibility
+- Loaded from `.openhands/skills/repo.md` (V0) or `.openhands/skills/` directory (V1)
+- V1 also supports `.openhands/skills/` for backward compatibility
 - Specific to individual repositories
 - Automatically activated for their repository
 - Perfect for team practices and project conventions
@@ -107,7 +107,7 @@ Key features:
 - **Always active**: Automatically loaded for the repository
 - **Locally maintained**: Updated with the project
 
-You can see an example of a repo agent in [the agent for the OpenHands repo itself](https://github.com/OpenHands/OpenHands/blob/main/.openhands/microagents/repo.md).
+You can see an example of a repo agent in [the agent for the OpenHands repo itself](https://github.com/OpenHands/OpenHands/blob/main/.openhands/skills/repo.md).
 
 ## Contributing
 
@@ -151,10 +151,10 @@ You can see an example of a repo agent in [the agent for the OpenHands repo itse
 
 1. Create your agent file in the appropriate directory:
    - `skills/` for expertise (public, shareable)
-   - Note: Repository-specific agents should remain in their respective repositories' `.openhands/skills/` (V1) or `.openhands/microagents/` (V0) directory
+   - Note: Repository-specific agents should remain in their respective repositories' `.openhands/skills/` (V1) or `.openhands/skills/` (V0) directory
 2. Test thoroughly
 3. Submit a pull request to OpenHands
 
 ## License
 
-All skills/microagents are subject to the same license as OpenHands. See the root LICENSE file for details.
+All skills/skills are subject to the same license as OpenHands. See the root LICENSE file for details.

--- a/skills/README.md
+++ b/skills/README.md
@@ -54,7 +54,7 @@ your-repository/
     ├── skills/        # V1: Preferred location for repository-specific skills
     │   └── repo.md    # Repository-specific instructions
     │   └── ...        # Private skills that are only available inside this
-    └── skills/   # V0: Current location (also supported in V1 for backward compatibility)
+    └── microagents/   # V0: Current location (also supported in V1 for backward compatibility)
         └── repo.md    # Repository-specific instructions
         └── ...        # Private micro-agents that are only available inside this repo
 ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -68,7 +68,7 @@ When OpenHands works with a repository, it:
 
 **Note**: V1 also supports loading from `.openhands/skills/` for backward compatibility.
 
-## Types of Skills/Skills
+## Types of Skills
 
 Most skills use markdown files with YAML frontmatter. For repository agents (repo.md), the frontmatter is optional - if not provided, the file will be loaded with default settings as a repository agent.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -157,4 +157,4 @@ You can see an example of a repo agent in [the agent for the OpenHands repo itse
 
 ## License
 
-All skills/skills are subject to the same license as OpenHands. See the root LICENSE file for details.
+All skills are subject to the same license as OpenHands. See the root LICENSE file for details.

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,7 +31,7 @@ OpenHands/skills/
 │   ├── git.md         # Git operations
 │   ├── testing.md     # Testing practices
 │   └── docker.md      # Docker guidelines
-└── # These skills/skills are always loaded
+└── # These skills are always loaded
     ├── pr_review.md   # PR review process
     ├── bug_fix.md     # Bug fixing workflow
     └── feature.md     # Feature implementation

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,7 @@ Each repository can have its own instructions in `.openhands/microagents/` (V0) 
 - Private to that repository
 - Automatically loaded when working with that repository
 - Perfect for repository-specific guidelines and team practices
-- V1 supports both `.openhands/skills/` (preferred) and `.openhands/skills/` (backward compatibility)
+- V1 supports both `.openhands/skills/` (preferred) and `.openhands/microagents/` (backward compatibility)
 
 Example repository structure:
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -95,7 +95,7 @@ You can see an example of a knowledge-based agent in [OpenHands's github skill](
 Repository agents provide repository-specific knowledge and guidelines. They are:
 
 - Loaded from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` directory (V1)
-- V1 also supports `.openhands/skills/` for backward compatibility
+- V1 also supports `.openhands/microagents/` for backward compatibility
 - Specific to individual repositories
 - Automatically activated for their repository
 - Perfect for team practices and project conventions

--- a/skills/add-agent/SKILL.md
+++ b/skills/add-agent/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: This agent helps create new microagents in the `.openhands/microagents`
+description: This agent helps create new skills in the `.openhands/skills`
   directory by providing guidance and templates.
 metadata:
   agent: CodeActAgent
@@ -8,25 +8,25 @@ metadata:
 name: add-agent
 triggers:
 - new agent
-- new microagent
+- new skill
 - create agent
 - create an agent
-- create microagent
-- create a microagent
+- create skill
+- create a skill
 - add agent
 - add an agent
-- add microagent
-- add a microagent
-- microagent template
+- add skill
+- add a skill
+- skill template
 ---
 
-This agent helps create new microagents in the `.openhands/microagents` directory by providing guidance and templates.
+This agent helps create new skills in the `.openhands/skills` directory by providing guidance and templates.
 
-Microagents are specialized prompts that provide context and capabilities for specific domains or tasks. They are activated by trigger words in the conversation and help the AI assistant understand what capabilities are available, how to use specific APIs or tools, what limitations exist, and how to handle common scenarios.
+Skills are specialized prompts that provide context and capabilities for specific domains or tasks. They are activated by trigger words in the conversation and help the AI assistant understand what capabilities are available, how to use specific APIs or tools, what limitations exist, and how to handle common scenarios.
 
-When creating a new microagent:
+When creating a new skill:
 
-- Create a markdown file in `.openhands/microagents/` with an appropriate name (e.g., `github.md`, `google_workspace.md`)
+- Create a markdown file in `.openhands/skills/` with an appropriate name (e.g., `github.md`, `google_workspace.md`)
 - Include YAML frontmatter with metadata (name, type, version, agent, triggers)
 - type is by DEFAULT knowledge
 - version is DEFAULT 1.0.0
@@ -39,5 +39,5 @@ When creating a new microagent:
 
 For detailed information, see:
 
-- [Microagents Overview](https://docs.all-hands.dev/usage/prompting/microagents-overview)
+- [Skills Overview](https://docs.all-hands.dev/usage/prompting/skills-overview)
 - [Example GitHub Skill](https://github.com/OpenHands/OpenHands/blob/main/skills/github.md)

--- a/skills/add-repo-inst/SKILL.md
+++ b/skills/add-repo-inst/SKILL.md
@@ -16,12 +16,12 @@ triggers:
 
 Please browse the current repository under /workspace/{{ REPO_FOLDER_NAME }}, look at the documentation and relevant code, and understand the purpose of this repository.
 
-Specifically, I want you to create a `.openhands/skills/repo.md`  file. This file should contain succinct information that summarizes (1) the purpose of this repository, (2) the general setup of this repo, and (3) a brief description of the structure of this repo.
+Specifically, I want you to create an `AGENTS.md`  file. This file should contain succinct information that summarizes (1) the purpose of this repository, (2) the general setup of this repo, and (3) a brief description of the structure of this repo.
 
 Here's an example:
 ```markdown
 ---
-name: repo
+name: AGENTS
 type: repo
 agent: CodeActAgent
 ---
@@ -66,4 +66,4 @@ Frontend:
 ```
 
 Now, please write a similar markdown for the current repository.
-Read all the GitHub workflows under .github/ of the repository (if this folder exists) to understand the CI checks (e.g., linter, pre-commit), and include those in the repo.md file.
+Read all the GitHub workflows under .github/ of the repository (if this folder exists) to understand the CI checks (e.g., linter, pre-commit), and include those in the AGENTS.md file.

--- a/skills/add-repo-inst/SKILL.md
+++ b/skills/add-repo-inst/SKILL.md
@@ -16,7 +16,7 @@ triggers:
 
 Please browse the current repository under /workspace/{{ REPO_FOLDER_NAME }}, look at the documentation and relevant code, and understand the purpose of this repository.
 
-Specifically, I want you to create a `.openhands/microagents/repo.md`  file. This file should contain succinct information that summarizes (1) the purpose of this repository, (2) the general setup of this repo, and (3) a brief description of the structure of this repo.
+Specifically, I want you to create a `.openhands/skills/repo.md`  file. This file should contain succinct information that summarizes (1) the purpose of this repository, (2) the general setup of this repo, and (3) a brief description of the structure of this repo.
 
 Here's an example:
 ```markdown

--- a/skills/agent-memory/SKILL.md
+++ b/skills/agent-memory/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: '* Repository memory: Use .openhands/microagents/repo.md under each repository
+description: '* Repository memory: Use .openhands/skills/repo.md under each repository
   root to store and access important information.'
 metadata:
   agent: CodeActAgent
@@ -10,7 +10,7 @@ triggers:
 - /remember
 ---
 
-* Repository memory: Use .openhands/microagents/repo.md under each repository root to store and access important information.
+* Repository memory: Use .openhands/skills/repo.md under each repository root to store and access important information.
   - If this file exists, it will be added to your context automatically.
   - If missing, you should create it unless the user has explicitly asked you to not do so.
 

--- a/skills/agent-memory/SKILL.md
+++ b/skills/agent-memory/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: '* Repository memory: Use .openhands/skills/repo.md under each repository
+description: '* Repository memory: Use AGENTS.md in each repository
   root to store and access important information.'
 metadata:
   agent: CodeActAgent
@@ -10,7 +10,7 @@ triggers:
 - /remember
 ---
 
-* Repository memory: Use .openhands/skills/repo.md under each repository root to store and access important information.
+* Repository memory: Use AGENTS.md in each repository root to store and access important information.
   - If this file exists, it will be added to your context automatically.
   - If missing, you should create it unless the user has explicitly asked you to not do so.
 

--- a/skills/agent-memory/SKILL.md
+++ b/skills/agent-memory/SKILL.md
@@ -32,4 +32,4 @@ triggers:
   - If you've only explored a portion of the codebase, clearly note this limitation in the repository structure documentation
   - If you don't know the essential commands for working with the repository, such as lint or typecheck, ask the user and suggest adding them to repo.md for future reference (with permission)
 
-When you receive this message, please review and summarize your recent actions and observations, then present a list of valuable information that should be saved in repo.md to the user.
+When you receive this message, please review and summarize your recent actions and observations, then present a list of valuable information that should be saved in AGENTS.md to the user.

--- a/skills/onboarding-agent/SKILL.md
+++ b/skills/onboarding-agent/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 
 # First-time User Conversation with OpenHands
 
-## Microagent purpose
+## Skill purpose
 In **<= 5 progressive questions**, interview the user to identify their coding goal and constraints, then generate a **concrete, step-by-step plan** that maximizes the likelihood of a **successful pull request (PR)**.
 Finish by asking: **“Do you want me to execute the plan?”**
 

--- a/skills/ssh/SKILL.md
+++ b/skills/ssh/SKILL.md
@@ -1,11 +1,11 @@
 ---
-description: This microagent provides capabilities for establishing and managing SSH
+description: This skill provides capabilities for establishing and managing SSH
   connections to remote machines.
 metadata:
   agent: CodeActAgent
   type: knowledge
   version: 1.0.0
-name: sshmicroagent
+name: ssh
 triggers:
 - ssh
 - remote server
@@ -16,9 +16,9 @@ triggers:
 - ssh keys
 ---
 
-# SSH Microagent
+# SSH Skill
 
-This microagent provides capabilities for establishing and managing SSH connections to remote machines.
+This skill provides capabilities for establishing and managing SSH connections to remote machines.
 
 ## Capabilities
 


### PR DESCRIPTION
HUMAN: I thought we'll have a lot of "microagent" to replace with "skill"; actually a lot of "microagent" use were because we are specifically mentioning the legacy ones, so that's okay.

Also a few more tweaks.