### PR TITLE
fix(add-skill): install into .agents/skills

### DIFF
--- a/skills/add-skill/README.md
+++ b/skills/add-skill/README.md
@@ -17,7 +17,7 @@ It fetches only the requested skill directory (via git sparse checkout) and inst
 - Installs the skill into:
 
 ```text
-<workspace>/.openhands/skills/<skill-name>/
+<workspace>/.agents/skills/<skill-name>/
 ```
 
 ## Included files
@@ -64,4 +64,4 @@ python3 scripts/fetch_skill.py \
 
 - If `GITHUB_TOKEN` is set, it will be used for authentication (needed for private repos).
 - If the destination already exists, the script will fail unless `--force` is provided.
-- The script currently installs under `.openhands/skills/` (not `.agents/skills/`).
+- The script installs under `.agents/skills/`.

--- a/skills/add-skill/scripts/fetch_skill.py
+++ b/skills/add-skill/scripts/fetch_skill.py
@@ -118,7 +118,7 @@ def fetch_skill(github_url: str, workspace_path: str, force: bool = False) -> st
     
     # Determine the destination directory
     # Skills are installed to: <workspace>/.agents/skills/<skill-name>/
-    dest_dir = Path(workspace_path) / '.openhands' / 'skills' / skill_name
+    dest_dir = Path(workspace_path) / '.agents' / 'skills' / skill_name
     
     # Check if skill already exists - prevent accidental overwrites
     if dest_dir.exists():

--- a/tests/test_add_skill_installs_to_agents_dir.py
+++ b/tests/test_add_skill_installs_to_agents_dir.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_fetch_skill_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / 'skills' / 'add-skill' / 'scripts' / 'fetch_skill.py'
+    spec = importlib.util.spec_from_file_location('fetch_skill', module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_skill_installs_into_agents_skills_dir(tmp_path: Path, monkeypatch):
+    fetch_skill_mod = _load_fetch_skill_module()
+    fetch_skill = fetch_skill_mod.fetch_skill
+    monkeypatch.setattr('subprocess.run', lambda *args, **kwargs: None)
+
+    skill_path = 'skills/example-skill'
+    src_skill_dir = tmp_path / skill_path
+    src_skill_dir.mkdir(parents=True)
+    (src_skill_dir / 'SKILL.md').write_text('# Example skill\n')
+
+    class _FakeTempDir:
+        def __enter__(self):
+            return str(tmp_path)
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr('tempfile.TemporaryDirectory', lambda: _FakeTempDir())
+
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+
+    installed_path = Path(fetch_skill('OpenHands/skills/' + skill_path, str(workspace), force=True))
+
+    assert installed_path == workspace / '.agents' / 'skills' / 'example-skill'
+    assert (installed_path / 'SKILL.md').exists()


### PR DESCRIPTION
Fixes #40.

## Summary
- Update the add-skill fetch script to install skills into `.agents/skills` (instead of `.openhands/skills`).
- Update add-skill README to reflect the correct install location.
- Add a unit test asserting installation goes to `.agents/skills`.

## Testing
- `pytest -q`

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7b8d625564aa47359501633294ab91d2)