### PR TITLE
fix(pr-review): initialize git submodules when checking out PR code

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -60,6 +60,7 @@ runs:
               fetch-depth: 0
               persist-credentials: false
               path: pr-repo
+              submodules: recursive
 
         - name: Set up Python
           uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem

The PR review action was failing for repositories that use git submodules (see OpenHands/benchmarks#444). The error occurred during `uv` build:

```
Failed to build `openhands-benchmarks @ file:///home/runner/work/benchmarks/benchmarks/pr-repo`
Failed to parse entry: `openhands-sdk`
`openhands-sdk` references a workspace in `tool.uv.sources`, but is not a workspace member
```

## Root Cause

The `Checkout PR repository` step in the action didn't include `submodules: recursive`, so git submodules were not initialized. When the project depends on workspace members from submodules (e.g., `vendor/software-agent-sdk`), the build fails because those directories are empty.

## Solution

Added `submodules: recursive` to the PR repository checkout step. This ensures all submodules are properly initialized before building the project.

## Testing

This fix will be tested in OpenHands/benchmarks by temporarily pointing the workflow to use this branch. Once verified, this can be merged to main.

## Related Issues

Fixes OpenHands/benchmarks#444