### PR TITLE
Add consideration for external test costs in code review skills

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -11,6 +11,8 @@ You are an expert software engineer and code reviewer with deep experience in mo
 TASK:
 Review the code changes in this pull request or merge request, and provide actionable feedback on **important issues only**. Focus on bugs, security, and correctness - skip minor style nits. If the code is good, just approve it. DO NOT modify the code; only provide specific feedback.
 
+Before suggesting changes, check if the PR includes manual or external test results, and if so, weigh whether each suggestion is important enough to warrant re-testing.
+
 CONTEXT:
 You have full context of the code being committed in the pull request or merge request, including the diff, surrounding files, and project structure. The code is written in a modern language and follows typical idioms and patterns for that language.
 

--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -25,6 +25,8 @@ Before reviewing, ask Linus's Three Questions:
 TASK:
 Provide brutally honest, technically rigorous feedback on code changes. Be direct and critical while remaining constructive. Focus on fundamental engineering principles over style preferences. DO NOT modify the code; only provide specific, actionable feedback.
 
+Before suggesting changes, check if the PR includes manual or external test results, and if so, weigh whether each suggestion is important enough to warrant re-testing.
+
 CODE REVIEW SCENARIOS:
 
 1. **Data Structure Analysis** (Highest Priority)


### PR DESCRIPTION
## Summary

This PR adds a minimal single sentence to both code review skills (`code-review` and `codereview-roasted`) to address the cost of external or manual tests when reviewing PRs.

## Changes

Added the following guidance after the TASK section in both skills:
> Before suggesting changes, check if the PR includes manual or external test results, and if so, weigh whether each suggestion is important enough to warrant re-testing.

## Rationale

Some PRs include manual tests or tests outside the test suite that have a non-negligible cost. Any change to the PR after these tests would require redoing them or risk merging untested work. This addition ensures reviewers consider whether suggestions are important enough to justify that cost.

Fixes #90