### PR TITLE
Add github-pr-review skill for PR review mechanics

### DIFF
--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -9,13 +9,20 @@ triggers:
 
 This skill teaches how to post PR review comments using the GitHub API, including inline comments on specific lines, multi-line suggestions, and proper use of the `gh` CLI.
 
+## CRITICAL: Post ONE Single Review with All Comments
+
+After completing your analysis, you MUST post your review as a **single API call** that includes both the summary AND all inline comments together.
+
+**IMPORTANT - Avoid Duplication:**
+- Do NOT post individual inline comments separately and then a summary review
+- Do NOT make multiple API calls - use ONE call with all comments bundled
+- The summary in the review body should be brief (1-3 sentences) since details are in inline comments
+
 ## Posting PR Reviews with Inline Comments
 
 Use the GitHub CLI (`gh`) to post reviews with inline comments. The `GITHUB_TOKEN` environment variable is automatically available.
 
-### Single API Call with Multiple Comments (Recommended)
-
-Always bundle all comments into ONE review API call to avoid notification spam:
+### Post a Review with Multiple Inline Comments (Required Approach)
 
 ```bash
 gh api \
@@ -23,15 +30,30 @@ gh api \
   repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id='{commit_sha}' \
   -f event='COMMENT' \
-  -f body='Brief summary of the review.' \
+  -f body='Brief 1-3 sentence summary. Details are in inline comments below.' \
   -f comments[][path]='path/to/file.py' \
   -F comments[][line]=42 \
   -f comments[][side]='RIGHT' \
-  -f comments[][body]='Your comment about this line.' \
+  -f comments[][body]='Your specific comment about this line.' \
   -f comments[][path]='path/to/another_file.js' \
   -F comments[][line]=15 \
   -f comments[][side]='RIGHT' \
-  -f comments[][body]='Another comment.'
+  -f comments[][body]='Another specific comment.'
+```
+
+### Only If You Have a Single Comment to Make
+
+```bash
+gh api \
+  -X POST \
+  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+  -f commit_id='{commit_sha}' \
+  -f event='COMMENT' \
+  -f body='Brief summary.' \
+  -f comments[][path]='path/to/file.py' \
+  -F comments[][line]=42 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='Your specific comment about this line.'
 ```
 
 ### Parameters Explained
@@ -39,9 +61,37 @@ gh api \
 - **commit_id**: The SHA of the commit to comment on (use `git rev-parse HEAD`)
 - **event**: Use `COMMENT` for neutral feedback, `APPROVE` to approve, `REQUEST_CHANGES` to request changes
 - **path**: Exact file path as shown in the diff (e.g., `src/utils/helper.py`)
-- **line**: Line number in the NEW version of the file (right side of diff)
+- **line**: Line number in the NEW version of the file (the right side of the diff). For added lines (starting with +), use the line number shown in the diff.
 - **side**: `RIGHT` for new/added lines (most common), `LEFT` for deleted lines
-- **body**: The comment text (supports markdown and suggestion syntax)
+- **body**: The comment text. Provide a clear, actionable comment. Be specific about what should be changed.
+
+## Priority Labels for Review Comments
+
+**IMPORTANT**: Each inline comment MUST start with a priority label to help the PR author understand the importance of each suggestion. Use one of these prefixes:
+
+- **🔴 Critical**: Must be fixed before merging. Security vulnerabilities, bugs that will cause failures, data loss risks, or breaking changes.
+- **🟠 Important**: Should be addressed. Logic errors, performance issues, missing error handling, or significant code quality concerns.
+- **🟡 Suggestion**: Nice to have improvements. Better naming, code organization, or minor optimizations that would improve the code.
+- **🟢 Nit**: Minor stylistic preferences. Formatting, comment wording, or trivial improvements that are optional.
+
+**Example comment with priority:**
+```
+🟠 Important: This function doesn't handle the case when `user` is None, which could cause an AttributeError in production.
+
+```suggestion
+if user is None:
+    raise ValueError("User cannot be None")
+```
+```
+
+**Another example:**
+```
+🟢 Nit: Consider using a more descriptive variable name for clarity.
+
+```suggestion
+user_count = len(users)
+```
+```
 
 ## Finding Line Numbers
 
@@ -65,7 +115,13 @@ head -n 42 filename | tail -1
 
 ## Multi-Line Comments and Suggestions
 
