### PR TITLE
Add CI workflow to enforce README.md presence in skill directories

### DIFF
--- a/.github/workflows/check-readme.yml
+++ b/.github/workflows/check-readme.yml
@@ -1,0 +1,54 @@
+name: Check README.md in Skills
+
+on:
+  pull_request:
+    branches: ["*"]
+  push:
+    branches: ["main", "master"]
+
+jobs:
+  check-readme:
+    name: Verify README.md exists in all skill directories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for README.md in each skill directory
+        run: |
+          echo "Checking for README.md in all skill directories..."
+          
+          # Find all immediate subdirectories of ./skills/
+          missing_readmes=()
+          
+          for dir in ./skills/*/; do
+            # Skip if not a directory
+            [ -d "$dir" ] || continue
+            
+            # Get the directory name
+            dirname=$(basename "$dir")
+            
+            # Skip hidden directories
+            [[ "$dirname" == .* ]] && continue
+            
+            # Check if README.md exists
+            if [ ! -f "${dir}README.md" ]; then
+              missing_readmes+=("$dirname")
+            fi
+          done
+          
+          # Report results
+          if [ ${#missing_readmes[@]} -gt 0 ]; then
+            echo ""
+            echo "❌ ERROR: The following skill directories are missing README.md:"
+            echo ""
+            for skill in "${missing_readmes[@]}"; do
+              echo "  - ./skills/$skill/"
+            done
+            echo ""
+            echo "Please add a README.md file to each of the above directories."
+            exit 1
+          else
+            echo ""
+            echo "✅ All skill directories contain a README.md file."
+          fi

--- a/skills/add-skill/README.md
+++ b/skills/add-skill/README.md
@@ -1,0 +1,67 @@
+# add-skill
+
+Add (import) an OpenHands skill from a GitHub repository into the current workspace.
+
+This skill is useful when a user says things like:
+
+- “Add the `codereview` skill from https://github.com/OpenHands/skills/”
+- “/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview”
+
+It fetches only the requested skill directory (via git sparse checkout) and installs it into the workspace so OpenHands can use it.
+
+## What it does
+
+- Parses a GitHub URL (multiple formats supported)
+- Downloads only the requested skill folder (no full repo clone)
+- Validates the downloaded folder contains a `SKILL.md`
+- Installs the skill into:
+
+```text
+<workspace>/.openhands/skills/<skill-name>/
+```
+
+## Included files
+
+- `SKILL.md` – skill metadata + usage guidance for the agent
+- `scripts/fetch_skill.py` – implementation used to fetch/install a skill
+
+## Usage
+
+From the `add-skill` skill directory:
+
+```bash
+python3 scripts/fetch_skill.py "<github-skill-url>" "<workspace-path>" [--force]
+```
+
+### Examples
+
+```bash
+# Full URL with explicit branch
+python3 scripts/fetch_skill.py \
+  "https://github.com/OpenHands/skills/tree/main/skills/docker" \
+  "/workspace"
+
+# Shorthand form (defaults to main)
+python3 scripts/fetch_skill.py \
+  "OpenHands/skills/skills/codereview" \
+  "/workspace"
+
+# Overwrite if the skill already exists
+python3 scripts/fetch_skill.py \
+  "OpenHands/skills/tree/main/skills/codereview" \
+  "/workspace" \
+  --force
+```
+
+## Supported URL formats
+
+- `https://github.com/<owner>/<repo>/tree/<branch>/<path/to/skill>`
+- `https://github.com/<owner>/<repo>/<path/to/skill>` (defaults to `main`)
+- `github.com/<owner>/<repo>/<path/to/skill>`
+- `<owner>/<repo>/<path/to/skill>`
+
+## Notes / caveats
+
+- If `GITHUB_TOKEN` is set, it will be used for authentication (needed for private repos).
+- If the destination already exists, the script will fail unless `--force` is provided.
+- The script currently installs under `.openhands/skills/` (not `.agents/skills/`).


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that enforces the presence of `README.md` files in all skill directories under `./skills/`.

## Changes

- Added `.github/workflows/check-readme.yml` - A CI workflow that:
  - ✅ Runs automatically on all PRs (to any branch)
  - ✅ Runs on pushes to main/master
  - ✅ Checks every immediate subdirectory of `./skills/` for `README.md`
  - ✅ Fails with a clear error message listing any directories missing `README.md`

## Example Output

When a skill directory is missing `README.md`:
```
❌ ERROR: The following skill directories are missing README.md:

  - ./skills/example-skill/

Please add a README.md file to each of the above directories.
```

When all skill directories have `README.md`:
```
✅ All skill directories contain a README.md file.
```

## Next Steps

After merging this PR, a repository administrator should configure branch protection rules to require the "Verify README.md exists in all skill directories" check for merges to main.

Fixes #30

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2b6152e4135b43c8b999ef044a82a531)