### PR TITLE
Add stacked-prs skill for managing PR stacks

### DIFF
--- a/skills/stacked-prs/SKILL.md
+++ b/skills/stacked-prs/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: stacked-prs
+description: Guide for breaking large pull requests into stacked, dependent PRs that are easier to review. Use when (1) a PR is too large (>400 lines), (2) splitting an existing big PR into smaller pieces, (3) planning a multi-part feature implementation, (4) setting up a stacked PR workflow, or (5) managing dependent branches and rebasing cascades.
+---
+
+# Stacked PRs Workflow
+
+Stacked PRs (or "stacked diffs") break large changes into a series of small, dependent PRs where each branch builds on the previous one. This creates a narrative that walks reviewers through changes logically.
+
+## Why Stack PRs
+
+- **200-line PRs get reviewed in minutes; 2000-line PRs sit for days**
+- Smaller changes are easier to understand and review thoroughly
+- Developers stay productive while waiting for reviews
+- Reduces bug risk through better review quality
+- Creates a story that guides reviewers through the change
+
+## Quick Reference
+
+### Creating a Stack (Manual Git)
+
+```bash
+# Start from main
+git checkout main && git pull
+
+# Create first branch
+git checkout -b feature/auth-01-models
+# ... make changes, commit ...
+git push -u origin feature/auth-01-models
+
+# Create second branch FROM first
+git checkout -b feature/auth-02-api
+# ... make changes, commit ...
+git push -u origin feature/auth-02-api
+
+# Create third branch FROM second
+git checkout -b feature/auth-03-ui
+# ... make changes, commit ...
+git push -u origin feature/auth-03-ui
+```
+
+### Creating PRs for the Stack
+
+Open PRs with the correct base branches:
+- PR #1: `feature/auth-01-models` → `main`
+- PR #2: `feature/auth-02-api` → `feature/auth-01-models`
+- PR #3: `feature/auth-03-ui` → `feature/auth-02-api`
+
+### Updating After Review Feedback (Manual Rebase)
+
+When PR #1 changes, update downstream PRs:
+
+```bash
+# Update PR #1
+git checkout feature/auth-01-models
+# ... make changes, commit, push ...
+
+# Rebase PR #2 onto updated PR #1
+git checkout feature/auth-02-api
+git rebase feature/auth-01-models
+git push --force-with-lease
+
+# Rebase PR #3 onto updated PR #2
+git checkout feature/auth-03-ui
+git rebase feature/auth-02-api
+git push --force-with-lease
+```
+
+### After PR #1 Merges
+
+Rebase remaining PRs onto main and update PR base branches:
+
+```bash
+git checkout main && git pull
+
+# Rebase PR #2 onto main
+git checkout feature/auth-02-api
+git rebase main
+git push --force-with-lease
+# Update PR #2's base branch to main (via GitHub UI or CLI)
+
+# Rebase PR #3 onto updated PR #2
+git checkout feature/auth-03-ui
+git rebase feature/auth-02-api
+git push --force-with-lease
+```
+
+## Breaking Down a Large PR
+
+When splitting an existing large PR, analyze by logical layers:
+
+### Decomposition Strategies
+
+1. **By Layer** (most common)
+   - Data models / schemas
+   - Business logic / services
+   - API endpoints / controllers
+   - UI components
+   - Tests
+
+2. **By Feature Slice**
+   - Core functionality first
+   - Edge cases and error handling
+   - Optimizations and polish
+
+3. **By Dependency Order**
+   - What can exist independently?
+   - What requires something else to be merged first?
+
+### Decision Framework
+
+For each logical chunk, ask:
+- Can this be reviewed independently?
+- Does it pass tests on its own?
+- Is it <400 lines of meaningful change?
+- Does it tell a coherent story?
+
+## PR Description Template
+
+For stacked PRs, always include stack context in descriptions. See `references/pr-template.md` for a copy-paste template.
+
+Key elements:
+- Stack overview with links to all PRs
+- Position indicator (e.g., "Part 2 of 4")
+- What THIS PR specifically accomplishes
+- Any special review considerations
+
+## Tooling Options
+
+### Graphite CLI (Recommended for Teams)
+
+Automates rebasing, PR creation, and merge orchestration:
+
+```bash
+# Install
+npm install -g @withgraphite/graphite-cli
+
+# Create stacked branches
+gt branch create feature/models
+gt branch create feature/api      # automatically stacks on feature/models
+gt branch create feature/ui       # automatically stacks on feature/api
+
+# Submit stack as PRs
+gt stack submit
+
+# Sync after changes (automatic rebase cascade)
+gt stack sync
+```
+
+### Manual Git (No Dependencies)
+
+Use the commands in Quick Reference above. More effort but works everywhere.
+
+### GitHub CLI Helpers
+
+```bash
+# Create PR with specific base
+gh pr create --base feature/auth-01-models --title "Part 2: Auth API"
+
+# Update PR base branch after merge
+gh pr edit 123 --base main
+```
+
+## Common Pitfalls
+
+1. **Circular dependencies** - Each PR must be mergeable without later PRs
+2. **Breaking tests** - Each PR in stack should pass CI independently
+3. **Force-push without --force-with-lease** - Can lose collaborator changes
+4. **Forgetting to update base branches** - After merge, update remaining PRs' base
+5. **Stack too deep** - Keep stacks to 3-5 PRs; beyond that, complexity increases
+
+## Maintaining Stack Coherence
+
+The hardest part of stacked PRs is maintaining coherence when changes cascade:
+
+1. **Rebase early and often** - Don't let branches diverge too far
+2. **Small, focused commits** - Easier to resolve conflicts
+3. **Clear commit boundaries** - Each commit should be atomic
+4. **Communicate with reviewers** - Let them know when you've rebased
+
+## Further Reading
+
+See `references/pr-template.md` for PR description template.
+See `references/advanced-workflows.md` for complex scenarios like mid-stack changes and handling merge conflicts.