-For comments spanning multiple lines, you have two options:
+When your comment or suggestion spans multiple lines, you MUST specify a line range using both `start_line` and `line` parameters. This is **critical** for multi-line suggestions - if you only specify `line`, the suggestion will be misaligned.
+
+**Parameters for multi-line comments:**
+- **start_line**: The first line of the range (required for multi-line)
+- **line**: The last line of the range
+- **start_side**: Side of the first line (optional, defaults to same as `side`)
+- **side**: Side of the last line
 
 ### Option 1: Using `start_line` and `line` parameters
 
@@ -97,11 +153,11 @@ You can also comment on a range of lines using `--line 10-20` syntax:
 gh pr comment {pr_number} --body "Your comment here" --line 10-20 --path path/to/file.py
 ```
 
-**IMPORTANT**: The number of lines in your suggestion block MUST match the line range. If you select lines 10-12 (3 lines), your suggestion must contain exactly 3 lines.
+**IMPORTANT**: The number of lines in your suggestion block MUST match the number of lines in the selected range (line - start_line + 1). If you select lines 10-12 (3 lines), your suggestion must also contain exactly 3 lines.
 
 ## GitHub Suggestion Syntax
 
-For small code changes, use GitHub's suggestion feature (one-click apply):
+For small, concrete code changes, use GitHub's suggestion feature. This allows the PR author to apply your suggested change with one click. Format suggestions in the comment body using the special markdown syntax:
 
 ~~~markdown
 ```suggestion
@@ -110,19 +166,42 @@ def improved_function():
 ```
 ~~~
 
+### Example: Including a Suggestion in Your Review
+
+Include the suggestion syntax in the `body` field of your inline comment within the review:
+
+```bash
+gh api \
+  -X POST \
+  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+  -f commit_id='{commit_sha}' \
+  -f event='COMMENT' \
+  -f body='Found one issue with variable naming.' \
+  -f comments[][path]='path/to/file.py' \
+  -F comments[][line]=42 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='🟡 Suggestion: Consider using a more descriptive variable name:
+
+```suggestion
+user_count = len(users)
+```'
+```
+
 ### When to Use Suggestions
 
 ✅ Good for:
-- Renaming variables or functions
-- Fixing typos or formatting
+- Renaming variables or functions for clarity
+- Fixing typos or formatting issues
 - Small refactors (1-5 lines)
-- Adding type hints or docstrings
-- Fixing comments
+- Adding missing type hints or docstrings
+- Fixing misleading or outdated comments
+- Updating documentation or README content
+- Correcting comments in configuration files (YAML, JSON, etc.)
 
 ❌ Avoid for:
-- Large refactors (multiple files)
-- Architectural changes needing discussion
-- Changes with multiple valid approaches
+- Large refactors requiring multiple file changes
+- Architectural changes that need discussion
+- Changes where multiple valid approaches exist
 
 ## Fallback: Using curl
 
@@ -156,6 +235,15 @@ curl -X POST \
   }'
 ```
 
+## What to Review
+
+- Focus on bugs, security issues, performance problems, and code quality
+- Only post comments for actual issues or important suggestions
+- Use the suggestion syntax for small, concrete code changes
+- Be constructive and specific about what should be changed
+- **Always include a priority label** (🔴 Critical, 🟠 Important, 🟡 Suggestion, 🟢 Nit) at the start of each inline comment
+- If there are no issues, post a single review with an approval message (no inline comments needed)
+
 ## Best Practices
 
 1. **One API call**: Bundle all comments into a single review to avoid notification spam
@@ -163,3 +251,15 @@ curl -X POST \
 3. **Specific line numbers**: Always verify line numbers before posting
 4. **Match suggestion lines**: Ensure suggestion line count matches the selected range
 5. **Use RIGHT side**: For commenting on new/modified code (most common case)
+6. **Priority labels**: Always start inline comments with a priority emoji (🔴🟠🟡🟢)
+
+## Your Task
+
+1. Analyze the diff and code carefully
+2. Identify ALL specific issues on specific lines
+3. Post ONE single review using the GitHub API that includes:
+   - A brief summary in the review body (1-3 sentences)
+   - ALL inline comments bundled in the same API call
+4. Do NOT make multiple API calls or post comments separately
+
+**CRITICAL**: Make exactly ONE API call to post your complete review. Do NOT post individual comments first and then a summary - this creates duplication.

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -1,28 +1,21 @@
 ---
 name: github-pr-review
