### PR TITLE
feat: add /init skill to scaffold AGENTS.md

### DIFF
--- a/.plugin/marketplace.json
+++ b/.plugin/marketplace.json
@@ -190,6 +190,19 @@
             ]
         },
         {
+            "name": "init",
+            "source": "./init",
+            "description": "Scaffold an AGENTS.md contributor guide for a repository or subdirectory.",
+            "category": "documentation",
+            "keywords": [
+                "agents",
+                "agents-md",
+                "documentation",
+                "guidelines",
+                "init"
+            ]
+        },
+        {
             "name": "jupyter",
             "source": "./jupyter",
             "description": "Read, modify, execute, and convert Jupyter notebooks programmatically. Use when working with .ipynb files for data science workflows, including editing cells, clearing outputs, or converting to other formats.",

--- a/skills/init/README.md
+++ b/skills/init/README.md
@@ -1,0 +1,12 @@
+# `/init` skill
+
+This skill helps an agent generate an `AGENTS.md` file (a concise contributor/repo-guidelines doc for AI-assisted development).
+
+## Usage
+
+- `/init` → create `AGENTS.md` at the repository root.
+- `/init <path>` → create `AGENTS.md` scoped to the given path:
+  - If `<path>` is a directory, the file is written to `<path>/AGENTS.md`.
+  - If `<path>` ends with `.md`, it is treated as the output file path.
+
+The generated document follows a short, repo-specific template (structure, commands, style, testing, PR conventions) and avoids overwriting any existing `AGENTS.md` without confirmation.

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: init
+description: Create an AGENTS.md contributor guide for a repository (or a subdirectory) following a concise, repo-specific template. Use when the user runs /init.
+triggers:
+- /init
+---
+
+# Initialize `AGENTS.md`
+
+Use this skill when the user asks to scaffold an `AGENTS.md` file (project guidelines for AI agents) for the current repository.
+
+## Target path rules
+
+- `/init`: create `AGENTS.md` at the repository root.
+- `/init <path>`: create `AGENTS.md` scoped to `<path>`.
+  - If `<path>` is a directory, write `<path>/AGENTS.md`.
+  - If `<path>` ends with `.md`, treat it as the full output file path.
+
+Never overwrite an existing file silently. If the target file already exists, ask the user whether to (a) keep it, (b) edit it, or (c) replace it.
+
+## Workflow
+
+1. **Inspect the repo to tailor the guide**
+   - Skim top-level structure (`ls`, `find -maxdepth 2`).
+   - Read the primary docs (`README*`, `CONTRIBUTING*`, `DEVELOPMENT*`, `Makefile`).
+   - Identify build tooling and common commands (`pyproject.toml`, `package.json`, CI configs).
+   - Locate tests and how they are run (`tests/`, workflow YAMLs, task runners).
+
+2. **Write a concise `AGENTS.md`** using the spec below.
+
+3. **Create the file** at the target location.
+
+## `AGENTS.md` spec (inspired by Codex `/init`)
+
+- Title the document: `# Repository Guidelines`.
+- Use Markdown headings (`##`) to organize sections.
+- Keep it concise: **200–400 words**.
+- Keep explanations short, direct, and specific to the repo.
+- Prefer concrete examples (commands, directory paths, naming patterns).
+
+### Recommended sections (adapt as needed)
+
+- Project Structure & Module Organization
+- Build, Test, and Development Commands
+- Coding Style & Naming Conventions
+- Testing Guidelines
+- Commit & Pull Request Guidelines
+- Optional: Security & Configuration Tips, Architecture Overview, Agent-specific instructions
+
+## Content guidelines
+
+- Only include information that’s broadly useful for future tasks (avoid one-off issue details).
+- If the repo already contains nested `AGENTS.md` files, briefly mention that more deeply nested files override broader ones within their directory tree.


### PR DESCRIPTION
Adds a new public skill `init` (trigger: `/init`) that teaches agents how to create an `AGENTS.md` at repo root or a provided path (directory or explicit `.md` file).

Includes a Codex-inspired `AGENTS.md` spec (concise 200–400 words, key sections: structure, commands, style, testing, PRs).