--- a/skills/stacked-prs/references/advanced-workflows.md
+++ b/skills/stacked-prs/references/advanced-workflows.md
@@ -1,0 +1,251 @@
+# Advanced Stacked PR Workflows
+
+## Mid-Stack Changes
+
+When a reviewer requests changes to PR #2 in a 4-PR stack:
+
+### Step 1: Make the change on the affected branch
+
+```bash
+git checkout feature/auth-02-api
+# Make changes
+git add . && git commit -m "Address review feedback"
+git push
+```
+
+### Step 2: Rebase downstream branches
+
+```bash
+# Rebase PR #3 onto updated PR #2
+git checkout feature/auth-03-ui
+git rebase feature/auth-02-api
+# Resolve any conflicts
+git push --force-with-lease
+
+# Rebase PR #4 onto updated PR #3
+git checkout feature/auth-04-tests
+git rebase feature/auth-03-ui
+git push --force-with-lease
+```
+
+### Step 3: Notify reviewers
+
+Comment on downstream PRs that they've been rebased. Reviewers may need to re-review.
+
+---
+
+## Handling Merge Conflicts in Rebases
+
+When conflicts occur during `git rebase`:
+
+```bash
+# Git will pause at the conflicting commit
+# 1. Edit the conflicting files
+# 2. Mark as resolved
+git add <conflicting-files>
+# 3. Continue rebase
+git rebase --continue
+
+# If things go wrong, abort and start fresh
+git rebase --abort
+```
+
+### Conflict Prevention Strategies
+
+1. **Frequent rebases** - Don't let branches drift far from their base
+2. **Smaller commits** - Easier to identify and resolve conflicts
+3. **Communication** - Coordinate with team on shared files
+4. **Feature flags** - Allow incomplete features to coexist
+
+---
+
+## Reordering PRs in a Stack
+
+Sometimes you realize PR #2 should come before PR #1. This is complex:
+
+### Option A: Interactive Rebase (risky)
+
+```bash
+git checkout feature/last-branch-in-stack
+git rebase -i main
+# Reorder commits in the editor
+```
+
+**Warning:** This rewrites all history. Only do this if you're comfortable with interactive rebase.
+
+### Option B: Create New Branches (safer)
+
+1. Create new branches in the correct order
+2. Cherry-pick commits to the right branches
+3. Open new PRs, close old ones
+
+---
+
+## Inserting a PR into an Existing Stack
+
+To add a new PR #2.5 between existing PRs #2 and #3:
+
+```bash
+# Start from PR #2
+git checkout feature/auth-02-api
+git checkout -b feature/auth-02b-validation
+
+# Make your new changes
+git add . && git commit -m "Add validation layer"
+git push -u origin feature/auth-02b-validation
+
+# Rebase PR #3 onto the new branch
+git checkout feature/auth-03-ui
+git rebase feature/auth-02b-validation
+git push --force-with-lease
+
+# Update PR #3's base branch to the new PR
+gh pr edit <pr-3-number> --base feature/auth-02b-validation
+```
+
+---
+
+## Splitting a PR That's Already Open
+
+To split an existing large PR into a stack:
+
+### Strategy 1: Reset and Recommit
+
+```bash
+# Create a backup branch
+git checkout large-feature
+git checkout -b large-feature-backup
+
+# Reset to main, keeping changes
+git checkout -b feature/part-1
+git reset main
+# Now all changes are unstaged
+
+# Selectively stage and commit just part 1
+git add <part-1-files>
+git commit -m "Part 1: Models"
+git push -u origin feature/part-1
+
+# Create part 2 branch
+git checkout -b feature/part-2
+git add <part-2-files>
+git commit -m "Part 2: API"
+git push -u origin feature/part-2
+
+# Repeat for remaining parts
+```
+
+### Strategy 2: Cherry-Pick Commits
+
+If the original PR has well-structured commits:
+
+```bash
+# Identify commits for each part
+git log --oneline large-feature
+
+# Create branches and cherry-pick
+git checkout main
+git checkout -b feature/part-1
+git cherry-pick <commit-a> <commit-b>
+
+git checkout -b feature/part-2
+git cherry-pick <commit-c> <commit-d>
+```
+
+---
+
+## Working with Graphite CLI
+
+### Basic Stack Operations
+
+```bash
+# Initialize graphite in repo
+gt init
+
+# Create stacked branches
+gt branch create part-1
+gt branch create part-2  # automatically builds on part-1
+
+# View your stack
+gt stack
+
+# Submit all PRs in stack
+gt stack submit
+
+# Sync entire stack after upstream changes
+gt stack sync
+
+# Restack after main changes
+gt stack restack
+```
+
+### Handling Feedback with Graphite
+
+```bash
+# After making changes to part-1
+gt branch checkout part-1
+# ... make changes ...
+git commit -m "Address feedback"
+
+# Sync propagates changes through stack automatically
+gt stack sync
+```
+
+---
+
+## When Stacks Go Wrong
+
+### Scenario: Stack is too tangled to fix
+
+Sometimes it's easier to start fresh:
+
+1. Create a new branch from main
+2. Use `git diff` to get all changes from the stack
+3. Apply changes to new branch
+4. Re-split into clean stack
+
+```bash
+# Get combined diff of entire stack
+git diff main...feature/part-4 > all-changes.patch
+
+# Start fresh
+git checkout main
+git checkout -b feature-clean/part-1
+
+# Apply patch selectively or reference it
+# Then re-split logically
+```
+
+### Scenario: Reviewer wants to see full feature context
+
+Provide a "preview" branch that merges all stack branches:
+
+```bash
+git checkout feature/part-4  # Last branch has all changes
+# Or create a merge preview:
+git checkout main
+git checkout -b feature/preview
+git merge --no-ff feature/part-1
+git merge --no-ff feature/part-2
+git merge --no-ff feature/part-3
+git merge --no-ff feature/part-4
+git push origin feature/preview
+```
+
+Include a link to the preview branch in PR descriptions for reviewers who want full context.
+
+---
+
+## Team Coordination
+
+### When Multiple People Work on a Stack
+
+1. **Designate a stack owner** - One person manages rebases
+2. **Communicate before force-pushing** - Prevent lost work
+3. **Use `--force-with-lease`** - Safer than `--force`
+4. **Consider protected branches** - For critical base branches
+
+### Review Assignment
+
+- Assign the same reviewers to all PRs in a stack for context continuity
+- Or split by expertise: backend reviewer for API PRs, frontend for UI PRs