-description: How to post PR review comments using GitHub API, including inline comments, line numbers, multi-line suggestions, and the gh CLI. Use when reviewing pull requests and need to post structured feedback.
+description: Post PR review comments using the GitHub API with inline comments, suggestions, and priority labels.
 triggers:
 - /github-pr-review
 ---
 
-# GitHub PR Review Mechanics
+# GitHub PR Review
 
-This skill teaches how to post PR review comments using the GitHub API, including inline comments on specific lines, multi-line suggestions, and proper use of the `gh` CLI.
+Post structured code review feedback using the GitHub API with inline comments on specific lines.
 
-## CRITICAL: Post ONE Single Review with All Comments
+## Key Rule: One API Call
 
-After completing your analysis, you MUST post your review as a **single API call** that includes both the summary AND all inline comments together.
+Bundle ALL comments into a **single review API call**. Do not post comments individually.
 
-**IMPORTANT - Avoid Duplication:**
-- Do NOT post individual inline comments separately and then a summary review
-- Do NOT make multiple API calls - use ONE call with all comments bundled
-- The summary in the review body should be brief (1-3 sentences) since details are in inline comments
+## Posting a Review
 
-## Posting PR Reviews with Inline Comments
-
-Use the GitHub CLI (`gh`) to post reviews with inline comments. The `GITHUB_TOKEN` environment variable is automatically available.
-
-### Post a Review with Multiple Inline Comments (Required Approach)
+Use the GitHub CLI (`gh`). The `GITHUB_TOKEN` is automatically available.
 
 ```bash
 gh api \
@@ -30,53 +23,42 @@ gh api \
   repos/{owner}/{repo}/pulls/{pr_number}/reviews \
   -f commit_id='{commit_sha}' \
   -f event='COMMENT' \
-  -f body='Brief 1-3 sentence summary. Details are in inline comments below.' \
+  -f body='Brief 1-3 sentence summary.' \
   -f comments[][path]='path/to/file.py' \
   -F comments[][line]=42 \
   -f comments[][side]='RIGHT' \
-  -f comments[][body]='Your specific comment about this line.' \
-  -f comments[][path]='path/to/another_file.js' \
+  -f comments[][body]='🟠 Important: Your comment here.' \
+  -f comments[][path]='another/file.js' \
   -F comments[][line]=15 \
   -f comments[][side]='RIGHT' \
-  -f comments[][body]='Another specific comment.'
+  -f comments[][body]='🟡 Suggestion: Another comment.'
 ```
 
-### Only If You Have a Single Comment to Make
+### Parameters
 
-```bash
-gh api \
-  -X POST \
-  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-  -f commit_id='{commit_sha}' \
-  -f event='COMMENT' \
-  -f body='Brief summary.' \
-  -f comments[][path]='path/to/file.py' \
-  -F comments[][line]=42 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='Your specific comment about this line.'
+| Parameter | Description |
+|-----------|-------------|
+| `commit_id` | Commit SHA to comment on (use `git rev-parse HEAD`) |
+| `event` | `COMMENT`, `APPROVE`, or `REQUEST_CHANGES` |
+| `path` | File path as shown in the diff |
+| `line` | Line number in the NEW version (right side of diff) |
+| `side` | `RIGHT` for new/added lines, `LEFT` for deleted lines |
+| `body` | Comment text with priority label |
+
+## Priority Labels
+
+Start each comment with a priority label:
+
+| Label | When to Use |
+|-------|-------------|
+| 🔴 **Critical** | Must fix: security vulnerabilities, bugs, data loss risks |
+| 🟠 **Important** | Should fix: logic errors, performance issues, missing error handling |
+| 🟡 **Suggestion** | Nice to have: better naming, code organization |
+| 🟢 **Nit** | Optional: formatting, minor style preferences |
+
+**Example:**
 ```
