### PR TITLE
docs: sync marketplace.json with skills registry

### DIFF
--- a/.plugin/marketplace.json
+++ b/.plugin/marketplace.json
@@ -1,182 +1,368 @@
 {
-  "name": "openhands-skills",
-  "owner": {
-    "name": "OpenHands",
-    "email": "contact@all-hands.dev"
-  },
-  "metadata": {
-    "description": "Public registry of Skills for OpenHands - reusable guidelines that customize agent behavior",
-    "version": "1.0.0",
-    "pluginRoot": "./skills"
-  },
-  "plugins": [
-    {
-      "name": "agent-memory",
-      "source": "./agent-memory",
-      "description": "Persist and retrieve repository-specific knowledge using AGENTS.md files. Use when you want to save important information about a codebase (build commands, code style, workflows) for future sessions.",
-      "category": "productivity",
-      "keywords": ["memory", "knowledge", "persistence", "agents"]
+    "name": "openhands-skills",
+    "owner": {
+        "name": "OpenHands",
+        "email": "contact@all-hands.dev"
     },
-    {
-      "name": "agent-sdk-builder",
-      "source": "./agent-sdk-builder",
-      "description": "Guided workflow for building custom AI agents using the OpenHands Software Agent SDK. Use when you want to create a new agent through an interactive interview process that gathers requirements and generates implementation plans.",
-      "category": "development",
-      "keywords": ["agent", "sdk", "builder", "openhands"]
+    "metadata": {
+        "description": "Public registry of Skills for OpenHands - reusable guidelines that customize agent behavior",
+        "version": "1.0.0",
+        "pluginRoot": "./skills"
     },
-    {
-      "name": "azure-devops",
-      "source": "./azure-devops",
-      "description": "Interact with Azure DevOps repositories, pull requests, and APIs using the AZURE_DEVOPS_TOKEN environment variable. Use when working with code hosted on Azure DevOps or managing Azure DevOps resources.",
-      "category": "integration",
-      "keywords": ["azure", "devops", "git", "pull-request"]
-    },
-    {
-      "name": "bitbucket",
-      "source": "./bitbucket",
-      "description": "Interact with Bitbucket repositories and pull requests using the BITBUCKET_TOKEN environment variable. Use when working with code hosted on Bitbucket or managing Bitbucket resources via API.",
-      "category": "integration",
-      "keywords": ["bitbucket", "git", "pull-request"]
-    },
-    {
-      "name": "codereview",
-      "source": "./codereview",
-      "description": "Structured code review covering style, readability, and security concerns with actionable feedback. Use when reviewing pull requests or merge requests to identify issues and suggest improvements.",
-      "category": "code-quality",
-      "keywords": ["code-review", "quality", "security", "style"]
-    },
-    {
-      "name": "codereview-roasted",
-      "source": "./codereview-roasted",
-      "description": "Brutally honest code review in the style of Linus Torvalds, focusing on data structures, simplicity, and pragmatism. Use when you want critical, no-nonsense feedback that prioritizes engineering fundamentals over style preferences.",
-      "category": "code-quality",
-      "keywords": ["code-review", "quality", "linus-torvalds"]
-    },
-    {
-      "name": "datadog",
-      "source": "./datadog",
-      "description": "Query and analyze Datadog logs, metrics, APM traces, and monitors using the Datadog API. Use when debugging production issues, monitoring application performance, or investigating alerts.",
-      "category": "monitoring",
-      "keywords": ["datadog", "monitoring", "logs", "metrics", "apm"]
-    },
-    {
-      "name": "docker",
-      "source": "./docker",
-      "description": "Run Docker commands within a container environment, including starting the Docker daemon and managing containers. Use when building, running, or managing Docker containers and images.",
-      "category": "infrastructure",
-      "keywords": ["docker", "container", "images"]
-    },
-    {
-      "name": "flarglebargle",
-      "source": "./flarglebargle",
-      "description": "A test skill that responds to the magic word 'flarglebargle' with a compliment. Use for testing skill activation and trigger functionality.",
-      "category": "testing",
-      "keywords": ["test", "demo"]
-    },
-    {
-      "name": "frontend-design",
-      "source": "./frontend-design",
-      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications. Generates creative, polished code and UI design that avoids generic AI aesthetics.",
-      "category": "design",
-      "keywords": ["frontend", "design", "ui", "web", "react", "html", "css"]
-    },
-    {
-      "name": "github",
-      "source": "./github",
-      "description": "Interact with GitHub repositories, pull requests, issues, and workflows using the GITHUB_TOKEN environment variable and GitHub CLI. Use when working with code hosted on GitHub or managing GitHub resources.",
-      "category": "integration",
-      "keywords": ["github", "git", "pull-request", "issues", "workflows"]
-    },
-    {
-      "name": "gitlab",
-      "source": "./gitlab",
-      "description": "Interact with GitLab repositories, merge requests, and APIs using the GITLAB_TOKEN environment variable. Use when working with code hosted on GitLab or managing GitLab resources.",
-      "category": "integration",
-      "keywords": ["gitlab", "git", "merge-request"]
-    },
-    {
-      "name": "jupyter",
-      "source": "./jupyter",
-      "description": "Read, modify, execute, and convert Jupyter notebooks programmatically. Use when working with .ipynb files for data science workflows, including editing cells, clearing outputs, or converting to other formats.",
-      "category": "data-science",
-      "keywords": ["jupyter", "notebook", "ipynb", "data-science"]
-    },
-    {
-      "name": "kubernetes",
-      "source": "./kubernetes",
-      "description": "Set up and manage local Kubernetes clusters using KIND (Kubernetes IN Docker). Use when testing Kubernetes applications locally or developing cloud-native workloads.",
-      "category": "infrastructure",
-      "keywords": ["kubernetes", "k8s", "kind", "cloud-native"]
-    },
-    {
-      "name": "notion",
-      "source": "./notion",
-      "description": "Create, search, and update Notion pages/databases using the Notion API. Use for documenting work, generating runbooks, and automating knowledge base updates.",
-      "category": "productivity",
-      "keywords": ["notion", "documentation", "knowledge-base"]
-    },
-    {
-      "name": "npm",
-      "source": "./npm",
-      "description": "Handle npm package installation in non-interactive environments by piping confirmations. Use when installing Node.js packages that require user confirmation prompts.",
-      "category": "development",
-      "keywords": ["npm", "nodejs", "packages"]
-    },
-    {
-      "name": "onboarding-agent",
-      "source": "./onboarding-agent",
-      "description": "Interactive onboarding workflow that interviews users to understand their coding goals and generates PR-ready implementation plans. Use when starting a new development task to ensure clear requirements and structured execution.",
-      "category": "productivity",
-      "keywords": ["onboarding", "planning", "requirements"]
-    },
-    {
-      "name": "pdflatex",
-      "source": "./pdflatex",
-      "description": "Install and use pdflatex to compile LaTeX documents into PDFs on Linux. Use when generating academic papers, research publications, or any documents written in LaTeX.",
-      "category": "documentation",
-      "keywords": ["latex", "pdf", "academic", "documents"]
-    },
-    {
-      "name": "releasenotes",
-      "source": "./releasenotes",
-      "description": "Generate formatted changelogs from git history since the last release tag. Use when preparing release notes that categorize changes into breaking changes, features, fixes, and other sections.",
-      "category": "development",
-      "keywords": ["release", "changelog", "git"]
-    },
-    {
-      "name": "security",
-      "source": "./security",
-      "description": "Security best practices for secure coding, authentication, authorization, and data protection. Use when developing features that handle sensitive data, user authentication, or require security review.",
-      "category": "security",
-      "keywords": ["security", "authentication", "authorization", "encryption"]
-    },
-    {
-      "name": "skill-creator",
-      "source": "./skill-creator",
-      "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.",
-      "category": "development",
-      "keywords": ["skill", "plugin", "create"]
-    },
-    {
-      "name": "ssh",
-      "source": "./ssh",
-      "description": "Establish and manage SSH connections to remote machines, including key generation, configuration, and file transfers. Use when connecting to remote servers, executing remote commands, or transferring files via SCP.",
-      "category": "infrastructure",
-      "keywords": ["ssh", "remote", "scp", "server"]
-    },
-    {
-      "name": "swift-linux",
-      "source": "./swift-linux",
-      "description": "Install and configure Swift programming language on Debian Linux for server-side development. Use when building Swift applications on Linux or setting up a Swift development environment.",
-      "category": "development",
-      "keywords": ["swift", "linux", "server-side"]
-    },
-    {
-      "name": "theme-factory",
-      "source": "./theme-factory",
-      "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
-      "category": "design",
-      "keywords": ["theme", "styling", "design", "slides", "documents"]
-    }
-  ]
+    "plugins": [
+        {
+            "name": "add-skill",
+            "source": "./add-skill",
+            "description": "Add (import) an OpenHands skill from a GitHub repository into the current workspace.",
+            "category": "productivity",
+            "keywords": [
+                "skill",
+                "import",
+                "github",
+                "sparse-checkout"
+            ]
+        },
+        {
+            "name": "agent-memory",
+            "source": "./agent-memory",
+            "description": "Persist and retrieve repository-specific knowledge using AGENTS.md files. Use when you want to save important information about a codebase (build commands, code style, workflows) for future sessions.",
+            "category": "productivity",
+            "keywords": [
+                "memory",
+                "knowledge",
+                "persistence",
+                "agents"
+            ]
+        },
+        {
+            "name": "agent-sdk-builder",
+            "source": "./agent-sdk-builder",
+            "description": "Guided workflow for building custom AI agents using the OpenHands Software Agent SDK. Use when you want to create a new agent through an interactive interview process that gathers requirements and generates implementation plans.",
+            "category": "development",
+            "keywords": [
+                "agent",
+                "sdk",
+                "builder",
+                "openhands"
+            ]
+        },
+        {
+            "name": "azure-devops",
+            "source": "./azure-devops",
+            "description": "Interact with Azure DevOps repositories, pull requests, and APIs using the AZURE_DEVOPS_TOKEN environment variable. Use when working with code hosted on Azure DevOps or managing Azure DevOps resources.",
+            "category": "integration",
+            "keywords": [
+                "azure",
+                "devops",
+                "git",
+                "pull-request"
+            ]
+        },
+        {
+            "name": "bitbucket",
+            "source": "./bitbucket",
+            "description": "Interact with Bitbucket repositories and pull requests using the BITBUCKET_TOKEN environment variable. Use when working with code hosted on Bitbucket or managing Bitbucket resources via API.",
+            "category": "integration",
+            "keywords": [
+                "bitbucket",
+                "git",
+                "pull-request"
+            ]
+        },
+        {
+            "name": "codereview",
+            "source": "./codereview",
+            "description": "Structured code review covering style, readability, and security concerns with actionable feedback. Use when reviewing pull requests or merge requests to identify issues and suggest improvements.",
+            "category": "code-quality",
+            "keywords": [
+                "code-review",
+                "quality",
+                "security",
+                "style"
+            ]
+        },
+        {
+            "name": "codereview-roasted",
+            "source": "./codereview-roasted",
+            "description": "Brutally honest code review in the style of Linus Torvalds, focusing on data structures, simplicity, and pragmatism. Use when you want critical, no-nonsense feedback that prioritizes engineering fundamentals over style preferences.",
+            "category": "code-quality",
+            "keywords": [
+                "code-review",
+                "quality",
+                "linus-torvalds"
+            ]
+        },
+        {
+            "name": "datadog",
+            "source": "./datadog",
+            "description": "Query and analyze Datadog logs, metrics, APM traces, and monitors using the Datadog API. Use when debugging production issues, monitoring application performance, or investigating alerts.",
+            "category": "monitoring",
+            "keywords": [
+                "datadog",
+                "monitoring",
+                "logs",
+                "metrics",
+                "apm"
+            ]
+        },
+        {
+            "name": "deno",
+            "source": "./deno",
+            "description": "Common project operations using Deno (tasks, run/test/lint/fmt, and dependency management).",
+            "category": "development",
+            "keywords": [
+                "deno",
+                "typescript",
+                "javascript",
+                "runtime"
+            ]
+        },
+        {
+            "name": "docker",
+            "source": "./docker",
+            "description": "Run Docker commands within a container environment, including starting the Docker daemon and managing containers. Use when building, running, or managing Docker containers and images.",
+            "category": "infrastructure",
+            "keywords": [
+                "docker",
+                "container",
+                "images"
+            ]
+        },
+        {
+            "name": "flarglebargle",
+            "source": "./flarglebargle",
+            "description": "A test skill that responds to the magic word 'flarglebargle' with a compliment. Use for testing skill activation and trigger functionality.",
+            "category": "testing",
+            "keywords": [
+                "test",
+                "demo"
+            ]
+        },
+        {
+            "name": "frontend-design",
+            "source": "./frontend-design",
+            "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications. Generates creative, polished code and UI design that avoids generic AI aesthetics.",
+            "category": "design",
+            "keywords": [
+                "frontend",
+                "design",
+                "ui",
+                "web",
+                "react",
+                "html",
+                "css"
+            ]
+        },
+        {
+            "name": "github",
+            "source": "./github",
+            "description": "Interact with GitHub repositories, pull requests, issues, and workflows using the GITHUB_TOKEN environment variable and GitHub CLI. Use when working with code hosted on GitHub or managing GitHub resources.",
+            "category": "integration",
+            "keywords": [
+                "github",
+                "git",
+                "pull-request",
+                "issues",
+                "workflows"
+            ]
+        },
+        {
+            "name": "github-pr-review",
+            "source": "./github-pr-review",
+            "description": "Post structured PR reviews to GitHub with inline comments/suggestions in a single API call.",
+            "category": "code-quality",
+            "keywords": [
+                "github",
+                "pull-request",
+                "review",
+                "code-review"
+            ]
+        },
+        {
+            "name": "gitlab",
+            "source": "./gitlab",
+            "description": "Interact with GitLab repositories, merge requests, and APIs using the GITLAB_TOKEN environment variable. Use when working with code hosted on GitLab or managing GitLab resources.",
+            "category": "integration",
+            "keywords": [
+                "gitlab",
+                "git",
+                "merge-request"
+            ]
+        },
+        {
+            "name": "jupyter",
+            "source": "./jupyter",
+            "description": "Read, modify, execute, and convert Jupyter notebooks programmatically. Use when working with .ipynb files for data science workflows, including editing cells, clearing outputs, or converting to other formats.",
+            "category": "data-science",
+            "keywords": [
+                "jupyter",
+                "notebook",
+                "ipynb",
+                "data-science"
+            ]
+        },
+        {
+            "name": "kubernetes",
+            "source": "./kubernetes",
+            "description": "Set up and manage local Kubernetes clusters using KIND (Kubernetes IN Docker). Use when testing Kubernetes applications locally or developing cloud-native workloads.",
+            "category": "infrastructure",
+            "keywords": [
+                "kubernetes",
+                "k8s",
+                "kind",
+                "cloud-native"
+            ]
+        },
+        {
+            "name": "notion",
+            "source": "./notion",
+            "description": "Create, search, and update Notion pages/databases using the Notion API. Use for documenting work, generating runbooks, and automating knowledge base updates.",
+            "category": "productivity",
+            "keywords": [
+                "notion",
+                "documentation",
+                "knowledge-base"
+            ]
+        },
+        {
+            "name": "npm",
+            "source": "./npm",
+            "description": "Handle npm package installation in non-interactive environments by piping confirmations. Use when installing Node.js packages that require user confirmation prompts.",
+            "category": "development",
+            "keywords": [
+                "npm",
+                "nodejs",
+                "packages"
+            ]
+        },
+        {
+            "name": "onboarding-agent",
+            "source": "./onboarding-agent",
+            "description": "Interactive onboarding workflow that interviews users to understand their coding goals and generates PR-ready implementation plans. Use when starting a new development task to ensure clear requirements and structured execution.",
+            "category": "productivity",
+            "keywords": [
+                "onboarding",
+                "planning",
+                "requirements"
+            ]
+        },
+        {
+            "name": "pdflatex",
+            "source": "./pdflatex",
+            "description": "Install and use pdflatex to compile LaTeX documents into PDFs on Linux. Use when generating academic papers, research publications, or any documents written in LaTeX.",
+            "category": "documentation",
+            "keywords": [
+                "latex",
+                "pdf",
+                "academic",
+                "documents"
+            ]
+        },
+        {
+            "name": "readiness-report",
+            "source": "./readiness-report",
+            "description": "Assess repository readiness for autonomous AI development and generate prioritized recommendations.",
+            "category": "productivity",
+            "keywords": [
+                "readiness",
+                "report",
+                "repo",
+                "quality"
+            ]
+        },
+        {
+            "name": "releasenotes",
+            "source": "./releasenotes",
+            "description": "Generate formatted changelogs from git history since the last release tag. Use when preparing release notes that categorize changes into breaking changes, features, fixes, and other sections.",
+            "category": "development",
+            "keywords": [
+                "release",
+                "changelog",
+                "git"
+            ]
+        },
+        {
+            "name": "security",
+            "source": "./security",
+            "description": "Security best practices for secure coding, authentication, authorization, and data protection. Use when developing features that handle sensitive data, user authentication, or require security review.",
+            "category": "security",
+            "keywords": [
+                "security",
+                "authentication",
+                "authorization",
+                "encryption"
+            ]
+        },
+        {
+            "name": "skill-creator",
+            "source": "./skill-creator",
+            "description": "Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.",
+            "category": "development",
+            "keywords": [
+                "skill",
+                "plugin",
+                "create"
+            ]
+        },
+        {
+            "name": "ssh",
+            "source": "./ssh",
+            "description": "Establish and manage SSH connections to remote machines, including key generation, configuration, and file transfers. Use when connecting to remote servers, executing remote commands, or transferring files via SCP.",
+            "category": "infrastructure",
+            "keywords": [
+                "ssh",
+                "remote",
+                "scp",
+                "server"
+            ]
+        },
+        {
+            "name": "swift-linux",
+            "source": "./swift-linux",
+            "description": "Install and configure Swift programming language on Debian Linux for server-side development. Use when building Swift applications on Linux or setting up a Swift development environment.",
+            "category": "development",
+            "keywords": [
+                "swift",
+                "linux",
+                "server-side"
+            ]
+        },
+        {
+            "name": "theme-factory",
+            "source": "./theme-factory",
+            "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.",
+            "category": "design",
+            "keywords": [
+                "theme",
+                "styling",
+                "design",
+                "slides",
+                "documents"
+            ]
+        },
+        {
+            "name": "uv",
+            "source": "./uv",
+            "description": "Common project, dependency, and environment operations using uv.",
+            "category": "development",
+            "keywords": [
+                "uv",
+                "python",
+                "dependencies",
+                "venv"
+            ]
+        },
+        {
+            "name": "vercel",
+            "source": "./vercel",
+            "description": "Deploy and manage applications on Vercel, including preview deployments and deployment protection.",
+            "category": "integration",
+            "keywords": [
+                "vercel",
+                "deployment",
+                "preview",
+                "hosting"
+            ]
+        }
+    ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ OpenHands uses an **extended AgentSkills standard**:
 - **Compatible with the AgentSkills specification** (https://agentskills.io/specification)
 - **Extended with optional `triggers:` frontmatter** for keyword-based activation
 
-When editing or adding skills in this repo, follow these rules:
+When editing or adding skills in this repo, follow these rules (and add new skills to `.plugin/marketplace.json`):
 
 1. **One skill per directory**
    - Create `skills/<skill-name>/SKILL.md`.


### PR DESCRIPTION
## Summary
- Updated `.plugin/marketplace.json` to include all skill directories currently present under `skills/` (added: add-skill, deno, github-pr-review, readiness-report, uv, vercel).
- Updated `AGENTS.md` with a concise note telling agents to keep `.plugin/marketplace.json` in sync when adding skills.

## Testing
- `python -m pytest`


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c9668990b32142b19d84045808bb0bed)