### PR TITLE
Add learn-from-code-review skill

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -239,6 +239,19 @@
             ]
         },
         {
+            "name": "learn-from-code-review",
+            "source": "./learn-from-code-review",
+            "description": "Distill code review feedback from GitHub PRs into reusable skills and guidelines. Use when users ask to learn from code reviews, extract review patterns, or generate coding standards from historical PR feedback.",
+            "category": "code-quality",
+            "keywords": [
+                "code-review",
+                "learning",
+                "skills",
+                "guidelines",
+                "pr-feedback"
+            ]
+        },
+        {
             "name": "notion",
             "source": "./notion",
             "description": "Create, search, and update Notion pages/databases using the Notion API. Use for documenting work, generating runbooks, and automating knowledge base updates.",

--- a/skills/learn-from-code-review/README.md
+++ b/skills/learn-from-code-review/README.md
@@ -1,0 +1,64 @@
+# Learn from Code Review
+
+Distill code review feedback from GitHub pull requests into reusable skills and repository guidelines.
+
+## What It Does
+
+This skill analyzes PR review comments from a repository and extracts recurring patterns of feedback. These patterns are then transformed into:
+
+- **Repository-specific skills** (`.openhands/skills/`) for domain-specific patterns
+- **AGENTS.md updates** for general coding conventions and best practices
+
+## When to Use
+
+- "Learn from our code reviews"
+- "Distill PR feedback into guidelines"
+- "What patterns do reviewers keep pointing out?"
+- "Generate coding standards from review history"
+- Running `/learn-from-reviews`
+
+## Requirements
+
+- `GITHUB_TOKEN` environment variable
+- GitHub CLI (`gh`) available
+
+## Example
+
+```
+User: Learn from our code reviews over the past month
+
+Agent: I'll analyze recent PR review comments and distill them into actionable guidelines.
+
+[Analyzes 25 merged PRs with 150 review comments]
+[Filters out bot comments and low-signal responses]
+[Identifies 4 recurring patterns]
+
+Found the following patterns from code review feedback:
+
+1. Error Handling (12 comments)
+   - Always include context when logging errors
+   - Use structured error responses in APIs
+
+2. Testing (8 comments)
+   - Add edge case tests for validation logic
+   - Mock external services consistently
+
+3. Database Queries (6 comments)
+   - Use parameterized queries exclusively
+   - Add appropriate indexes for new queries
+
+I'll create a draft PR with:
+- New skill: `.openhands/skills/error-handling/SKILL.md`
+- Updates to `AGENTS.md` with testing and database guidelines
+```
+
+## Output
+
+The skill generates a draft PR containing proposed changes based on the analysis. Human review is expected before merging.
+
+## Related Skills
+
+- `github-pr-review` - Post structured code reviews
+- `code-review` - Perform code reviews
+- `skill-creator` - Create new skills manually
+- `agent-memory` - Persist repository knowledge

--- a/skills/learn-from-code-review/SKILL.md
+++ b/skills/learn-from-code-review/SKILL.md
@@ -85,9 +85,9 @@ For each category with sufficient examples (3+ similar comments), identify:
 
 ### Step 5: Generate Output
 
-Based on the patterns found, generate skills. Prefer creating focused skill files over modifying AGENTS.md, since AGENTS.md typically already contains general coding guidelines.
+If clear, actionable patterns emerge, generate focused skill files. If no clear patterns emerge, report this to the user—it's fine to produce no output when the codebase already has strong conventions or when review comments don't cluster into recurring themes.
 
-Create a skill file in `.openhands/skills/{domain-name}/SKILL.md`:
+When creating skills, place them in `.openhands/skills/{domain-name}/SKILL.md`:
 
 ```yaml
 ---
@@ -104,9 +104,9 @@ description: Database query patterns and best practices for this repository.
 [Pattern description with examples]
 ```
 
-Only propose AGENTS.md additions if the patterns represent genuinely new guidelines not already covered by existing content.
+Prefer skills over AGENTS.md updates, since AGENTS.md typically already contains general coding guidelines.
 
-### Step 6: Create Draft PR
+### Step 6: Create Draft PR (if applicable)
 
 Use the `create_pr` tool to open a draft PR with the proposed changes. The PR description should include:
 - Number of PRs analyzed

--- a/skills/learn-from-code-review/SKILL.md
+++ b/skills/learn-from-code-review/SKILL.md
@@ -99,12 +99,10 @@ Example structure:
 ```yaml
 ---
 name: database-queries
-description: Database query patterns and best practices derived from code review feedback.
+description: Database query patterns and best practices for this repository.
 ---
 
 # Database Query Guidelines
-
-## Patterns from Code Reviews
 
 ### Always Use Parameterized Queries
 [Pattern description with examples]
@@ -118,13 +116,11 @@ description: Database query patterns and best practices derived from code review
 When patterns are general repository conventions, propose additions to AGENTS.md:
 
 ```markdown
-## Code Review Learnings
-
-### Error Handling
+## Error Handling
 - Always wrap external API calls in try-catch blocks
 - Log errors with context before re-throwing
 
-### Testing
+## Testing
 - Include edge case tests for user input validation
 - Mock external services in unit tests
 ```
@@ -144,12 +140,10 @@ Use the `create_pr` tool to open a draft PR with the proposed changes. The PR de
 ```yaml
 ---
 name: api-error-handling
-description: API error handling patterns learned from code review feedback.
+description: API error handling patterns for this repository.
 ---
 
-# API Error Handling Patterns
-
-Based on recurring code review feedback, follow these patterns:
+# API Error Handling
 
 ## Always Return Structured Errors
 

--- a/skills/learn-from-code-review/SKILL.md
+++ b/skills/learn-from-code-review/SKILL.md
@@ -85,17 +85,10 @@ For each category with sufficient examples (3+ similar comments), identify:
 
 ### Step 5: Generate Output
 
-Based on the patterns found, generate appropriate outputs:
+Based on the patterns found, generate skills. Prefer creating focused skill files over modifying AGENTS.md, since AGENTS.md typically already contains general coding guidelines.
 
-#### For Specific Domain Patterns → Create Skills
+Create a skill file in `.openhands/skills/{domain-name}/SKILL.md`:
 
-When patterns are specific to a domain (e.g., database queries, API design, testing), create a skill file:
-
-```
-.openhands/skills/{domain-name}/SKILL.md
-```
-
-Example structure:
 ```yaml
 ---
 name: database-queries
@@ -111,19 +104,7 @@ description: Database query patterns and best practices for this repository.
 [Pattern description with examples]
 ```
 
-#### For General Guidelines → Update AGENTS.md
-
-When patterns are general repository conventions, propose additions to AGENTS.md:
-
-```markdown
-## Error Handling
-- Always wrap external API calls in try-catch blocks
-- Log errors with context before re-throwing
-
-## Testing
-- Include edge case tests for user input validation
-- Mock external services in unit tests
-```
+Only propose AGENTS.md additions if the patterns represent genuinely new guidelines not already covered by existing content.
 
 ### Step 6: Create Draft PR
 

--- a/skills/learn-from-code-review/SKILL.md
+++ b/skills/learn-from-code-review/SKILL.md
@@ -131,31 +131,11 @@ When patterns are general repository conventions, propose additions to AGENTS.md
 
 ### Step 6: Create Draft PR
 
-Open a draft PR with the proposed changes:
-
-```bash
-# Create branch
-git checkout -b openhands/learn-from-reviews-$(date +%Y%m%d)
-
-# Add generated files
-git add .openhands/skills/ AGENTS.md
-
-# Commit
-git commit -m "Add learnings from code review analysis
-
-Distilled patterns from recent PR reviews into:
-- [List of new skills if any]
-- AGENTS.md guideline updates"
-
-# Push and create draft PR
-git push -u origin HEAD
-```
-
-Use the `create_pr` tool to open a draft PR with a summary of:
+Use the `create_pr` tool to open a draft PR with the proposed changes. The PR description should include:
 - Number of PRs analyzed
 - Number of comments processed
 - Categories of patterns found
-- List of proposed changes
+- List of proposed changes (new skills and/or AGENTS.md updates)
 
 ## Example Output
 
@@ -197,16 +177,9 @@ return error_response(e)
 ```
 ```
 
-## Configuration Options
+## Defaults
 
-When running this workflow, consider:
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| Time range | 30 days | How far back to look for PRs |
-| Min comments | 3 | Minimum similar comments to form a pattern |
-| Include bots | No | Whether to include bot review comments |
-| Output format | both | Generate skills, AGENTS.md, or both |
+This workflow analyzes PRs from the past 30 days by default.
 
 ## Best Practices
 
@@ -215,6 +188,15 @@ When running this workflow, consider:
 3. **Iterate** - Refine patterns based on team feedback
 4. **Avoid duplication** - Check existing AGENTS.md and skills before adding
 5. **Cite sources** - Reference PR numbers when documenting patterns
+
+## Error Handling
+
+Handle these common edge cases gracefully:
+
+- **Repository has few PRs**: If fewer than 10 merged PRs exist in the timeframe, inform the user that there may not be enough data to identify patterns. Proceed with analysis but note the limited sample size.
+- **No patterns emerge**: When comments don't cluster into recurring themes (common for well-established codebases), report this to the user and suggest either expanding the time range or that the codebase may already have strong conventions.
+- **Token lacks repository access**: If the GitHub API returns 403/404, explain that the token may not have access to the repository and suggest checking token permissions.
+- **`gh` CLI unavailable**: Fall back to direct GitHub API calls using `curl` with `$GITHUB_TOKEN`, or inform the user that `gh` needs to be installed.
 
 ## Limitations
 

--- a/skills/learn-from-code-review/SKILL.md
+++ b/skills/learn-from-code-review/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: learn-from-code-review
+description: Distill code review feedback from GitHub PRs into reusable skills and guidelines. This skill should be used when users ask to "learn from code reviews", "distill PR feedback", "improve coding standards", "extract learnings from reviews", or want to generate skills/guidelines from historical review comments.
+triggers:
+- /learn-from-reviews
+- learn from code review
+- distill reviews
+---
+
+# Learn from Code Review
+
+Analyze code review comments from GitHub pull requests and distill them into reusable skills or repository guidelines that improve future code quality.
+
+## Overview
+
+Code review feedback contains valuable institutional knowledge that often gets buried across hundreds of PRs. This skill extracts meaningful patterns from review comments and transforms them into:
+
+1. **Repository-specific skills** - Placed in `.openhands/skills/` for domain-specific patterns
+2. **AGENTS.md guidelines** - Overall repository conventions and best practices
+
+## Prerequisites
+
+- `GITHUB_TOKEN` environment variable must be set
+- GitHub CLI (`gh`) should be available
+
+## Workflow
+
+### Step 1: Identify Target Repository
+
+Determine the repository to analyze:
+
+```bash
+# Get current repo info
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+If not in a repository, ask the user which repository to analyze.
+
+### Step 2: Fetch Review Comments
+
+Retrieve PR review comments from the repository:
+
+```bash
+# Fetch merged PRs from the last 30 days (adjustable)
+gh pr list --repo {owner}/{repo} \
+  --state merged \
+  --limit 50 \
+  --json number,title,mergedAt
+
+# For each PR, fetch review comments
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments \
+  --jq '.[] | {body: .body, path: .path, user: .user.login, created_at: .created_at}'
+
+# Also fetch review-level comments (not tied to specific lines)
+gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+  --jq '.[] | select(.body != "") | {body: .body, user: .user.login, state: .state}'
+```
+
+### Step 3: Filter and Categorize Comments
+
+Apply noise filtering to keep only meaningful feedback:
+
+**Exclude:**
+- Bot comments (dependabot, copilot, github-actions, etc.)
+- Low-signal responses ("LGTM", "+1", "looks good", "thanks", "nice")
+- Comments shorter than 30 characters
+- Auto-generated comments (CI status, coverage reports)
+
+**Categorize remaining comments by:**
+- Security concerns
+- Performance patterns
+- Code style/conventions
+- Architecture/design patterns
+- Error handling
+- Testing requirements
+- Documentation standards
+
+### Step 4: Distill Patterns
+
+For each category with sufficient examples (3+ similar comments), identify:
+
+1. **The recurring issue** - What mistake or oversight keeps appearing
+2. **The desired pattern** - What reviewers consistently ask for
+3. **Example context** - Concrete before/after code snippets when available
+
+### Step 5: Generate Output
+
+Based on the patterns found, generate appropriate outputs:
+
+#### For Specific Domain Patterns → Create Skills
+
+When patterns are specific to a domain (e.g., database queries, API design, testing), create a skill file:
+
+```
+.openhands/skills/{domain-name}/SKILL.md
+```
+
+Example structure:
+```yaml
+---
+name: database-queries
+description: Database query patterns and best practices derived from code review feedback.
+---
+
+# Database Query Guidelines
+
+## Patterns from Code Reviews
+
+### Always Use Parameterized Queries
+[Pattern description with examples]
+
+### Connection Pool Management
+[Pattern description with examples]
+```
+
+#### For General Guidelines → Update AGENTS.md
+
+When patterns are general repository conventions, propose additions to AGENTS.md:
+
+```markdown
+## Code Review Learnings
+
+### Error Handling
+- Always wrap external API calls in try-catch blocks
+- Log errors with context before re-throwing
+
+### Testing
+- Include edge case tests for user input validation
+- Mock external services in unit tests
+```
+
+### Step 6: Create Draft PR
+
+Open a draft PR with the proposed changes:
+
+```bash
+# Create branch
+git checkout -b openhands/learn-from-reviews-$(date +%Y%m%d)
+
+# Add generated files
+git add .openhands/skills/ AGENTS.md
+
+# Commit
+git commit -m "Add learnings from code review analysis
+
+Distilled patterns from recent PR reviews into:
+- [List of new skills if any]
+- AGENTS.md guideline updates"
+
+# Push and create draft PR
+git push -u origin HEAD
+```
+
+Use the `create_pr` tool to open a draft PR with a summary of:
+- Number of PRs analyzed
+- Number of comments processed
+- Categories of patterns found
+- List of proposed changes
+
+## Example Output
+
+### Sample Skill: API Error Handling
+
+```yaml
+---
+name: api-error-handling
+description: API error handling patterns learned from code review feedback.
+---
+
+# API Error Handling Patterns
+
+Based on recurring code review feedback, follow these patterns:
+
+## Always Return Structured Errors
+
+❌ Avoid:
+```python
+return {"error": str(e)}
+```
+
+✅ Prefer:
+```python
+return {
+    "error": {
+        "code": "VALIDATION_ERROR",
+        "message": "Invalid input",
+        "details": {"field": "email", "reason": "Invalid format"}
+    }
+}
+```
+
+## Log Before Returning Errors
+
+```python
+logger.error(f"API error in {endpoint}: {e}", exc_info=True)
+return error_response(e)
+```
+```
+
+## Configuration Options
+
+When running this workflow, consider:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| Time range | 30 days | How far back to look for PRs |
+| Min comments | 3 | Minimum similar comments to form a pattern |
+| Include bots | No | Whether to include bot review comments |
+| Output format | both | Generate skills, AGENTS.md, or both |
+
+## Best Practices
+
+1. **Run periodically** - Schedule monthly or quarterly to capture evolving patterns
+2. **Review before merging** - Generated content is a draft; human review is essential
+3. **Iterate** - Refine patterns based on team feedback
+4. **Avoid duplication** - Check existing AGENTS.md and skills before adding
+5. **Cite sources** - Reference PR numbers when documenting patterns
+
+## Limitations
+
+- Only analyzes accessible repositories (requires appropriate permissions)
+- Cannot capture verbal feedback from pair programming or meetings
+- Patterns may reflect individual reviewer preferences vs. team consensus
+- Historical comments may reference outdated code patterns
+
+## Additional Resources
+
+For posting structured code reviews, see the `github-pr-review` skill.
+For creating new skills, see the `skill-creator` skill.


### PR DESCRIPTION
## Summary

This PR adds a new skill that distills code review feedback from GitHub PRs into reusable skills and repository guidelines.

Closes #86

## What this skill does

The `learn-from-code-review` skill analyzes PR review comments from a repository and extracts recurring patterns of feedback. These patterns are transformed into:

- **Repository-specific skills** (`.openhands/skills/`) for domain-specific patterns (e.g., database queries, API design)
- **AGENTS.md updates** for general coding conventions and best practices

## Workflow

1. Fetch PR review comments from the target repository using GitHub API
2. Filter out noise (bot comments, low-signal responses like "LGTM", short comments)
3. Categorize comments by type (security, performance, style, architecture, etc.)
4. Identify recurring patterns (3+ similar comments)
5. Generate skills and/or AGENTS.md updates
6. Create a draft PR with the proposed changes

## Trigger phrases

- `/learn-from-reviews`
- "learn from code reviews"
- "distill reviews"

## Files changed

- `skills/learn-from-code-review/SKILL.md` - Main skill definition
- `skills/learn-from-code-review/README.md` - Documentation
- `marketplaces/default.json` - Added skill to marketplace

## Testing

- ✅ All existing tests pass (`test_skills_have_readme.py`)
- ✅ Marketplace JSON is valid

## Evidence

The skill was tested on the `OpenHands/software-agent-sdk` repository. The workflow analyzed 15 merged PRs from the past 30 days, processed 25+ review comments, and identified 4 recurring patterns.

**Test PR**: https://github.com/OpenHands/software-agent-sdk/pull/2280

The test generated:
- A new skill: `.openhands/skills/eval-risk-assessment/SKILL.md`
- Updates to `AGENTS.md` with a Code Review Learnings section

## Related

- Inspired by [dstl-code-review](https://github.com/AmitPoonia/dstl-code-review)
- Related skills: `code-review`, `github-pr-review`, `skill-creator`, `agent-memory`