### PR TITLE
docs(github): add GraphQL examples for resolving review threads

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -50,7 +50,7 @@ git checkout -b create-widget && git add . && git commit -m "Create widget" && g
 
 ## Resolving Review Threads via GraphQL
 
-The CI check `Review Thread Gate/unresolved-review-threads` will fail if there are unresolved review threads. To resolve threads programmatically:
+To resolve existing review threads programmatically:
 
 1. Get the thread IDs (replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>`):
 ```bash

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -35,3 +35,71 @@ Here are some instructions for pushing, but ONLY do this if the user asks you to
 git remote -v && git branch # to find the current org, repo and branch
 git checkout -b create-widget && git add . && git commit -m "Create widget" && git push -u origin create-widget
 ```
+
+## Handling Review Comments
+
+- Critically evaluate each review comment before acting on it. Not all feedback is worth implementing:
+  - Does it fix a real bug or improve clarity significantly?
+  - Does it align with the project's engineering principles (simplicity, maintainability)?
+  - Is the suggested change proportional to the benefit, or does it add unnecessary complexity?
+- It's acceptable to respectfully decline suggestions that add verbosity without clear benefit, over-engineer for hypothetical edge cases, or contradict the project's pragmatic approach.
+- After addressing (or deciding not to address) inline review comments, mark the corresponding review threads as resolved.
+- Before resolving a thread, leave a reply comment that either explains the reason for dismissing the feedback or references the specific commit (e.g., commit SHA) that addressed the issue.
+- Prefer resolving threads only once fixes are pushed or a clear decision is documented.
+- Use the GitHub GraphQL API to reply to and resolve review threads (see below).
+
+## Resolving Review Threads via GraphQL
+
+The CI check `Review Thread Gate/unresolved-review-threads` will fail if there are unresolved review threads. To resolve threads programmatically:
+
+1. Get the thread IDs (replace `<OWNER>`, `<REPO>`, `<PR_NUMBER>`):
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "<OWNER>", name: "<REPO>") {
+    pullRequest(number: <PR_NUMBER>) {
+      reviewThreads(first: 20) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { body }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+2. Reply to the thread explaining how the feedback was addressed:
+```bash
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "<THREAD_ID>"
+    body: "Fixed in <COMMIT_SHA>"
+  }) {
+    comment { id }
+  }
+}'
+```
+
+3. Resolve the thread:
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<THREAD_ID>"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+4. Get the failed workflow run ID and rerun it:
+```bash
+# Find the run ID from the failed check URL, or use:
+gh run list --repo <OWNER>/<REPO> --branch <BRANCH> --limit 5
+
+# Rerun failed jobs
+gh run rerun <RUN_ID> --repo <OWNER>/<REPO> --failed
+```


### PR DESCRIPTION
## Summary

Adds step-by-step instructions to the GitHub SKILL.md for programmatically resolving review threads when the `Review Thread Gate/unresolved-review-threads` CI check fails.

## Motivation

When working on PRs, AI agents may address review feedback by pushing commits but forget to resolve the review threads. This causes the Review Thread Gate check to fail. Without clear instructions, agents may not know how to:

1. Query for unresolved thread IDs using the GitHub GraphQL API
2. Resolve threads programmatically via mutation
3. Rerun the failed CI check

This content was originally added to [OpenHands/software-agent-sdk#1993](https://github.com/OpenHands/software-agent-sdk/pull/1993) and is now being ported to the skills repository for broader use.

## Changes

Added two new sections:
- **Handling Review Comments**: Guidelines for critically evaluating review comments before acting on them
- **Resolving Review Threads via GraphQL**: Step-by-step instructions including:
  - GraphQL query to list unresolved review threads with their IDs
  - GraphQL mutation to reply to threads
  - GraphQL mutation to resolve threads by ID
  - Commands to rerun failed CI checks

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/979bb03925bd4b788e27b02ac9050695)