### PR TITLE
docs: add uv and deno agent skills

### DIFF
--- a/skills/deno/README.md
+++ b/skills/deno/README.md
@@ -1,0 +1,5 @@
+# deno
+
+This skill documents common project operations using **Deno** (tasks, run/test/lint/fmt, and dependency management).
+
+See: [SKILL.md](./SKILL.md)

--- a/skills/deno/SKILL.md
+++ b/skills/deno/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: deno
+description: If the project uses deno, use this skill. Use this skill to initialize and work with Deno projects, add/remove dependencies (JSR and npm), run tasks and scripts with appropriate permissions, and use built-in tooling (fmt/lint/test).
+triggers:
+- deno.json
+- deno.jsonc
+- deno.lock
+- deno task
+- jsr:
+- npm:
+---
+
+# Deno
+
+Use Deno as the default runtime/tooling when the repo contains `deno.json`/`deno.jsonc`, uses `deno.lock`, or scripts/documentation reference `deno task`, `deno run`, `deno test`, etc.
+
+## Quick decision rules
+
+- Prefer `deno task <name>` if the repo defines tasks.
+- Use `deno add` / `deno remove` to manage dependencies (writes to config).
+- Be explicit about permissions for `deno run` / `deno test`.
+
+## Common operations
+
+### Initialize a new project
+
+```bash
+deno init
+```
+
+### Add dependencies (JSR and npm)
+
+```bash
+# JSR (recommended for Deno-first packages)
+deno add jsr:@std/path
+
+# npm packages are supported too
+deno add npm:react
+
+# multiple at once
+deno add jsr:@std/assert npm:chalk
+```
+
+### Remove dependencies
+
+```bash
+deno remove jsr:@std/path
+```
+
+### Run a script
+
+```bash
+# Minimal permissions: only what the program needs
+# Examples:
+#   --allow-net=api.example.com
+#   --allow-read=./data
+#   --allow-env=FOO,BAR
+
+deno run --allow-net --allow-read main.ts
+```
+
+### Run tasks
+
+```bash
+# list tasks
+deno task
+
+# run a task defined in deno.json/deno.jsonc
+deno task dev
+```
+
+### Formatting, linting, testing
+
+```bash
+deno fmt
+deno lint
+deno test
+
+# common permissioned test run
+deno test --allow-net --allow-read
+```
+
+### Install / run CLIs
+
+```bash
+# Run a JSR or npm package's CLI without installing globally
+deno x jsr:@std/http/file-server -p 8080
+
+# Install globally (requires choosing permissions at install time)
+deno install -g -N -R jsr:@std/http/file-server -- -p 8080
+```
+
+## Notes / pitfalls
+
+- Deno is secure-by-default: missing permissions cause runtime errors; add the smallest set of `--allow-*` flags needed.
+- Dependency specifiers:
+  - `jsr:` for JSR registry packages
+  - `npm:` for npm packages
+  - URL imports are also supported (and cached)
+- Lockfile: `deno.lock` helps ensure reproducible dependency resolution.

--- a/skills/deno/SKILL.md
+++ b/skills/deno/SKILL.md
@@ -2,12 +2,7 @@
 name: deno
 description: If the project uses deno, use this skill. Use this skill to initialize and work with Deno projects, add/remove dependencies (JSR and npm), run tasks and scripts with appropriate permissions, and use built-in tooling (fmt/lint/test).
 triggers:
-- deno.json
-- deno.jsonc
-- deno.lock
-- deno task
-- jsr:
-- npm:
+- deno
 ---
 
 # Deno

--- a/skills/deno/SKILL.md
+++ b/skills/deno/SKILL.md
@@ -3,6 +3,9 @@ name: deno
 description: If the project uses deno, use this skill. Use this skill to initialize and work with Deno projects, add/remove dependencies (JSR and npm), run tasks and scripts with appropriate permissions, and use built-in tooling (fmt/lint/test).
 triggers:
 - deno
+- deno.json
+- deno.jsonc
+- deno.lock
 ---
 
 # Deno
