### PR TITLE
refactor: prepare for rename to OpenHands/extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# OpenHands Skills Registry — Agent Notes
+# OpenHands Extensions — Agent Notes
 
-This repository (`OpenHands/skills`) is the **public skills registry** for OpenHands.
-It contains **shareable skills** that can be loaded by OpenHands (CLI/GUI/Cloud) and by client code using the **Software Agent SDK**.
+This repository (`OpenHands/extensions`) is the **public extensions registry** for OpenHands.
+It contains **shareable skills and plugins** that can be loaded by OpenHands (CLI/GUI/Cloud) and by client code using the **Software Agent SDK**.
 
 ## What this repo contains
 
@@ -9,7 +9,12 @@ It contains **shareable skills** that can be loaded by OpenHands (CLI/GUI/Cloud)
   - `skills/<skill-name>/SKILL.md` — the skill definition (AgentSkills-style progressive disclosure)
   - `skills/<skill-name>/README.md` — optional extra docs/examples for humans
 
-There is no application code here; the primary artifacts are Markdown skill definitions, though they can contain `scripts/`, `hooks/` sub-directories as part of the Agentskill.
+- `plugins/` — a catalog of plugins with executable code components.
+  - `plugins/<plugin-name>/SKILL.md` — the plugin definition
+  - `plugins/<plugin-name>/hooks/` — lifecycle hooks (optional)
+  - `plugins/<plugin-name>/scripts/` — utility scripts (optional)
+
+There is no application code here; the primary artifacts are Markdown skill definitions and plugin configurations, which can contain `scripts/`, `hooks/` sub-directories.
 
 ## How client code uses this repo
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
-# OpenHands Skills Registry
+# OpenHands Extensions
 
