### PR TITLE
fix(skill): github-pr-review

### DIFF
--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -21,17 +21,17 @@ Use the GitHub CLI (`gh`). The `GITHUB_TOKEN` is automatically available.
 gh api \
   -X POST \
   repos/{owner}/{repo}/pulls/{pr_number}/reviews \
-  -f commit_id='{commit_sha}' \
-  -f event='COMMENT' \
-  -f body='Brief 1-3 sentence summary.' \
-  -f comments[][path]='path/to/file.py' \
+  -F commit_id='{commit_sha}' \
+  -F event='COMMENT' \
+  -F body='Brief 1-3 sentence summary.' \
+  -F comments[][path]='path/to/file.py' \
   -F comments[][line]=42 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='🟠 Important: Your comment here.' \
-  -f comments[][path]='another/file.js' \
+  -F comments[][side]='RIGHT' \
+  -F comments[][body]='🟠 Important: Your comment here.' \
+  -F comments[][path]='another/file.js' \
   -F comments[][line]=15 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='🟡 Suggestion: Another comment.'
+  -F comments[][side]='RIGHT' \
+  -F comments[][body]='🟡 Suggestion: Another comment.'
 ```
 
 ### Parameters
@@ -50,11 +50,11 @@ gh api \
 For comments spanning multiple lines, add `start_line` to specify the range:
 
 ```bash
-  -f comments[][path]='path/to/file.py' \
+  -F comments[][path]='path/to/file.py' \
   -F comments[][start_line]=10 \
   -F comments[][line]=12 \
-  -f comments[][side]='RIGHT' \
-  -f comments[][body]='🟡 Suggestion: Refactor this block:
+  -F comments[][side]='RIGHT' \
+  -F comments[][body]='🟡 Suggestion: Refactor this block:
 
 ```suggestion
 line_one = "new"


### PR DESCRIPTION
The PR adresses issue #52 

The problem was that th `gh` api tracks [] array indices separately for -f (string) and -F (typed) flags. Since line used -F and
everything else used -f, the line numbers ended up on the wrong comments.

The fix changes every -f to -F. When all flags use the same type, `gh` uses a single index counter so fields group
correctly. -F also auto-infers types.

Small experiment: run both versions side by side and compare:

mixed -f/-F

```text
gh api --method POST https://httpbin.org/post \
-f 'comments[][path]=file1.py' \
-F 'comments[][line]=42' \
-f 'comments[][side]=RIGHT' \
-f 'comments[][body]=first comment' \
-f 'comments[][path]=file2.js' \
-F 'comments[][line]=15' \
-f 'comments[][side]=RIGHT' \
-f 'comments[][body]=second comment' \
2>&1 | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['json']['comments'], indent=2))"
```
produces

```text
[
  {"body": "first comment", "path": "file1.py", "side": "RIGHT"},          ← line MISSING
  {"body": "second comment", "line": 42, "path": "file2.js", "side": "RIGHT"}, ← WRONG line
  {"line": 15}                                                               ← ORPHANED
]
```

all -F

```text
gh api --method POST https://httpbin.org/post \
-F 'comments[][path]=file1.py' \
-F 'comments[][line]=42' \
-F 'comments[][side]=RIGHT' \
-F 'comments[][body]=first comment' \
-F 'comments[][path]=file2.js' \
-F 'comments[][line]=15' \
-F 'comments[][side]=RIGHT' \
-F 'comments[][body]=second comment' \
2>&1 | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['json']['comments'], indent=2))"
```

produces

```text
[
  {"body": "first comment", "line": 42, "path": "file1.py", "side": "RIGHT"},  ← correct
  {"body": "second comment", "line": 15, "path": "file2.js", "side": "RIGHT"}  ← correct
]
```