--- a/skills/stacked-prs/references/pr-template.md
+++ b/skills/stacked-prs/references/pr-template.md
@@ -1,0 +1,78 @@
+# Stacked PR Description Template
+
+Copy and customize this template for each PR in your stack.
+
+---
+
+## Template
+
+```markdown
+## 🥞 Stack Overview
+
+This PR is **part [X] of [Y]** in the [Feature Name] stack.
+
+| # | PR | Status | Description |
+|---|-----|--------|-------------|
+| 1 | #123 | ✅ Merged | Data models and migrations |
+| 2 | #124 | 👀 This PR | API endpoints |
+| 3 | #125 | ⏳ Blocked | UI components |
+| 4 | #126 | ⏳ Blocked | Integration tests |
+
+**Stack base:** `main`
+**Full feature:** [Brief description of overall feature]
+
+---
+
+## What This PR Does
+
+[Describe what THIS specific PR accomplishes - keep it focused]
+
+## Why This Ordering
+
+[Explain why this PR comes at this position in the stack]
+
+## Review Notes
+
+- [ ] Review this PR in isolation - it should make sense without later PRs
+- [ ] Previous PR(s) must be merged first
+- [ ] Any specific areas to focus review on
+
+## Testing
+
+- [ ] All existing tests pass
+- [ ] New tests added for this PR's changes (if applicable)
+- [ ] Manually tested [describe how]
+
+## Dependencies
+
+- **Depends on:** #123 (must be merged first)
+- **Blocks:** #125, #126 (waiting on this PR)
+```
+
+---
+
+## Compact Template (for smaller stacks)
+
+```markdown
+## Stack: [Feature Name] (Part X/Y)
+
+**Previous:** #123 | **Next:** #125
+
+### This PR
+[What this specific PR does]
+
+### Stack Progress
+1. ✅ #123 - Models
+2. 👀 #124 - API (this PR)
+3. ⏳ #125 - UI
+```
+
+---
+
+## Tips for Good Stack Descriptions
+
+1. **Always link all PRs** - Makes navigation easy
+2. **Update status indicators** - Keep ✅/👀/⏳ current
+3. **Explain the "why"** - Help reviewers understand the decomposition
+4. **Keep individual PR descriptions focused** - Don't repeat full feature spec in each
+5. **Note special review considerations** - Anything non-obvious about this slice