-This repository is the **public skill registry** for [OpenHands](https://github.com/OpenHands/OpenHands).
-It contains reusable, shareable skills that customize agent behavior.
+This repository is the **public extensions registry** for [OpenHands](https://github.com/OpenHands/OpenHands).
+It contains reusable, shareable skills and plugins that customize agent behavior.
 
 - Skills overview docs: https://docs.openhands.dev/overview/skills
 - SDK skill guide: https://docs.openhands.dev/sdk/guides/skill
 
-## Repository layout
+## Repository Layout
 
-Skills live under `skills/`, **one directory per skill**:
+### Skills
+
+Skills are Markdown-based guidelines that provide domain-specific knowledge and instructions.
+They live under `skills/`, **one directory per skill**:
 
 - `skills/<skill-name>/SKILL.md` — the skill definition (AgentSkills-style progressive disclosure)
 - `skills/<skill-name>/README.md` — optional human-facing notes/examples
 
 Browse the catalog in [`skills/`](skills/).
 
+### Plugins
+
+Plugins are extensions with executable code components (hooks, scripts).
+They live under `plugins/`, **one directory per plugin**:
+
+- `plugins/<plugin-name>/SKILL.md` — the plugin definition
+- `plugins/<plugin-name>/hooks/` — lifecycle hooks
+- `plugins/<plugin-name>/scripts/` — utility scripts
+
+Browse available plugins in [`plugins/`](plugins/).
+
 ## Contributing
+
+### Adding a Skill
 
 1. Fork this repository
 2. Create a new directory: `skills/<your-skill-name>/`
@@ -23,6 +39,14 @@ Browse the catalog in [`skills/`](skills/).
 4. (Optional) Add `README.md`, `references/`, `scripts/`, etc.
 5. Submit a pull request
 
-## Agent instructions for working in this repo
+### Adding a Plugin
 
-See [`AGENTS.md`](AGENTS.md) for the rules agents should follow when editing/adding skills.
+1. Fork this repository
+2. Create a new directory: `plugins/<your-plugin-name>/`
+3. Add `plugins/<your-plugin-name>/SKILL.md`
+4. Add `hooks/` and/or `scripts/` directories with your executable code
+5. Submit a pull request
+
+## Agent Instructions
+
+See [`AGENTS.md`](AGENTS.md) for the rules agents should follow when editing/adding skills and plugins.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,30 @@
+# Plugins Directory
+
+This directory contains OpenHands plugins - extensions with executable code components such as hooks and advanced scripts.
+
+## What are Plugins?
+
+Plugins differ from skills in that they include executable code that can hook into OpenHands workflows:
+
+- **hooks/**: Scripts that run at specific points in the agent lifecycle
+- **scripts/**: Executable utilities that extend agent capabilities
+
+## Structure
+
+Each plugin follows the same structure as a skill but with additional executable components:
+
+```
+plugins/
+└── my-plugin/
+    ├── SKILL.md          # Plugin definition and documentation
+    ├── hooks/            # Lifecycle hooks (optional)
+    │   ├── pre-task.sh
+    │   └── post-task.sh
+    └── scripts/          # Utility scripts (optional)
+        └── helper.py
+```
+
+## Contributing
+
+See the main [README](../README.md) for contribution guidelines.
+

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,7 +8,7 @@ Skills are specialized prompts that enhance OpenHands with domain-specific knowl
 
 **Version 1 (V1)**: The term "skills" is used for V1 conversations. V1 UI and app server have not yet been released, but the codebase has been updated to use "skills" terminology in preparation for the V1 release.
 
-This directory (`OpenHands/skills/`) contains shareable skills that will be used in V1 conversations. For V0 conversations, the system continues to use skills from the same underlying files.
+This directory (`OpenHands/extensions/`) contains shareable skills that will be used in V1 conversations. For V0 conversations, the system continues to use skills from the same underlying files.
 
 ## Sources of Skills
 
@@ -16,7 +16,7 @@ OpenHands loads skills (V1) or skills (V0) from two sources:
 
 ### 1. Shareable Skills (Public)
 
-This directory (`OpenHands/skills/`) contains shareable skills (V1) or skills (V0) that are:
+This directory (`OpenHands/extensions/`) contains shareable skills (V1) or skills (V0) that are:
 
 - Available to all OpenHands users
 - Maintained in the OpenHands repository
@@ -26,7 +26,7 @@ This directory (`OpenHands/skills/`) contains shareable skills (V1) or skills (V
 Directory structure:
 
 ```
-OpenHands/skills/
+OpenHands/extensions/
 ├── # Keyword-triggered expertise
 │   ├── git.md         # Git operations
 │   ├── testing.md     # Testing practices

--- a/skills/add-skill/README.md
+++ b/skills/add-skill/README.md
@@ -4,8 +4,8 @@ Add (import) an OpenHands skill from a GitHub repository into the current worksp
 
 This skill is useful when a user says things like:
 
-- “Add the `codereview` skill from https://github.com/OpenHands/skills/”
-- “/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview”
+- “Add the `codereview` skill from https://github.com/OpenHands/extensions/”
+- “/add-skill https://github.com/OpenHands/extensions/tree/main/skills/codereview”
 
 It fetches only the requested skill directory (via git sparse checkout) and installs it into the workspace so OpenHands can use it.
 
@@ -38,17 +38,17 @@ python3 scripts/fetch_skill.py "<github-skill-url>" "<workspace-path>" [--force]
 ```bash
 # Full URL with explicit branch
 python3 scripts/fetch_skill.py \
-  "https://github.com/OpenHands/skills/tree/main/skills/docker" \
+  "https://github.com/OpenHands/extensions/tree/main/skills/docker" \
   "/workspace"
 
 # Shorthand form (defaults to main)
 python3 scripts/fetch_skill.py \
-  "OpenHands/skills/skills/codereview" \
+  "OpenHands/extensions/skills/codereview" \
   "/workspace"
 
 # Overwrite if the skill already exists
 python3 scripts/fetch_skill.py \
-  "OpenHands/skills/tree/main/skills/codereview" \
+  "OpenHands/extensions/tree/main/skills/codereview" \
   "/workspace" \
   --force
 ```

--- a/skills/add-skill/SKILL.md
+++ b/skills/add-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-skill
-description: Add an external skill from a GitHub repository to the current workspace. Use when users want to import, install, or add a skill from a GitHub URL (e.g., `/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview` or "add the codereview skill from https://github.com/OpenHands/skills/"). Handles fetching the skill files and placing them in .agents/skills/.
+description: Add an external skill from a GitHub repository to the current workspace. Use when users want to import, install, or add a skill from a GitHub URL (e.g., `/add-skill https://github.com/OpenHands/extensions/tree/main/skills/codereview` or "add the codereview skill from https://github.com/OpenHands/extensions/"). Handles fetching the skill files and placing them in .agents/skills/.
 ---
 
 # Add Skill
@@ -28,11 +28,11 @@ When a user requests to add a skill from a GitHub URL:
 
 ## Example
 
-User: `/add-skill https://github.com/OpenHands/skills/tree/main/skills/codereview`
+User: `/add-skill https://github.com/OpenHands/extensions/tree/main/skills/codereview`
 
 ```bash
 # Run the fetch script
-python3 scripts/fetch_skill.py "https://github.com/OpenHands/skills/tree/main/skills/codereview" "/path/to/workspace"
+python3 scripts/fetch_skill.py "https://github.com/OpenHands/extensions/tree/main/skills/codereview" "/path/to/workspace"
 
 # Verify installation
 ls /path/to/workspace/.agents/skills/codereview/SKILL.md

--- a/skills/add-skill/scripts/fetch_skill.py
+++ b/skills/add-skill/scripts/fetch_skill.py
@@ -11,13 +11,13 @@ Usage:
 
 Examples:
     # Full GitHub URL with branch
-    python fetch_skill.py "https://github.com/OpenHands/skills/tree/main/skills/docker" /workspace
+    python fetch_skill.py "https://github.com/OpenHands/extensions/tree/main/skills/docker" /workspace
     
     # Simplified URL (assumes 'main' branch)
-    python fetch_skill.py "https://github.com/OpenHands/skills/skills/npm" /workspace
+    python fetch_skill.py "https://github.com/OpenHands/extensions/skills/npm" /workspace
     
     # Shorthand format
-    python fetch_skill.py "OpenHands/skills/skills/codereview" /workspace
+    python fetch_skill.py "OpenHands/extensions/skills/codereview" /workspace
 
 The script will:
 1. Parse the GitHub URL to extract owner, repo, branch, and skill path
@@ -68,14 +68,14 @@ def parse_github_url(url: str) -> tuple[str, str, str, str]:
     
     # Step 3: Try to match full URL pattern with explicit branch
     # Pattern: owner/repo/tree/branch/path/to/skill
-    # Example: "OpenHands/skills/tree/main/skills/docker"
+    # Example: "OpenHands/extensions/tree/main/skills/docker"
     tree_match = re.match(r'^([^/]+)/([^/]+)/tree/([^/]+)/(.+)$', url)
     if tree_match:
         return tree_match.group(1), tree_match.group(2), tree_match.group(3), tree_match.group(4)
     
     # Step 4: Fall back to simple pattern (assumes 'main' branch)
     # Pattern: owner/repo/path/to/skill
-    # Example: "OpenHands/skills/skills/docker"
+    # Example: "OpenHands/extensions/skills/docker"
     parts = url.split('/')
     if len(parts) >= 3:
         owner = parts[0]
@@ -222,8 +222,8 @@ def main():
         description='Fetch a skill from a GitHub repository and install it locally.',
         epilog='''
 Examples:
-  %(prog)s "https://github.com/OpenHands/skills/tree/main/skills/docker" /workspace
-  %(prog)s "OpenHands/skills/skills/npm" /workspace
+  %(prog)s "https://github.com/OpenHands/extensions/tree/main/skills/docker" /workspace
+  %(prog)s "OpenHands/extensions/skills/npm" /workspace
   %(prog)s "owner/repo/my-skill" /workspace --force
         '''
     )

--- a/tests/test_add_skill_installs_to_agents_dir.py
+++ b/tests/test_add_skill_installs_to_agents_dir.py
@@ -36,7 +36,7 @@ def test_fetch_skill_installs_into_agents_skills_dir(tmp_path: Path, monkeypatch
     workspace = tmp_path / 'workspace'
     workspace.mkdir()
 
-    installed_path = Path(fetch_skill('OpenHands/skills/' + skill_path, str(workspace), force=True))
+    installed_path = Path(fetch_skill('OpenHands/extensions/' + skill_path, str(workspace), force=True))
 
     assert installed_path == workspace / '.agents' / 'skills' / 'example-skill'
     assert (installed_path / 'SKILL.md').exists()


### PR DESCRIPTION
## Summary

This PR prepares the repository for renaming from `OpenHands/skills` to `OpenHands/extensions`.

## Changes

### New Structure
- Added `plugins/` directory for extensions with executable code (hooks, scripts)
- Skills remain in `skills/` directory (no change to existing structure)

### Updated References
- Updated all internal references from `OpenHands/skills` to `OpenHands/extensions`
- Updated `README.md` to document new repository layout
- Updated `AGENTS.md` with new structure documentation
- Updated `add-skill` skill documentation and scripts

## Repository Structure After This Change

```
OpenHands/extensions/
├── skills/              # Markdown-based skills (existing)
│   ├── github/
│   ├── discord/
│   └── ...
├── plugins/             # NEW: Extensions with executable code
│   └── README.md
├── .plugin/
│   └── marketplace.json
├── README.md
├── AGENTS.md
└── tests/
```

## Next Steps

After this PR is merged:

1. **Rename the repository** via GitHub Settings → General → Repository name
   - Change from `skills` to `extensions`
   - GitHub will automatically set up redirects from the old URL

2. **Merge dependent PRs**:
   - [x] OpenHands/software-agent-sdk#2085
   - [x] OpenHands/docs#337
   - [x] OpenHands/OpenHands-CLI#505

## Related PRs

This is part of a coordinated refactoring:

| Repository | PR | Status | Merge Order |
|------------|----|---------|----|\n| **OpenHands/skills** | This PR | Open | 1️⃣ Merge first |
| **GitHub Settings** | (manual) | Pending | 2️⃣ Rename `skills` → `extensions` |
| **OpenHands/software-agent-sdk** | [#2085](https://github.com/OpenHands/software-agent-sdk/pull/2085) | Open | 3️⃣ Merge after rename |
| **OpenHands/docs** | [#337](https://github.com/OpenHands/docs/pull/337) | Open | 3️⃣ Merge after rename |
| **OpenHands/OpenHands-CLI** | [#505](https://github.com/OpenHands/OpenHands-CLI/pull/505) | Open | 3️⃣ Merge after rename |

## Testing

- Verified all internal references have been updated
- The `plugins/` directory is ready for future plugin additions
- Existing skills remain unchanged in `skills/` directory