-
-### Parameters Explained
-
-- **commit_id**: The SHA of the commit to comment on (use `git rev-parse HEAD`)
-- **event**: Use `COMMENT` for neutral feedback, `APPROVE` to approve, `REQUEST_CHANGES` to request changes
-- **path**: Exact file path as shown in the diff (e.g., `src/utils/helper.py`)
-- **line**: Line number in the NEW version of the file (the right side of the diff). For added lines (starting with +), use the line number shown in the diff.
-- **side**: `RIGHT` for new/added lines (most common), `LEFT` for deleted lines
-- **body**: The comment text. Provide a clear, actionable comment. Be specific about what should be changed.
-
-## Priority Labels for Review Comments
-
-**IMPORTANT**: Each inline comment MUST start with a priority label to help the PR author understand the importance of each suggestion. Use one of these prefixes:
-
-- **🔴 Critical**: Must be fixed before merging. Security vulnerabilities, bugs that will cause failures, data loss risks, or breaking changes.
-- **🟠 Important**: Should be addressed. Logic errors, performance issues, missing error handling, or significant code quality concerns.
-- **🟡 Suggestion**: Nice to have improvements. Better naming, code organization, or minor optimizations that would improve the code.
-- **🟢 Nit**: Minor stylistic preferences. Formatting, comment wording, or trivial improvements that are optional.
-
-**Example comment with priority:**
-```
-🟠 Important: This function doesn't handle the case when `user` is None, which could cause an AttributeError in production.
+🟠 Important: This function doesn't handle None, which could cause an AttributeError.
 
 ```suggestion
 if user is None:
@@ -84,116 +66,49 @@ if user is None:
 ```
 ```
 
-**Another example:**
-```
-🟢 Nit: Consider using a more descriptive variable name for clarity.
+## GitHub Suggestions
 
+For small code changes, use the suggestion syntax for one-click apply:
+
+~~~
 ```suggestion
-user_count = len(users)
-```
-```
-
-## Finding Line Numbers
-
-### From the Diff Header
-
-The diff header shows line ranges: `@@ -old_start,old_count +new_start,new_count @@`
-
-Count lines from `new_start` for added/modified lines in the new version.
-
-### Using grep
-
-```bash
-grep -n "pattern" filename
-```
-
-### Verifying a Line
-
-```bash
-head -n 42 filename | tail -1
-```
-
-## Multi-Line Comments and Suggestions
-
-When your comment or suggestion spans multiple lines, you MUST specify a line range using both `start_line` and `line` parameters. This is **critical** for multi-line suggestions - if you only specify `line`, the suggestion will be misaligned.
-
-**Parameters for multi-line comments:**
-- **start_line**: The first line of the range (required for multi-line)
-- **line**: The last line of the range
-- **start_side**: Side of the first line (optional, defaults to same as `side`)
-- **side**: Side of the last line
-
-```bash
-gh api \
-  -X POST \
-  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-  -f commit_id='{commit_sha}' \
-  -f event='COMMENT' \
-  -f body='Found an issue spanning multiple lines.' \
-  -f comments[][path]='path/to/file.py' \
-  -F comments[][start_line]=10 \
-  -F comments[][line]=12 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='Consider this improvement:
-
-```suggestion
-first_line = "improved"
-second_line = "code"
-third_line = "here"
-```'
-```
-
-**IMPORTANT**: The number of lines in your suggestion block MUST match the number of lines in the selected range (line - start_line + 1). If you select lines 10-12 (3 lines), your suggestion must also contain exactly 3 lines.
-
-## GitHub Suggestion Syntax
-
-For small, concrete code changes, use GitHub's suggestion feature. This allows the PR author to apply your suggested change with one click. Format suggestions in the comment body using the special markdown syntax:
-
-~~~markdown
-```suggestion
-def improved_function():
-    return "better code here"
+improved_code_here()
 ```
 ~~~
 
-### Example: Including a Suggestion in Your Review
+Use suggestions for: renaming, typos, small refactors (1-5 lines), type hints, docstrings.
 
-Include the suggestion syntax in the `body` field of your inline comment within the review:
+Avoid for: large refactors, architectural changes, ambiguous improvements.
+
+## Multi-Line Comments
+
+For comments spanning multiple lines, add `start_line`:
 
 ```bash
-gh api \
-  -X POST \
-  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-  -f commit_id='{commit_sha}' \
-  -f event='COMMENT' \
-  -f body='Found one issue with variable naming.' \
-  -f comments[][path]='path/to/file.py' \
-  -F comments[][line]=42 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='🟡 Suggestion: Consider using a more descriptive variable name:
+-F comments[][start_line]=10 \
+-F comments[][line]=12 \
+-f comments[][body]='🟡 Suggestion: Refactor this block:
 
 ```suggestion
-user_count = len(users)
+line_one = "new"
+line_two = "code"
+line_three = "here"
 ```'
 ```
 
-### When to Use Suggestions
+**Important**: The suggestion must have the same number of lines as the range (e.g., lines 10-12 = 3 lines).
 