### PR DESCRIPTION
## Summary

This PR adds a new skill for breaking large pull requests into stacked, dependent PRs that are easier to review. The skill was created based on research into industry best practices from companies like Meta, Airbnb, and Google who use "stacked diffs" as a standard practice.

## Motivation

Large PRs (2000+ lines) sit for days waiting for review, while smaller PRs (~200 lines) get reviewed in minutes. Stacked PRs solve this by:
- Breaking large features into small, reviewable pieces
- Creating a narrative that walks reviewers through changes logically
- Allowing developers to stay productive while waiting for reviews
- Reducing bug risk through better review quality

## What's Included

### `SKILL.md` (184 lines)
- Why stack PRs and when to use this approach
- Quick reference for manual git workflow
- Decomposition strategies for splitting large PRs
- Tooling options (Graphite CLI and manual git)
- Common pitfalls and how to avoid them
- Guidance on maintaining stack coherence

### `references/pr-template.md`
Copy-paste templates for PR descriptions with:
- Stack overview with status indicators
- Links to all related PRs
- Position context (e.g., "Part 2 of 4")

### `references/advanced-workflows.md`
Detailed guides for complex scenarios:
- Mid-stack changes and rebase cascades
- Handling merge conflicts
- Reordering PRs in a stack
- Inserting new PRs into existing stacks
- Splitting an already-open large PR
- Team coordination strategies

## Triggers

The skill triggers on keywords related to:
- Large PRs / splitting PRs
- Stacked PRs / stacked diffs
- Dependent branches / rebasing cascades
- Multi-part feature implementation

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)