### PR TITLE
chore: update skills path references

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -39,34 +39,34 @@ OpenHands/skills/
 
 ### 2. Repository Instructions (Private)
 
-Each repository can have its own instructions in `.openhands/microagents/` (V0) or `.agents/skills/` (V1). These instructions are:
+Each repository can have its own instructions. On V1, use `.agents/skills/`. For backward compatibility, `.openhands/skills/` and `.openhands/microagents/` are still supported. These instructions are:
 
 - Private to that repository
 - Automatically loaded when working with that repository
 - Perfect for repository-specific guidelines and team practices
-- V1 supports `.agents/skills/` (as well as `.openhands/skills` and `.openhands/microagents` for backward compatibility)
 
 Example repository structure:
 
 ```
 your-repository/
-└── .openhands/
-    ├── skills/        # V1: Preferred location for repository-specific skills
-    │   └── repo.md    # Repository-specific instructions
-    │   └── ...        # Private skills that are only available inside this
-    └── microagents/   # V0: Current location (also supported in V1 for backward compatibility)
-        └── repo.md    # Repository-specific instructions
-        └── ...        # Private micro-agents that are only available inside this repo
+├── .agents/
+│   └── skills/        # V1: Preferred location for repository-specific skills
+│       └── repo.md    # Repository-specific instructions
+│       └── ...        # Private skills that are only available inside this repo
+└── .openhands/         # Legacy locations (still supported)
+    ├── skills/         # Legacy V1 path
+    │   └── repo.md
+    └── microagents/    # Legacy V0 path
+        └── repo.md
 ```
 
 ## Loading Order
 
 When OpenHands works with a repository, it:
 
-1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.agents/skills/` (V1) if present
-2. Loads relevant knowledge agents based on keywords in conversations
-
-**Note**: V1 also supports loading from `.openhands/microagents/` for backward compatibility.
+1. Loads repository-specific instructions from `.agents/skills/` (V1) if present
+2. Also checks `.openhands/skills/` and `.openhands/microagents/` for backward compatibility
+3. Loads relevant knowledge agents based on keywords in conversations
 
 ## Types of Skills
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,12 +39,12 @@ OpenHands/skills/
 
 ### 2. Repository Instructions (Private)
 
-Each repository can have its own instructions in `.openhands/microagents/` (V0) or `.openhands/skills/` (V1). These instructions are:
+Each repository can have its own instructions in `.openhands/microagents/` (V0) or `.agents/skills/` (V1). These instructions are:
 
 - Private to that repository
 - Automatically loaded when working with that repository
 - Perfect for repository-specific guidelines and team practices
-- V1 supports both `.openhands/skills/` (preferred) and `.openhands/microagents/` (backward compatibility)
+- V1 supports `.agents/skills/`
 
 Example repository structure:
 
@@ -63,7 +63,7 @@ your-repository/
 
 When OpenHands works with a repository, it:
 
-1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` (V1) if present
+1. Loads repository-specific instructions from `.openhands/microagents/repo.md` (V0) or `.agents/skills/` (V1) if present
 2. Loads relevant knowledge agents based on keywords in conversations
 
 **Note**: V1 also supports loading from `.openhands/microagents/` for backward compatibility.