-✅ Good for:
-- Renaming variables or functions for clarity
-- Fixing typos or formatting issues
-- Small refactors (1-5 lines)
-- Adding missing type hints or docstrings
-- Fixing misleading or outdated comments
-- Updating documentation or README content
-- Correcting comments in configuration files (YAML, JSON, etc.)
+## Finding Line Numbers
 
-❌ Avoid for:
-- Large refactors requiring multiple file changes
-- Architectural changes that need discussion
-- Changes where multiple valid approaches exist
+```bash
+# From diff header: @@ -old_start,old_count +new_start,new_count @@
+# Count from new_start for added/modified lines
 
-## Fallback: Using curl
+grep -n "pattern" filename     # Find line number
+head -n 42 filename | tail -1  # Verify line content
+```
+
+## Fallback: curl
 
 If `gh` is unavailable:
 
@@ -201,55 +116,23 @@ If `gh` is unavailable:
 curl -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github+json" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
   "https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews" \
   -d '{
     "commit_id": "{commit_sha}",
-    "body": "Review summary.",
     "event": "COMMENT",
+    "body": "Review summary.",
     "comments": [
-      {
-        "path": "path/to/file.py",
-        "line": 42,
-        "side": "RIGHT",
-        "body": "Your comment here."
-      },
-      {
-        "path": "path/to/file.py",
-        "start_line": 10,
-        "line": 12,
-        "side": "RIGHT",
-        "body": "Multi-line suggestion:\n\n```suggestion\nline1\nline2\nline3\n```"
-      }
+      {"path": "file.py", "line": 42, "side": "RIGHT", "body": "Comment"},
+      {"path": "file.py", "start_line": 10, "line": 12, "side": "RIGHT", "body": "Multi-line"}
     ]
   }'
 ```
 
-## What to Review
+## Summary
 
-- Focus on bugs, security issues, performance problems, and code quality
-- Only post comments for actual issues or important suggestions
-- Use the suggestion syntax for small, concrete code changes
-- Be constructive and specific about what should be changed
-- **Always include a priority label** (🔴 Critical, 🟠 Important, 🟡 Suggestion, 🟢 Nit) at the start of each inline comment
-- If there are no issues, post a single review with an approval message (no inline comments needed)
-
-## Best Practices
-
-1. **One API call**: Bundle all comments into a single review to avoid notification spam
-2. **Brief summary**: Keep the review body short (1-3 sentences) since details are in inline comments
-3. **Specific line numbers**: Always verify line numbers before posting
-4. **Match suggestion lines**: Ensure suggestion line count matches the selected range
-5. **Use RIGHT side**: For commenting on new/modified code (most common case)
-6. **Priority labels**: Always start inline comments with a priority emoji (🔴🟠🟡🟢)
-
-## Your Task
-
-1. Analyze the diff and code carefully
-2. Identify ALL specific issues on specific lines
-3. Post ONE single review using the GitHub API that includes:
-   - A brief summary in the review body (1-3 sentences)
-   - ALL inline comments bundled in the same API call
-4. Do NOT make multiple API calls or post comments separately
-
-**CRITICAL**: Make exactly ONE API call to post your complete review. Do NOT post individual comments first and then a summary - this creates duplication.
+1. Analyze the code and identify issues
+2. Post **ONE** review with all inline comments bundled
+3. Use priority labels (🔴🟠🟡🟢) on every comment
+4. Use suggestion syntax for concrete code changes
+5. Keep the review body brief (details go in inline comments)
+6. If no issues: post a short approval message

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -45,6 +45,26 @@ gh api \
 | `side` | `RIGHT` for new/added lines, `LEFT` for deleted lines |
 | `body` | Comment text with priority label |
 
+### Multi-Line Comments
+
+For comments spanning multiple lines, add `start_line` to specify the range:
+
+```bash
+  -f comments[][path]='path/to/file.py' \
+  -F comments[][start_line]=10 \
+  -F comments[][line]=12 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='🟡 Suggestion: Refactor this block:
+
+```suggestion
+line_one = "new"
+line_two = "code"
+line_three = "here"
+```'
+```
+
+**Important**: The suggestion must have the same number of lines as the range (e.g., lines 10-12 = 3 lines).
+
 ## Priority Labels
 
 Start each comment with a priority label:
@@ -79,24 +99,6 @@ improved_code_here()
 Use suggestions for: renaming, typos, small refactors (1-5 lines), type hints, docstrings.
 
 Avoid for: large refactors, architectural changes, ambiguous improvements.
-
-## Multi-Line Comments
-
-For comments spanning multiple lines, add `start_line`:
-
-```bash
--F comments[][start_line]=10 \
--F comments[][line]=12 \
--f comments[][body]='🟡 Suggestion: Refactor this block:
-
-```suggestion
-line_one = "new"
-line_two = "code"
-line_three = "here"
-```'
-```
-
-**Important**: The suggestion must have the same number of lines as the range (e.g., lines 10-12 = 3 lines).
 
 ## Finding Line Numbers
 

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: github-pr-review
+description: How to post PR review comments using GitHub API, including inline comments, line numbers, multi-line suggestions, and the gh CLI. Use when reviewing pull requests and need to post structured feedback.
+triggers:
+- pr review
+- pull request review
+- review pr
+- inline comment
+- review comment
+---
+
+# GitHub PR Review Mechanics
+
+This skill teaches how to post PR review comments using the GitHub API, including inline comments on specific lines, multi-line suggestions, and proper use of the `gh` CLI.
+
+## Posting PR Reviews with Inline Comments
+
+Use the GitHub CLI (`gh`) to post reviews with inline comments. The `GITHUB_TOKEN` environment variable is automatically available.
+
+### Single API Call with Multiple Comments (Recommended)
+
+Always bundle all comments into ONE review API call to avoid notification spam:
+
+```bash
+gh api \
+  -X POST \
+  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+  -f commit_id='{commit_sha}' \
+  -f event='COMMENT' \
+  -f body='Brief summary of the review.' \
+  -f comments[][path]='path/to/file.py' \
+  -F comments[][line]=42 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='Your comment about this line.' \
+  -f comments[][path]='path/to/another_file.js' \
+  -F comments[][line]=15 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='Another comment.'
+```
+
+### Parameters Explained
+
+- **commit_id**: The SHA of the commit to comment on (use `git rev-parse HEAD`)
+- **event**: Use `COMMENT` for neutral feedback, `APPROVE` to approve, `REQUEST_CHANGES` to request changes
+- **path**: Exact file path as shown in the diff (e.g., `src/utils/helper.py`)
+- **line**: Line number in the NEW version of the file (right side of diff)
+- **side**: `RIGHT` for new/added lines (most common), `LEFT` for deleted lines
+- **body**: The comment text (supports markdown and suggestion syntax)
+
+## Finding Line Numbers
+
+### From the Diff Header
+
+The diff header shows line ranges: `@@ -old_start,old_count +new_start,new_count @@`
+
+Count lines from `new_start` for added/modified lines in the new version.
+
+### Using grep
+
+```bash
+grep -n "pattern" filename
+```
+
+### Verifying a Line
+
+```bash
+head -n 42 filename | tail -1
+```
+
+## Multi-Line Comments and Suggestions
+
+For comments spanning multiple lines, use both `start_line` and `line`:
+
+```bash
+gh api \
+  -X POST \
+  repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+  -f commit_id='{commit_sha}' \
+  -f event='COMMENT' \
+  -f body='Found an issue spanning multiple lines.' \
+  -f comments[][path]='path/to/file.py' \
+  -F comments[][start_line]=10 \
+  -F comments[][line]=12 \
+  -f comments[][side]='RIGHT' \
+  -f comments[][body]='Consider this improvement:
+
+```suggestion
+first_line = "improved"
+second_line = "code"
+third_line = "here"
+```'
+```
+
+**IMPORTANT**: The number of lines in your suggestion block MUST match the line range. If you select lines 10-12 (3 lines), your suggestion must contain exactly 3 lines.
+
+## GitHub Suggestion Syntax
+
+For small code changes, use GitHub's suggestion feature (one-click apply):
+
+~~~markdown
+```suggestion
+def improved_function():
+    return "better code here"
+```
+~~~
+
+### When to Use Suggestions
+
+✅ Good for:
+- Renaming variables or functions
+- Fixing typos or formatting
+- Small refactors (1-5 lines)
+- Adding type hints or docstrings
+- Fixing comments
+
+❌ Avoid for:
+- Large refactors (multiple files)
+- Architectural changes needing discussion
+- Changes with multiple valid approaches
+
+## Fallback: Using curl
+
+If `gh` is unavailable:
+
+```bash
+curl -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews" \
+  -d '{
+    "commit_id": "{commit_sha}",
+    "body": "Review summary.",
+    "event": "COMMENT",
+    "comments": [
+      {
+        "path": "path/to/file.py",
+        "line": 42,
+        "side": "RIGHT",
+        "body": "Your comment here."
+      },
+      {
+        "path": "path/to/file.py",
+        "start_line": 10,
+        "line": 12,
+        "side": "RIGHT",
+        "body": "Multi-line suggestion:\n\n```suggestion\nline1\nline2\nline3\n```"
+      }
+    ]
+  }'
+```
+
+## Best Practices
+
+1. **One API call**: Bundle all comments into a single review to avoid notification spam
+2. **Brief summary**: Keep the review body short (1-3 sentences) since details are in inline comments
+3. **Specific line numbers**: Always verify line numbers before posting
+4. **Match suggestion lines**: Ensure suggestion line count matches the selected range
+5. **Use RIGHT side**: For commenting on new/modified code (most common case)

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -2,11 +2,7 @@
 name: github-pr-review
 description: How to post PR review comments using GitHub API, including inline comments, line numbers, multi-line suggestions, and the gh CLI. Use when reviewing pull requests and need to post structured feedback.
 triggers:
-- pr review
-- pull request review
-- review pr
-- inline comment
-- review comment
+- /github-pr-review
 ---
 
 # GitHub PR Review Mechanics

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -65,7 +65,9 @@ head -n 42 filename | tail -1
 
 ## Multi-Line Comments and Suggestions
 
-For comments spanning multiple lines, use both `start_line` and `line`:
+For comments spanning multiple lines, you have two options:
+
+### Option 1: Using `start_line` and `line` parameters
 
 ```bash
 gh api \