@@ -82,6 +85,7 @@ deno test --allow-net --allow-read
 deno x jsr:@std/http/file-server -p 8080
 
 # Install globally (requires choosing permissions at install time)
+# Prefer the smallest set of permissions; avoid blanket flags unless necessary.
 deno install -g -N -R jsr:@std/http/file-server -- -p 8080
 ```
 

--- a/skills/deno/references/README.md
+++ b/skills/deno/references/README.md
@@ -1,0 +1,12 @@
+# References (deno)
+
+- https://docs.deno.com/runtime/reference/cli/
+- https://docs.deno.com/runtime/reference/cli/add/
+- https://docs.deno.com/runtime/reference/cli/remove/
+- https://docs.deno.com/runtime/reference/cli/run/
+- https://docs.deno.com/runtime/reference/cli/task/
+- https://docs.deno.com/runtime/reference/cli/test/
+- https://docs.deno.com/runtime/reference/cli/fmt/
+- https://docs.deno.com/runtime/reference/cli/lint/
+- https://docs.deno.com/runtime/reference/cli/install/
+- https://docs.deno.com/runtime/reference/cli/x/

--- a/skills/deno/references/README.md
+++ b/skills/deno/references/README.md
@@ -2,11 +2,5 @@
 
 - https://docs.deno.com/runtime/reference/cli/
 - https://docs.deno.com/runtime/reference/cli/add/
-- https://docs.deno.com/runtime/reference/cli/remove/
 - https://docs.deno.com/runtime/reference/cli/run/
 - https://docs.deno.com/runtime/reference/cli/task/
-- https://docs.deno.com/runtime/reference/cli/test/
-- https://docs.deno.com/runtime/reference/cli/fmt/
-- https://docs.deno.com/runtime/reference/cli/lint/
-- https://docs.deno.com/runtime/reference/cli/install/
-- https://docs.deno.com/runtime/reference/cli/x/

--- a/skills/uv/README.md
+++ b/skills/uv/README.md
@@ -1,0 +1,5 @@
+# uv
+
+This skill documents common project, dependency, and environment operations using **uv**.
+
+See: [SKILL.md](./SKILL.md)

--- a/skills/uv/SKILL.md
+++ b/skills/uv/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: uv
+description: If the project uses uv, use this skill. Use this skill to create/manage Python projects and environments with `uv`, add/remove dependencies, sync a project from `uv.lock`, and run commands in the project environment.
+triggers:
+- uv
+- uv.lock
+- .python-version
+- pyproject.toml
+- astral uv
+- python package manager
+---
+
+# uv (Python)
+
+Use `uv` as the default tool for Python dependency + environment management when the repo has `uv.lock`, mentions `uv` in its docs/Makefile, or already uses a `.venv` created by `uv`.
+
+## Quick decision rules
+
+- If the repo has `uv.lock` and `pyproject.toml`: treat it as a uv-managed project.
+- If the repo has only `requirements.txt`: you can still use `uv pip` for fast installs.
+- Prefer **project commands** (`uv add/remove/sync/run/lock`) over raw `pip` unless the repo explicitly uses `uv pip`.
+
+## Installation (if needed)
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+## Common operations
+
+### Initialize a new project
+
+```bash
+uv init
+# or
+uv init my-project
+```
+
+### Create / use a virtual environment
+
+```bash
+uv venv              # creates .venv
+uv venv --python 3.11
+
+# optional activation (not required for uv commands)
+source .venv/bin/activate  # macOS/Linux
+# .venv\\Scripts\\activate   # Windows
+```
+
+### Add / remove dependencies (updates pyproject.toml and uv.lock)
+
+```bash
+uv add requests
+uv add 'requests==2.31.0'
+uv add -r requirements.txt
+
+uv remove requests
+```
+
+### Lock + sync (reproducible installs)
+
+```bash
+uv lock   # (re)generate uv.lock
+uv sync   # create/update .venv to match uv.lock
+```
+
+If you pulled new changes and `uv.lock` changed, run `uv sync`.
+
+### Run commands inside the project environment
+
+```bash
+uv run python -m pytest -q
+uv run python main.py
+uv run ruff check .
+```
+
+### Using uv as a fast pip replacement (requirements workflows)
+
+```bash
+uv venv
+uv pip install -r requirements.txt
+uv pip freeze
+uv pip list
+```
+
+## Notes / pitfalls
+
+- `uv` will usually auto-detect and use `.venv` in the project root.
+- In CI/containers you may see `uv pip install --system`, but prefer virtualenvs for local dev.
+- If a command mutates deps, prefer `uv add/remove/lock/sync` so `uv.lock` stays correct.

--- a/skills/uv/SKILL.md
+++ b/skills/uv/SKILL.md
@@ -40,7 +40,7 @@ uv init my-project
 
 ```bash
 uv venv              # creates .venv
