### PR TITLE
Add note to verify PR title/description after changes

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -47,7 +47,7 @@ git checkout -b create-widget && git add . && git commit -m "Create widget" && g
 - Before resolving a thread, leave a reply comment that either explains the reason for dismissing the feedback or references the specific commit (e.g., commit SHA) that addressed the issue.
 - Prefer resolving threads only once fixes are pushed or a clear decision is documented.
 - Use the GitHub GraphQL API to reply to and resolve review threads (see below).
-- After making changes to a PR, verify that the PR title and description still accurately reflect the PR content. If they no longer match (e.g., scope changed, new features added, or original intent modified), update the title and/or description accordingly.
+- After making changes to a PR, verify the title and description still match the content. Update them if the scope, features, or intent changed.
 
 ## Resolving Review Threads via GraphQL
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -47,6 +47,7 @@ git checkout -b create-widget && git add . && git commit -m "Create widget" && g
 - Before resolving a thread, leave a reply comment that either explains the reason for dismissing the feedback or references the specific commit (e.g., commit SHA) that addressed the issue.
 - Prefer resolving threads only once fixes are pushed or a clear decision is documented.
 - Use the GitHub GraphQL API to reply to and resolve review threads (see below).
+- After making changes to a PR, verify that the PR title and description still accurately reflect the PR content. If they no longer match (e.g., scope changed, new features added, or original intent modified), update the title and/or description accordingly.
 
 ## Resolving Review Threads via GraphQL
 


### PR DESCRIPTION
This PR adds a note to the GitHub skill's "Handling Review Comments" section reminding developers to verify that the PR title and description still accurately reflect the PR content after making changes.

## Changes

Added the following guidance to the PR iteration workflow:

> After making changes to a PR, verify that the PR title and description still accurately reflect the PR content. If they no longer match (e.g., scope changed, new features added, or original intent modified), update the title and/or description accordingly.

This ensures that PRs remain well-documented and reviewers have accurate context about the changes being proposed.