@@ -85,6 +87,14 @@ first_line = "improved"
 second_line = "code"
 third_line = "here"
 ```'
+```
+
+### Option 2: Using `--line` with a range (simpler)
+
+You can also comment on a range of lines using `--line 10-20` syntax:
+
+```bash
+gh pr comment {pr_number} --body "Your comment here" --line 10-20 --path path/to/file.py
 ```
 
 **IMPORTANT**: The number of lines in your suggestion block MUST match the line range. If you select lines 10-12 (3 lines), your suggestion must contain exactly 3 lines.

--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -123,8 +123,6 @@ When your comment or suggestion spans multiple lines, you MUST specify a line ra
 - **start_side**: Side of the first line (optional, defaults to same as `side`)
 - **side**: Side of the last line
 
-### Option 1: Using `start_line` and `line` parameters
-
 ```bash
 gh api \
   -X POST \
@@ -143,14 +141,6 @@ first_line = "improved"
 second_line = "code"
 third_line = "here"
 ```'
-```
-
-### Option 2: Using `--line` with a range (simpler)
-
-You can also comment on a range of lines using `--line 10-20` syntax:
-
-```bash
-gh pr comment {pr_number} --body "Your comment here" --line 10-20 --path path/to/file.py
 ```
 
 **IMPORTANT**: The number of lines in your suggestion block MUST match the number of lines in the selected range (line - start_line + 1). If you select lines 10-12 (3 lines), your suggestion must also contain exactly 3 lines.


### PR DESCRIPTION
## Summary

This PR adds a new skill `github-pr-review` that teaches how to post PR review comments using the GitHub API.

## What's Included

The skill covers:

- **Inline comments** - How to post comments on specific lines using `gh api`
- **Finding line numbers** - Using diff headers, `grep -n`, and verification techniques
- **Multi-line comments** - Using `start_line` and `line` parameters for ranges
- **GitHub suggestion syntax** - One-click apply changes with ` ```suggestion ` blocks
- **Best practices** - Bundling comments into single API call to avoid notification spam

## Triggers

The skill is triggered by keywords:
- `pr review`
- `pull request review`
- `review pr`
- `inline comment`
- `review comment`

## Use Case

This skill is useful for:
- Automated PR review workflows (e.g., GitHub Actions that review PRs)
- Teaching agents how to post structured review feedback
- Ensuring proper use of inline comments vs. general PR comments

## Relationship to Existing Skills

- **`github`** - Covers general GitHub operations (pushing, creating PRs)
- **`codereview`** - Covers *what* to look for in code reviews
- **`github-pr-review`** (this PR) - Covers *how* to post review comments mechanically

These skills complement each other - an agent could use both `codereview` (for review guidance) and `github-pr-review` (for posting mechanics).

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)