-uv venv --python 3.11
+uv venv --python 3.13 # or the correct python version for the project
 
 # optional activation (not required for uv commands)
 source .venv/bin/activate  # macOS/Linux

--- a/skills/uv/SKILL.md
+++ b/skills/uv/SKILL.md
@@ -45,7 +45,7 @@ uv venv  # creates .venv
 
 # If you need a specific version, match the project's declared requirement
 # (e.g., pyproject.toml / CI config), not an arbitrary latest version.
-uv venv --python 3.11
+uv venv --python 3.x
 
 # optional activation (not required for uv commands)
 source .venv/bin/activate  # macOS/Linux

--- a/skills/uv/SKILL.md
+++ b/skills/uv/SKILL.md
@@ -18,11 +18,13 @@ Use `uv` as the default tool for Python dependency + environment management when
 
 ## Installation (if needed)
 
+Prefer a packaged install method when available. If you use the official installer, review it first (avoid blindly piping into a shell) and follow the latest instructions in the official docs.
+
 ```bash
-# macOS/Linux
+# macOS/Linux (official installer)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Windows (PowerShell)
+# Windows (PowerShell, official installer)
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
@@ -39,8 +41,11 @@ uv init my-project
 ### Create / use a virtual environment
 
 ```bash
-uv venv              # creates .venv
-uv venv --python 3.13 # or the correct python version for the project
+uv venv  # creates .venv
+
+# If you need a specific version, match the project's declared requirement
+# (e.g., pyproject.toml / CI config), not an arbitrary latest version.
+uv venv --python 3.11
 
 # optional activation (not required for uv commands)
 source .venv/bin/activate  # macOS/Linux

--- a/skills/uv/SKILL.md
+++ b/skills/uv/SKILL.md
@@ -4,10 +4,6 @@ description: If the project uses uv, use this skill. Use this skill to create/ma
 triggers:
 - uv
 - uv.lock
-- .python-version
-- pyproject.toml
-- astral uv
-- python package manager
 ---
 
 # uv (Python)

--- a/skills/uv/references/README.md
+++ b/skills/uv/references/README.md
@@ -1,0 +1,6 @@
+# References (uv)
+
+- https://docs.astral.sh/uv/
+- https://docs.astral.sh/uv/guides/projects/
+- https://docs.astral.sh/uv/reference/cli/
+- https://docs.astral.sh/uv/pip/environments/

--- a/skills/uv/references/README.md
+++ b/skills/uv/references/README.md
@@ -3,4 +3,3 @@
 - https://docs.astral.sh/uv/
 - https://docs.astral.sh/uv/guides/projects/
 - https://docs.astral.sh/uv/reference/cli/
-- https://docs.astral.sh/uv/pip/environments/


### PR DESCRIPTION
## Summary

Adds two new agent skills in the Agentskill format:
- `uv`: common project/dependency/env operations for uv (includes note: "If the project uses uv, use this skill")
- `deno`: common project/dependency/task/tooling operations for Deno (includes note: "If the project uses deno, use this skill")

Each skill includes a `references/` directory with links to the official documentation.

Closes #1522.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75d6d9c8999d411fa566937c8b0a14d3)