@@ -94,8 +94,7 @@ You can see an example of a knowledge-based agent in [OpenHands's github skill](
 
 Repository agents provide repository-specific knowledge and guidelines. They are:
 
-- Loaded from `.openhands/microagents/repo.md` (V0) or `.openhands/skills/` directory (V1)
-- V1 also supports `.openhands/microagents/` for backward compatibility
+- Loaded from `.openhands/microagents/repo.md` (V0) or `.agents/skills/` directory (V1)
 - Specific to individual repositories
 - Automatically activated for their repository
 - Perfect for team practices and project conventions
@@ -107,7 +106,7 @@ Key features:
 - **Always active**: Automatically loaded for the repository
 - **Locally maintained**: Updated with the project
 
-You can see an example of a repo agent in [the agent for the OpenHands repo itself](https://github.com/OpenHands/OpenHands/blob/main/.openhands/skills/repo.md).
+You can see an example of a repo agent in [the agent for the OpenHands repo itself](https://github.com/OpenHands/OpenHands/blob/main/.agents/skills/repo.md).
 
 ## Contributing
 
@@ -151,7 +150,7 @@ You can see an example of a repo agent in [the agent for the OpenHands repo itse
 
 1. Create your agent file in the appropriate directory:
    - `skills/` for expertise (public, shareable)
-   - Note: Repository-specific agents should remain in their respective repositories' `.openhands/skills/` (V1) or `.openhands/microagents/` (V0) directory
+   - Note: Repository-specific agents should remain in their respective repositories' `.agents/skills/` (V1) or `.openhands/microagents/` (V0) directory
 2. Test thoroughly
 3. Submit a pull request to OpenHands
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,7 @@ Each repository can have its own instructions in `.openhands/microagents/` (V0) 
 - Private to that repository
 - Automatically loaded when working with that repository
 - Perfect for repository-specific guidelines and team practices
-- V1 supports `.agents/skills/`
+- V1 supports `.agents/skills/` (as well as `.openhands/skills` and `.openhands/microagents` for backward compatibility)
 
 Example repository structure:
 

--- a/skills/add-skill/SKILL.md
+++ b/skills/add-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-skill
-description: Add an external skill from a GitHub repository to the current workspace. Use when users want to import, install, or add a skill from a GitHub URL (e.g., `/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview` or "add the codereview skill from https://github.com/OpenHands/skills/"). Handles fetching the skill files and placing them in .openhands/skills/.
+description: Add an external skill from a GitHub repository to the current workspace. Use when users want to import, install, or add a skill from a GitHub URL (e.g., `/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview` or "add the codereview skill from https://github.com/OpenHands/skills/"). Handles fetching the skill files and placing them in .agents/skills/.
 ---
 
 # Add Skill
@@ -35,13 +35,13 @@ User: `/add-skill https://github.com/OpenHands/skills/tree/main/skills/coderevie
 python3 scripts/fetch_skill.py "https://github.com/OpenHands/skills/tree/main/skills/codereview" "/path/to/workspace"
 
 # Verify installation
-ls /path/to/workspace/.openhands/skills/codereview/SKILL.md
+ls /path/to/workspace/.agents/skills/codereview/SKILL.md
 ```
 
 Response: "✅ Added `codereview` to your workspace. The skill is now available."
 
 ## Notes
 
-- Creates `.openhands/skills/` directory if it doesn't exist
+- Creates `.agents/skills/` directory if it doesn't exist
 - Uses `GITHUB_TOKEN` for authentication (required for private repos)
 - Warns before overwriting existing skills with the same name

--- a/skills/add-skill/scripts/fetch_skill.py
+++ b/skills/add-skill/scripts/fetch_skill.py
@@ -3,7 +3,7 @@
 Fetch a skill from a GitHub repository and install it locally.
 
 This script downloads OpenHands skills from GitHub repositories and installs them
-into the workspace's .openhands/skills/ directory. It uses git sparse checkout to
+into the workspace's .agents/skills/ directory. It uses git sparse checkout to
 efficiently download only the skill directory without cloning the entire repository.
 
 Usage:
@@ -23,7 +23,7 @@ The script will:
 1. Parse the GitHub URL to extract owner, repo, branch, and skill path
 2. Use git sparse checkout to download only the specified skill directory
 3. Validate the skill has a SKILL.md file
-4. Copy the skill to <workspace>/.openhands/skills/<skill-name>/
+4. Copy the skill to <workspace>/.agents/skills/<skill-name>/
 """
 
 import argparse
@@ -95,7 +95,7 @@ def fetch_skill(github_url: str, workspace_path: str, force: bool = False) -> st
     2. Creates a temporary directory for the git operation
     3. Uses git sparse checkout to download only the skill directory (efficient!)
     4. Validates the downloaded content is a valid skill (has SKILL.md)
-    5. Copies the skill to the workspace's .openhands/skills/ directory
+    5. Copies the skill to the workspace's .agents/skills/ directory
     
     Args:
         github_url: URL to the skill on GitHub (various formats supported)
@@ -117,7 +117,7 @@ def fetch_skill(github_url: str, workspace_path: str, force: bool = False) -> st
     skill_name = skill_path.rstrip('/').split('/')[-1]
     
     # Determine the destination directory
-    # Skills are installed to: <workspace>/.openhands/skills/<skill-name>/
+    # Skills are installed to: <workspace>/.agents/skills/<skill-name>/
     dest_dir = Path(workspace_path) / '.openhands' / 'skills' / skill_name
     
     # Check if skill already exists - prevent accidental overwrites
@@ -129,7 +129,7 @@ def fetch_skill(github_url: str, workspace_path: str, force: bool = False) -> st
         print(f"Removing existing skill at {dest_dir}")
         shutil.rmtree(dest_dir)
     
-    # Ensure the parent directory exists (.openhands/skills/)
+    # Ensure the parent directory exists (.agents/skills/)
     dest_dir.parent.mkdir(parents=True, exist_ok=True)
     
     # Use a temporary directory for the git clone operation
@@ -233,7 +233,7 @@ Examples:
     )
     parser.add_argument(
         'workspace',
-        help='Path to the workspace root where the skill will be installed (to .openhands/skills/)'
+        help='Path to the workspace root where the skill will be installed (to .agents/skills/)'
     )
     parser.add_argument(
         '--force', '-f',


### PR DESCRIPTION
Update documentation to refer to the .agents/skills repo-level path.