### PR TITLE
Add release notes generator plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - Keep formatting consistent across skills.
 - If you change a skill’s behavior or scope, update its `README.md` (if present) accordingly.
 - If you change top-level documentation, ensure links still resolve.
+- For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
+
 
 ## When uncertain
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - If you change a skill’s behavior or scope, update its `README.md` (if present) accordingly.
 - If you change top-level documentation, ensure links still resolve.
 - For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
+- Agent-driven plugins (for example `plugins/pr-review` and `plugins/release-notes`) use `uv run --with openhands-sdk --with openhands-tools ...` and require an `LLM_API_KEY` in addition to `GITHUB_TOKEN`.
+
 
 
 ## When uncertain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
 - Agent-driven plugins (for example `plugins/pr-review` and `plugins/release-notes`) use `uv run --with openhands-sdk --with openhands-tools ...` and require an `LLM_API_KEY` in addition to `GITHUB_TOKEN`.
 - For OpenHands Cloud API guidance, use `skills/openhands-api`. It is the canonical OpenHands Cloud API skill and documents the supported V1 API.
+- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context and fails if a change bullet omits explicit PR/commit refs or the matching author handles.
+
 
 ## CI / validation gotchas
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
 - Agent-driven plugins (for example `plugins/pr-review` and `plugins/release-notes`) use `uv run --with openhands-sdk --with openhands-tools ...` and require an `LLM_API_KEY` in addition to `GITHUB_TOKEN`.
 - For OpenHands Cloud API guidance, use `skills/openhands-api`. It is the canonical OpenHands Cloud API skill and documents the supported V1 API.
-- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context and fails if a change bullet omits explicit PR/commit refs or the matching author handles.
+- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context, fails if a change bullet omits explicit PR/commit refs or matching author handles, and enforces full PR/author coverage by appending a compact reference appendix when the agent omits lower-signal items.
 
 
 ## CI / validation gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
 - Agent-driven plugins (for example `plugins/pr-review` and `plugins/release-notes`) use `uv run --with openhands-sdk --with openhands-tools ...` and require an `LLM_API_KEY` in addition to `GITHUB_TOKEN`.
 - For OpenHands Cloud API guidance, use `skills/openhands-api`. It is the canonical OpenHands Cloud API skill and documents the supported V1 API.
-- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context, fails if a change bullet omits explicit PR/commit refs or matching author handles, and enforces full PR/author coverage by appending a compact `### 🔎 Small Fixes/Internal Changes` appendix grouped by author when the agent omits lower-signal items.
+- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context, fails if a change bullet omits explicit PR/commit refs or matching author handles, and enforces full PR/author coverage by appending a compact `### 🔎 Small Fixes/Internal Changes` appendix grouped by author when the agent omits lower-signal items. New contributor detection in `generate_release_notes.py` should use merged PR history for human authors (excluding bots) rather than commit-author lookup.
 
 
 ## CI / validation gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - For Python test runs, prefer `uv sync --group test` followed by `uv run pytest -q`; the full suite depends on `openhands-sdk`, which is not available in the base environment.
 - Agent-driven plugins (for example `plugins/pr-review` and `plugins/release-notes`) use `uv run --with openhands-sdk --with openhands-tools ...` and require an `LLM_API_KEY` in addition to `GITHUB_TOKEN`.
 - For OpenHands Cloud API guidance, use `skills/openhands-api`. It is the canonical OpenHands Cloud API skill and documents the supported V1 API.
-- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context, fails if a change bullet omits explicit PR/commit refs or matching author handles, and enforces full PR/author coverage by appending a compact reference appendix when the agent omits lower-signal items.
+- `plugins/release-notes` now has a standalone validator at `plugins/release-notes/scripts/validate_release_notes.py`; it rebuilds the deterministic tag-range context, fails if a change bullet omits explicit PR/commit refs or matching author handles, and enforces full PR/author coverage by appending a compact `### 🔎 Small Fixes/Internal Changes` appendix grouped by author when the agent omits lower-signal items.
 
 
 ## CI / validation gotchas

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -1,0 +1,251 @@
+# Release Notes Generator Plugin
+
+Automated release notes generation using OpenHands agents. This plugin provides GitHub workflows that generate consistent, well-structured release notes when release tags are pushed.
+
+## Quick Start
+
+Copy the workflow file to your repository:
+
+```bash
+mkdir -p .github/workflows
+curl -o .github/workflows/release-notes.yml \
+  https://raw.githubusercontent.com/OpenHands/extensions/main/plugins/release-notes/workflows/release-notes.yml
+```
+
+Then configure the required secrets (see [Installation](#installation) below).
+
+## Features
+
+- **Automatic Tag Detection**: Automatically finds the previous release tag to determine the commit range
+- **Categorized Changes**: Groups commits into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
+- **Conventional Commits Support**: Categorizes based on commit prefixes (`feat:`, `fix:`, `docs:`, etc.)
+- **PR Label Support**: Also categorizes based on GitHub PR labels
+- **Contributor Attribution**: Includes PR numbers and author usernames for each change
+- **New Contributor Highlighting**: Identifies and celebrates first-time contributors
+- **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
+
+## Plugin Contents
+
+```
+plugins/release-notes/
+├── README.md              # This file
+├── SKILL.md               # Plugin definition
+├── action.yml             # Composite GitHub Action
+├── scripts/               # Python scripts
+│   └── generate_release_notes.py
+└── workflows/             # Example GitHub workflow files
+    └── release-notes.yml
+```
+
+## Installation
+
+### 1. Copy the Workflow File
+
+Copy the workflow file to your repository's `.github/workflows/` directory:
+
+```bash
+mkdir -p .github/workflows
+curl -o .github/workflows/release-notes.yml \
+  https://raw.githubusercontent.com/OpenHands/extensions/main/plugins/release-notes/workflows/release-notes.yml
+```
+
+### 2. Configure Secrets
+
+Add the following secrets in your repository settings (**Settings → Secrets and variables → Actions**):
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `GITHUB_TOKEN` | Auto | Provided automatically by GitHub Actions |
+
+**Note**: The default `GITHUB_TOKEN` is sufficient for most use cases. For repositories that need elevated permissions, use a personal access token.
+
+### 3. Customize the Workflow (Optional)
+
+Edit the workflow file to customize:
+
+```yaml
+- name: Generate Release Notes
+  uses: OpenHands/extensions/plugins/release-notes@main
+  with:
+    # The release tag to generate notes for
+    tag: ${{ github.ref_name }}
+    
+    # Optional: Override previous tag detection
+    # previous-tag: v1.0.0
+    
+    # Include internal/infrastructure changes (default: false)
+    include-internal: false
+    
+    # Output format: 'release' (GitHub release) or 'changelog' (CHANGELOG.md)
+    output-format: release
+    
+    # Secrets
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Usage
+
+### Automatic Triggers
+
+Release notes are automatically generated when:
+
+1. A tag matching `v[0-9]+.[0-9]+.[0-9]+*` is pushed (e.g., `v1.2.0`, `v2.0.0-beta.1`)
+
+### Manual Triggering
+
+You can also manually trigger release notes generation:
+
+1. Go to **Actions** in your repository
+2. Select the "Generate Release Notes" workflow
+3. Click **Run workflow**
+4. Enter the tag to generate notes for
+
+## Action Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `tag` | Yes | - | The release tag to generate notes for |
+| `previous-tag` | No | Auto-detect | Override automatic detection of previous release |
+| `include-internal` | No | `false` | Include internal/infrastructure changes |
+| `output-format` | No | `release` | Output format: `release` or `changelog` |
+| `github-token` | Yes | - | GitHub token for API access |
+
+## Action Outputs
+
+| Output | Description |
+|--------|-------------|
+| `release-notes` | The generated release notes in markdown format |
+| `previous-tag` | The detected or provided previous release tag |
+| `commit-count` | Number of commits included in the release |
+| `contributor-count` | Number of unique contributors |
+| `new-contributor-count` | Number of first-time contributors |
+
+## Release Notes Structure
+
+Generated release notes follow this format:
+
+```markdown
+## [v1.2.0] - 2026-03-06
+
+### ⚠️ Breaking Changes
+- Remove deprecated `--legacy` CLI flag (#456) @maintainer
+
+### ✨ New Features
+- Add support for Claude Sonnet 4.6 model (#445) @contributor1
+- Implement parallel tool execution (#438) @contributor2
+
+### 🐛 Bug Fixes
+- Fix WebSocket reconnection on network interruption (#451) @contributor3
+- Resolve memory leak in long-running sessions (#447) @maintainer
+
+### 📚 Documentation
+- Update installation guide for v1.2 (#442) @contributor2
+
+### 🏗️ Internal/Infrastructure
+- Upgrade CI to use Node 20 (#440) @maintainer
+
+### 👥 New Contributors
+- @contributor3 made their first contribution in #451
+
+**Full Changelog**: https://github.com/org/repo/compare/v1.1.0...v1.2.0
+```
+
+## Change Categorization
+
+Changes are categorized using two methods:
+
+### 1. Conventional Commit Prefixes
+
+| Prefix | Category |
+|--------|----------|
+| `BREAKING:` or `!:` suffix | ⚠️ Breaking Changes |
+| `feat:`, `feature:` | ✨ New Features |
+| `fix:`, `bugfix:` | 🐛 Bug Fixes |
+| `docs:` | 📚 Documentation |
+| `chore:`, `ci:`, `refactor:`, `test:`, `build:` | 🏗️ Internal/Infrastructure |
+
+### 2. PR Labels
+
+| Labels | Category |
+|--------|----------|
+| `breaking-change`, `breaking` | ⚠️ Breaking Changes |
+| `enhancement`, `feature` | ✨ New Features |
+| `bug`, `bugfix` | 🐛 Bug Fixes |
+| `documentation`, `docs` | 📚 Documentation |
+| `internal`, `chore`, `ci`, `dependencies` | 🏗️ Internal/Infrastructure |
+
+## Content Guidelines
+
+The generator follows these principles:
+
+- **Concise but informative**: Provides enough context without being verbose
+- **User-focused**: Emphasizes user-facing changes over internal details
+- **Scannable**: Easy to quickly find relevant changes
+- **Imperative mood**: Uses "Add feature" not "Added feature"
+- **Attribution**: Includes PR number and author for traceability
+
+## Customizing Output
+
+### Excluding Internal Changes
+
+By default, internal/infrastructure changes are excluded. To include them:
+
+```yaml
+- uses: OpenHands/extensions/plugins/release-notes@main
+  with:
+    include-internal: true
+```
+
+### Generating CHANGELOG.md Entries
+
+To generate output suitable for a CHANGELOG.md file:
+
+```yaml
+- uses: OpenHands/extensions/plugins/release-notes@main
+  with:
+    output-format: changelog
+```
+
+Then use the output in a subsequent step:
+
+```yaml
+- name: Update CHANGELOG
+  run: |
+    echo "${{ steps.release-notes.outputs.release-notes }}" >> CHANGELOG.md
+```
+
+## Troubleshooting
+
+### Release Notes Not Generated
+
+1. Check that the tag matches the semver pattern: `v[0-9]+.[0-9]+.[0-9]+*`
+2. Verify the workflow file is in `.github/workflows/`
+3. Check the Actions tab for error messages
+
+### Wrong Previous Tag Detected
+
+Use the `previous-tag` input to override automatic detection:
+
+```yaml
+previous-tag: v1.0.0
+```
+
+### Missing Contributors
+
+The generator uses the GitHub API to fetch PR authors. Ensure:
+1. Commits are associated with merged PRs
+2. The `GITHUB_TOKEN` has read access to pull requests
+
+## Security
+
+- Uses the default `GITHUB_TOKEN` for API access
+- No secrets are persisted or logged
+- Read-only access to repository history and PRs
+
+## Contributing
+
+See the main [extensions repository](https://github.com/OpenHands/extensions) for contribution guidelines.
+
+## License
+
+This plugin is part of the OpenHands extensions repository. See [LICENSE](../../LICENSE) for details.

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -17,7 +17,8 @@ Then configure the required secrets (see [Installation](#installation) below).
 ## Features
 
 - **Automatic Tag Detection**: Automatically finds the previous release tag to determine the commit range
-- **Categorized Changes**: Groups commits into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
+- **Categorized Changes**: Groups user-facing updates into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
+- **PR-Level Summaries**: Uses merged PR titles when available and collapses multiple commits from the same PR into one entry
 - **Conventional Commits Support**: Categorizes based on commit prefixes (`feat:`, `fix:`, `docs:`, etc.)
 - **PR Label Support**: Also categorizes based on GitHub PR labels
 - **Contributor Attribution**: Includes PR numbers and author usernames for each change
@@ -178,8 +179,8 @@ Changes are categorized using two methods:
 
 The generator follows these principles:
 
-- **Concise but informative**: Provides enough context without being verbose
-- **User-focused**: Emphasizes user-facing changes over internal details
+- **Concise but informative**: Uses one line per merged PR where possible instead of listing every commit
+- **User-focused**: Prioritizes categorized, user-facing changes and omits uncategorized noise from the default output
 - **Scannable**: Easy to quickly find relevant changes
 - **Imperative mood**: Uses "Add feature" not "Added feature"
 - **Attribution**: Includes PR number and author for traceability

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -17,11 +17,11 @@ Then configure the required secrets (see [Installation](#installation) below).
 ## Features
 
 - **Automatic Tag Detection**: Automatically finds the previous release tag to determine the commit range
-- **Categorized Changes**: Groups user-facing updates into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
-- **PR-Level Summaries**: Uses merged PR titles when available and collapses multiple commits from the same PR into one entry
-- **Conventional Commits Support**: Categorizes based on commit prefixes (`feat:`, `fix:`, `docs:`, etc.)
-- **PR Label Support**: Also categorizes based on GitHub PR labels
-- **Contributor Attribution**: Includes PR numbers and author usernames for each change
+- **Agent-Based Summaries**: Uses an OpenHands agent to judge significance, merge related PRs, and decide what is worth mentioning
+- **Structured GitHub Context**: Feeds the agent merged PR titles, labels, bodies, authors, and contributor information for the release range
+- **Conventional Commits Support**: Uses commit prefixes (`feat:`, `fix:`, `docs:`, etc.) as categorization hints for the agent
+- **PR Label Support**: Uses GitHub PR labels as additional hints for the agent
+- **Contributor Attribution**: Includes PR numbers and author usernames for each change the agent keeps
 - **New Contributor Highlighting**: Identifies and celebrates first-time contributors
 - **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
 
@@ -33,7 +33,9 @@ plugins/release-notes/
 ├── SKILL.md               # Plugin definition
 ├── action.yml             # Composite GitHub Action
 ├── scripts/               # Python scripts
-│   └── generate_release_notes.py
+│   ├── agent_script.py    # OpenHands agent orchestration
+│   ├── generate_release_notes.py
+│   └── prompt.py
 └── workflows/             # Example GitHub workflow files
     └── release-notes.yml
 ```
@@ -56,6 +58,7 @@ Add the following secrets in your repository settings (**Settings → Secrets an
 
 | Secret | Required | Description |
 |--------|----------|-------------|
+| `LLM_API_KEY` | Yes | API key for the LLM used by the OpenHands agent |
 | `GITHUB_TOKEN` | Auto | Provided automatically by GitHub Actions |
 
 **Note**: The default `GITHUB_TOKEN` is sufficient for most use cases. For repositories that need elevated permissions, use a personal access token.
@@ -70,17 +73,21 @@ Edit the workflow file to customize:
   with:
     # The release tag to generate notes for
     tag: ${{ github.ref_name }}
-    
+
     # Optional: Override previous tag detection
     # previous-tag: v1.0.0
-    
+
     # Include internal/infrastructure changes (default: false)
     include-internal: false
-    
+
     # Output format: 'release' (GitHub release) or 'changelog' (CHANGELOG.md)
     output-format: release
-    
+
+    # Optional model override
+    # llm-model: anthropic/claude-sonnet-4-5-20250929
+
     # Secrets
+    llm-api-key: ${{ secrets.LLM_API_KEY }}
     github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -109,6 +116,9 @@ You can also manually trigger release notes generation:
 | `previous-tag` | No | Auto-detect | Override automatic detection of previous release |
 | `include-internal` | No | `false` | Include internal/infrastructure changes |
 | `output-format` | No | `release` | Output format: `release` or `changelog` |
+| `llm-model` | No | `anthropic/claude-sonnet-4-5-20250929` | LLM used by the OpenHands agent |
+| `llm-base-url` | No | - | Optional custom LLM endpoint |
+| `llm-api-key` | Yes | - | API key for the OpenHands agent's LLM |
 | `github-token` | Yes | - | GitHub token for API access |
 
 ## Action Outputs
@@ -153,7 +163,7 @@ Generated release notes follow this format:
 
 ## Change Categorization
 
-Changes are categorized using two methods:
+The agent receives deterministic categorization hints, but it makes the final decision about significance, grouping, and which entries to keep.
 
 ### 1. Conventional Commit Prefixes
 
@@ -179,8 +189,8 @@ Changes are categorized using two methods:
 
 The generator follows these principles:
 
-- **Concise but informative**: Uses one line per merged PR where possible instead of listing every commit
-- **User-focused**: Prioritizes categorized, user-facing changes and omits uncategorized noise from the default output
+- **Concise but informative**: The agent decides which changes matter and can merge related PRs into a single higher-signal bullet
+- **User-focused**: The agent prioritizes user-facing changes over low-level implementation detail
 - **Scannable**: Easy to quickly find relevant changes
 - **Imperative mood**: Uses "Add feature" not "Added feature"
 - **Attribution**: Includes PR number and author for traceability
@@ -216,6 +226,10 @@ Then use the output in a subsequent step:
 ```
 
 ## Troubleshooting
+
+### Missing LLM Credentials
+
+Make sure `LLM_API_KEY` is configured in repository secrets and passed to the action.
 
 ### Release Notes Not Generated
 

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -24,7 +24,7 @@ Then configure the required secrets (see [Installation](#installation) below).
 - **Contributor Attribution**: Includes PR numbers and author usernames for each change the agent keeps
 - **Attribution Validation**: Fails the workflow if any release-range PR/commit or corresponding author is omitted from the final notes
 - **Deterministic Coverage Appendix**: When the agent omits lower-signal PRs, the action appends a compact `### 🔎 Small Fixes/Internal Changes` appendix grouped by author so every PR and author in the release range is still listed somewhere in the output
-- **New Contributor Highlighting**: Identifies and celebrates first-time contributors
+- **New Contributor Highlighting**: Identifies first-time human contributors from merged PR history and excludes bot accounts
 - **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
 
 ## Plugin Contents
@@ -194,7 +194,8 @@ The generator follows these principles:
 
 - **Conversational overview**: Starts with a short plain-language summary of the release before the detailed sections
 - **Concise but informative**: The agent decides which changes matter and can merge related PRs into a single higher-signal bullet
-- **User-focused**: The agent prioritizes user-facing changes over low-level implementation detail
+- **User-focused**: The agent prioritizes end-user and client-developer impact over low-level implementation detail
+- **Internal changes stay secondary**: CI churn, prompt tweaks, workflow plumbing, contributor ergonomics, and similar toolkit-maintainer details belong in `### 🔎 Small Fixes/Internal Changes` unless they are unusually significant
 - **Scannable**: Easy to quickly find relevant changes
 - **Imperative mood**: Uses "Add feature" not "Added feature"
 - **Attribution**: Includes PR number and author for traceability

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -22,7 +22,8 @@ Then configure the required secrets (see [Installation](#installation) below).
 - **Conventional Commits Support**: Uses commit prefixes (`feat:`, `fix:`, `docs:`, etc.) as categorization hints for the agent
 - **PR Label Support**: Uses GitHub PR labels as additional hints for the agent
 - **Contributor Attribution**: Includes PR numbers and author usernames for each change the agent keeps
-- **Attribution Validation**: Fails the workflow if a change bullet omits an explicit PR/commit reference or the corresponding author handle
+- **Attribution Validation**: Fails the workflow if any release-range PR/commit or corresponding author is omitted from the final notes
+- **Deterministic Coverage Appendix**: When the agent omits lower-signal PRs, the action appends a compact reference appendix so every PR and author in the release range is still listed somewhere in the output
 - **New Contributor Highlighting**: Identifies and celebrates first-time contributors
 - **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
 
@@ -200,13 +201,14 @@ The generator follows these principles:
 ## Validation Guardrail
 
 After the agent writes `release_notes.md`, the action runs `scripts/validate_release_notes.py`.
-That validator rebuilds the deterministic PR/author context for the same tag range and checks that every change bullet:
+That validator rebuilds the deterministic PR/author context for the same tag range and checks that the final notes:
 
-- includes at least one explicit PR or commit reference
-- includes the author handle for every referenced PR or commit
-- does not reference unknown PRs or commits
+- include at least one explicit PR or commit reference in every user-facing change bullet
+- include the author handle for every referenced PR or commit
+- do not reference unknown PRs or commits
+- cover every PR/commit in the release range somewhere in the markdown
 
-This lets the agent stay concise while still guaranteeing traceable attribution in the final release description.
+If the agent keeps the main sections concise and omits lower-signal PRs, `agent_script.py` inserts a compact `### 🔎 Complete PR and Author Reference Coverage` appendix before the full changelog link so the output remains readable while still being exhaustive.
 
 ## Customizing Output
 

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -23,7 +23,7 @@ Then configure the required secrets (see [Installation](#installation) below).
 - **PR Label Support**: Uses GitHub PR labels as additional hints for the agent
 - **Contributor Attribution**: Includes PR numbers and author usernames for each change the agent keeps
 - **Attribution Validation**: Fails the workflow if any release-range PR/commit or corresponding author is omitted from the final notes
-- **Deterministic Coverage Appendix**: When the agent omits lower-signal PRs, the action appends a compact reference appendix so every PR and author in the release range is still listed somewhere in the output
+- **Deterministic Coverage Appendix**: When the agent omits lower-signal PRs, the action appends a compact `### 🔎 Small Fixes/Internal Changes` appendix grouped by author so every PR and author in the release range is still listed somewhere in the output
 - **New Contributor Highlighting**: Identifies and celebrates first-time contributors
 - **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
 
@@ -192,6 +192,7 @@ The agent receives deterministic categorization hints, but it makes the final de
 
 The generator follows these principles:
 
+- **Conversational overview**: Starts with a short plain-language summary of the release before the detailed sections
 - **Concise but informative**: The agent decides which changes matter and can merge related PRs into a single higher-signal bullet
 - **User-focused**: The agent prioritizes user-facing changes over low-level implementation detail
 - **Scannable**: Easy to quickly find relevant changes
@@ -208,7 +209,7 @@ That validator rebuilds the deterministic PR/author context for the same tag ran
 - do not reference unknown PRs or commits
 - cover every PR/commit in the release range somewhere in the markdown
 
-If the agent keeps the main sections concise and omits lower-signal PRs, `agent_script.py` inserts a compact `### 🔎 Complete PR and Author Reference Coverage` appendix before the full changelog link so the output remains readable while still being exhaustive.
+If the agent keeps the main sections concise and omits lower-signal PRs, `agent_script.py` inserts a compact `### 🔎 Small Fixes/Internal Changes` appendix before the full changelog link. That appendix is grouped by author so the output remains readable while still being exhaustive.
 
 ## Customizing Output
 

--- a/plugins/release-notes/README.md
+++ b/plugins/release-notes/README.md
@@ -22,6 +22,7 @@ Then configure the required secrets (see [Installation](#installation) below).
 - **Conventional Commits Support**: Uses commit prefixes (`feat:`, `fix:`, `docs:`, etc.) as categorization hints for the agent
 - **PR Label Support**: Uses GitHub PR labels as additional hints for the agent
 - **Contributor Attribution**: Includes PR numbers and author usernames for each change the agent keeps
+- **Attribution Validation**: Fails the workflow if a change bullet omits an explicit PR/commit reference or the corresponding author handle
 - **New Contributor Highlighting**: Identifies and celebrates first-time contributors
 - **Flexible Output**: Updates GitHub release notes directly or outputs for CHANGELOG.md
 
@@ -35,7 +36,8 @@ plugins/release-notes/
 ├── scripts/               # Python scripts
 │   ├── agent_script.py    # OpenHands agent orchestration
 │   ├── generate_release_notes.py
-│   └── prompt.py
+│   ├── prompt.py
+│   └── validate_release_notes.py
 └── workflows/             # Example GitHub workflow files
     └── release-notes.yml
 ```
@@ -194,6 +196,17 @@ The generator follows these principles:
 - **Scannable**: Easy to quickly find relevant changes
 - **Imperative mood**: Uses "Add feature" not "Added feature"
 - **Attribution**: Includes PR number and author for traceability
+
+## Validation Guardrail
+
+After the agent writes `release_notes.md`, the action runs `scripts/validate_release_notes.py`.
+That validator rebuilds the deterministic PR/author context for the same tag range and checks that every change bullet:
+
+- includes at least one explicit PR or commit reference
+- includes the author handle for every referenced PR or commit
+- does not reference unknown PRs or commits
+
+This lets the agent stay concise while still guaranteeing traceable attribution in the final release description.
 
 ## Customizing Output
 

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -13,11 +13,11 @@ Automates the generation of standardized release notes for OpenHands repositorie
 ## Features
 
 - **Automatic tag detection**: Finds the previous release tag to determine the commit range
-- **Agent-based editing**: Lets the agent decide which changes matter and group related PRs into higher-signal summaries
+- **Agent-based editing**: Lets the agent decide which changes matter, open with a short conversational summary, and group related PRs into higher-signal summaries
 - **Structured GitHub context**: Supplies PR titles, labels, descriptions, and contributor metadata to guide the agent
 - **Contributor attribution**: Includes PR numbers and author usernames for each change
 - **Attribution validation**: Verifies every change bullet contains explicit PR/commit references and the matching author handles
-- **Full coverage appendix**: Appends a compact reference section when needed so every PR and author in the release range is still listed somewhere in the final markdown
+- **Full coverage appendix**: Appends a compact `### 🔎 Small Fixes/Internal Changes` section grouped by author when needed so every PR and author in the release range is still listed somewhere in the final markdown
 - **New contributor highlighting**: Identifies and celebrates first-time contributors
 - **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries
 

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -8,12 +8,13 @@ triggers:
 
 # Release Notes Generator Plugin
 
-Automates the generation of standardized release notes for OpenHands repositories. This plugin can be triggered via GitHub Actions on release tags matching semver patterns (e.g., `v*.*.*`) or manually invoked.
+Automates the generation of standardized release notes for OpenHands repositories using an OpenHands agent. The agent reviews the release range, judges significance, groups related PRs, and produces concise markdown for GitHub releases or changelogs.
 
 ## Features
 
 - **Automatic tag detection**: Finds the previous release tag to determine the commit range
-- **Categorized changes**: Groups commits into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
+- **Agent-based editing**: Lets the agent decide which changes matter and group related PRs into higher-signal summaries
+- **Structured GitHub context**: Supplies PR titles, labels, descriptions, and contributor metadata to guide the agent
 - **Contributor attribution**: Includes PR numbers and author usernames for each change
 - **New contributor highlighting**: Identifies and celebrates first-time contributors
 - **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -17,6 +17,7 @@ Automates the generation of standardized release notes for OpenHands repositorie
 - **Structured GitHub context**: Supplies PR titles, labels, descriptions, and contributor metadata to guide the agent
 - **Contributor attribution**: Includes PR numbers and author usernames for each change
 - **Attribution validation**: Verifies every change bullet contains explicit PR/commit references and the matching author handles
+- **Full coverage appendix**: Appends a compact reference section when needed so every PR and author in the release range is still listed somewhere in the final markdown
 - **New contributor highlighting**: Identifies and celebrates first-time contributors
 - **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries
 

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: release-notes
+description: Generate consistent, well-structured release notes from git history. Triggered on release tags following semver patterns (v*.*.*) to produce categorized changelog with breaking changes, features, fixes, and contributor attribution.
+triggers:
+- /release-notes
+- /releasenotes
+---
+
+# Release Notes Generator Plugin
+
+Automates the generation of standardized release notes for OpenHands repositories. This plugin can be triggered via GitHub Actions on release tags matching semver patterns (e.g., `v*.*.*`) or manually invoked.
+
+## Features
+
+- **Automatic tag detection**: Finds the previous release tag to determine the commit range
+- **Categorized changes**: Groups commits into Breaking Changes, Features, Bug Fixes, Documentation, and Internal sections
+- **Contributor attribution**: Includes PR numbers and author usernames for each change
+- **New contributor highlighting**: Identifies and celebrates first-time contributors
+- **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries
+
+## Quick Start
+
+### As a GitHub Action
+
+Copy the workflow file to your repository:
+
+```bash
+mkdir -p .github/workflows
+curl -o .github/workflows/release-notes.yml \
+  https://raw.githubusercontent.com/OpenHands/extensions/main/plugins/release-notes/workflows/release-notes.yml
+```
+
+Configure required secrets (see the README for details).
+
+### Manual Invocation
+
+Use the `/release-notes` trigger in an OpenHands conversation to generate release notes for the current repository.
+
+## Release Notes Format
+
+Generated release notes follow this structure:
+
+```markdown
+## [v1.2.0] - 2026-03-06
+
+### ⚠️ Breaking Changes
+- Remove deprecated `--legacy` CLI flag (#456) @maintainer
+
+### ✨ New Features
+- Add support for Claude Sonnet 4.6 model (#445) @contributor1
+
+### 🐛 Bug Fixes
+- Fix WebSocket reconnection on network interruption (#451) @contributor3
+
+### 📚 Documentation
+- Update installation guide (#442) @contributor2
+
+### 👥 New Contributors
+- @contributor3 made their first contribution in #451
+
+**Full Changelog**: https://github.com/org/repo/compare/v1.1.0...v1.2.0
+```
+
+## Change Categorization
+
+Changes are categorized based on:
+
+1. **Conventional commit prefixes**: `feat:`, `fix:`, `docs:`, `chore:`, `BREAKING:`
+2. **PR labels**: `breaking-change`, `bug`, `enhancement`, `documentation`
+
+| Category | Commit Prefixes | PR Labels |
+|----------|-----------------|-----------|
+| Breaking Changes | `BREAKING:`, `!:` suffix | `breaking-change`, `breaking` |
+| Features | `feat:`, `feature:` | `enhancement`, `feature` |
+| Bug Fixes | `fix:`, `bugfix:` | `bug`, `bugfix` |
+| Documentation | `docs:` | `documentation`, `docs` |
+| Internal | `chore:`, `ci:`, `refactor:`, `test:` | `internal`, `chore`, `ci` |
+
+## Configuration
+
+See the [README](./README.md) for full configuration options and workflow setup instructions.

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -16,6 +16,7 @@ Automates the generation of standardized release notes for OpenHands repositorie
 - **Agent-based editing**: Lets the agent decide which changes matter and group related PRs into higher-signal summaries
 - **Structured GitHub context**: Supplies PR titles, labels, descriptions, and contributor metadata to guide the agent
 - **Contributor attribution**: Includes PR numbers and author usernames for each change
+- **Attribution validation**: Verifies every change bullet contains explicit PR/commit references and the matching author handles
 - **New contributor highlighting**: Identifies and celebrates first-time contributors
 - **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries
 

--- a/plugins/release-notes/SKILL.md
+++ b/plugins/release-notes/SKILL.md
@@ -13,12 +13,12 @@ Automates the generation of standardized release notes for OpenHands repositorie
 ## Features
 
 - **Automatic tag detection**: Finds the previous release tag to determine the commit range
-- **Agent-based editing**: Lets the agent decide which changes matter, open with a short conversational summary, and group related PRs into higher-signal summaries
+- **Agent-based editing**: Lets the agent decide which changes matter, open with a short conversational summary, and group related PRs into higher-signal summaries while keeping toolkit-maintainer-only details out of the main sections unless they are unusually significant
 - **Structured GitHub context**: Supplies PR titles, labels, descriptions, and contributor metadata to guide the agent
 - **Contributor attribution**: Includes PR numbers and author usernames for each change
 - **Attribution validation**: Verifies every change bullet contains explicit PR/commit references and the matching author handles
 - **Full coverage appendix**: Appends a compact `### 🔎 Small Fixes/Internal Changes` section grouped by author when needed so every PR and author in the release range is still listed somewhere in the final markdown
-- **New contributor highlighting**: Identifies and celebrates first-time contributors
+- **New contributor highlighting**: Identifies first-time human contributors from merged PR history and excludes bot accounts
 - **Flexible output**: Can update GitHub release notes or generate CHANGELOG.md entries
 
 ## Quick Start

--- a/plugins/release-notes/action.yml
+++ b/plugins/release-notes/action.yml
@@ -1,0 +1,91 @@
+---
+name: OpenHands Release Notes Generator
+description: Generate consistent, well-structured release notes from git history
+author: OpenHands
+
+branding:
+    icon: file-text
+    color: green
+
+inputs:
+    tag:
+        description: The release tag to generate notes for
+        required: true
+    previous-tag:
+        description: Override automatic detection of previous release tag
+        required: false
+        default: ''
+    include-internal:
+        description: Include internal/infrastructure changes in the release notes
+        required: false
+        default: 'false'
+    output-format:
+        description: "Output format: 'release' (GitHub release) or 'changelog' (CHANGELOG.md)"
+        required: false
+        default: release
+    github-token:
+        description: GitHub token for API access (required)
+        required: true
+
+outputs:
+    release-notes:
+        description: The generated release notes in markdown format
+        value: ${{ steps.generate.outputs.release_notes }}
+    previous-tag:
+        description: The detected or provided previous release tag
+        value: ${{ steps.generate.outputs.previous_tag }}
+    commit-count:
+        description: Number of commits included in the release
+        value: ${{ steps.generate.outputs.commit_count }}
+    contributor-count:
+        description: Number of unique contributors
+        value: ${{ steps.generate.outputs.contributor_count }}
+    new-contributor-count:
+        description: Number of first-time contributors
+        value: ${{ steps.generate.outputs.new_contributor_count }}
+
+runs:
+    using: composite
+    steps:
+        - name: Checkout extensions repository
+          uses: actions/checkout@v4
+          with:
+              repository: OpenHands/extensions
+              ref: main
+              path: extensions
+              sparse-checkout: plugins/release-notes
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+              python-version: '3.12'
+
+        - name: Install dependencies
+          shell: bash
+          run: |
+              pip install --quiet requests
+
+        - name: Generate release notes
+          id: generate
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              TAG: ${{ inputs.tag }}
+              PREVIOUS_TAG: ${{ inputs.previous-tag }}
+              INCLUDE_INTERNAL: ${{ inputs.include-internal }}
+              OUTPUT_FORMAT: ${{ inputs.output-format }}
+              REPO_NAME: ${{ github.repository }}
+          run: |
+              python extensions/plugins/release-notes/scripts/generate_release_notes.py
+
+        - name: Update GitHub release (if release format)
+          if: inputs.output-format == 'release'
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+          run: |
+              if [ -f release_notes.md ]; then
+                echo "Updating release notes for tag ${{ inputs.tag }}"
+                gh release edit "${{ inputs.tag }}" --notes-file release_notes.md || \
+                  echo "Note: Could not update release. Release may not exist yet."
+              fi

--- a/plugins/release-notes/action.yml
+++ b/plugins/release-notes/action.yml
@@ -60,11 +60,6 @@ runs:
           with:
               python-version: '3.12'
 
-        - name: Install dependencies
-          shell: bash
-          run: |
-              pip install --quiet requests
-
         - name: Generate release notes
           id: generate
           shell: bash

--- a/plugins/release-notes/action.yml
+++ b/plugins/release-notes/action.yml
@@ -1,6 +1,6 @@
 ---
 name: OpenHands Release Notes Generator
-description: Generate consistent, well-structured release notes from git history
+description: Generate agent-authored release notes from git history and PR context
 author: OpenHands
 
 branding:
@@ -23,6 +23,17 @@ inputs:
         description: "Output format: 'release' (GitHub release) or 'changelog' (CHANGELOG.md)"
         required: false
         default: release
+    llm-model:
+        description: LLM model to use for agent-based release note generation
+        required: false
+        default: anthropic/claude-sonnet-4-5-20250929
+    llm-base-url:
+        description: LLM base URL (optional, for custom LLM endpoints)
+        required: false
+        default: ''
+    llm-api-key:
+        description: LLM API key (required)
+        required: true
     github-token:
         description: GitHub token for API access (required)
         required: true
@@ -60,10 +71,18 @@ runs:
           with:
               python-version: '3.12'
 
+        - name: Install uv
+          uses: astral-sh/setup-uv@v6
+          with:
+              enable-cache: true
+
         - name: Generate release notes
           id: generate
           shell: bash
           env:
+              LLM_MODEL: ${{ inputs.llm-model }}
+              LLM_BASE_URL: ${{ inputs.llm-base-url }}
+              LLM_API_KEY: ${{ inputs.llm-api-key }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               TAG: ${{ inputs.tag }}
               PREVIOUS_TAG: ${{ inputs.previous-tag }}
@@ -71,7 +90,8 @@ runs:
               OUTPUT_FORMAT: ${{ inputs.output-format }}
               REPO_NAME: ${{ github.repository }}
           run: |
-              python extensions/plugins/release-notes/scripts/generate_release_notes.py
+              uv run --with openhands-sdk --with openhands-tools \
+                python extensions/plugins/release-notes/scripts/agent_script.py
 
         - name: Update GitHub release (if release format)
           if: inputs.output-format == 'release'

--- a/plugins/release-notes/action.yml
+++ b/plugins/release-notes/action.yml
@@ -93,6 +93,17 @@ runs:
               uv run --with openhands-sdk --with openhands-tools \
                 python extensions/plugins/release-notes/scripts/agent_script.py
 
+        - name: Validate PR and author attribution
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              TAG: ${{ inputs.tag }}
+              PREVIOUS_TAG: ${{ inputs.previous-tag }}
+              INCLUDE_INTERNAL: ${{ inputs.include-internal }}
+              REPO_NAME: ${{ github.repository }}
+          run: |
+              python extensions/plugins/release-notes/scripts/validate_release_notes.py
+
         - name: Update GitHub release (if release format)
           if: inputs.output-format == 'release'
           shell: bash

--- a/plugins/release-notes/scripts/agent_script.py
+++ b/plugins/release-notes/scripts/agent_script.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Generate release notes with an OpenHands agent.
+
+This script collects structured release metadata from GitHub, then asks an
+OpenHands agent to make editorial decisions about which changes matter, which
+PRs belong together, and how to phrase the final release notes.
+
+Environment Variables:
+    LLM_API_KEY: API key for the LLM (required)
+    LLM_MODEL: Language model to use
+    LLM_BASE_URL: Optional base URL for custom LLM endpoints
+    GITHUB_TOKEN: GitHub token for API access (required)
+    TAG: The release tag to generate notes for (required)
+    PREVIOUS_TAG: Override automatic detection of previous release (optional)
+    INCLUDE_INTERNAL: Include internal/infrastructure changes (default: false)
+    OUTPUT_FORMAT: Output format - 'release' or 'changelog' (default: release)
+    REPO_NAME: Repository name in format owner/repo (required)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from openhands.sdk import LLM, Agent, AgentContext, Conversation, get_logger
+from openhands.sdk.context.skills import load_project_skills
+from openhands.sdk.conversation import get_agent_final_response
+from openhands.tools.preset.default import get_default_condenser, get_default_tools
+
+script_dir = Path(__file__).parent
+sys.path.insert(0, str(script_dir))
+
+from generate_release_notes import Change, ReleaseNotes, generate_release_notes, set_github_output  # noqa: E402
+from prompt import format_prompt  # noqa: E402
+
+logger = get_logger(__name__)
+
+CATEGORY_ORDER = ["breaking", "features", "fixes", "docs", "internal", "other"]
+
+
+def _get_required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+def _get_bool_env(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() == "true"
+
+
+def validate_environment() -> dict[str, Any]:
+    """Validate required environment variables and return configuration."""
+    return {
+        "model": os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+        "base_url": os.getenv("LLM_BASE_URL", ""),
+        "api_key": _get_required_env("LLM_API_KEY"),
+        "github_token": _get_required_env("GITHUB_TOKEN"),
+        "tag": _get_required_env("TAG"),
+        "previous_tag": os.getenv("PREVIOUS_TAG") or None,
+        "include_internal": _get_bool_env("INCLUDE_INTERNAL", False),
+        "output_format": os.getenv("OUTPUT_FORMAT", "release"),
+        "repo_name": _get_required_env("REPO_NAME"),
+    }
+
+
+def create_agent(config: dict[str, Any]) -> Agent:
+    """Create and configure the release-notes agent."""
+    llm_config: dict[str, Any] = {
+        "model": config["model"],
+        "api_key": config["api_key"],
+        "usage_id": "release_notes_agent",
+        "drop_params": True,
+    }
+    if config["base_url"]:
+        llm_config["base_url"] = config["base_url"]
+
+    llm = LLM(**llm_config)
+
+    cwd = os.getcwd()
+    project_skills = load_project_skills(cwd)
+    logger.info(
+        "Loaded %s project skills: %s",
+        len(project_skills),
+        [skill.name for skill in project_skills],
+    )
+
+    agent_context = AgentContext(
+        load_public_skills=False,
+        skills=project_skills,
+    )
+
+    return Agent(
+        llm=llm,
+        tools=get_default_tools(enable_browser=False),
+        agent_context=agent_context,
+        system_prompt_kwargs={"cli_mode": True},
+        condenser=get_default_condenser(
+            llm=llm.model_copy(update={"usage_id": "release_notes_condenser"})
+        ),
+    )
+
+
+def _truncate(text: str, limit: int = 280) -> str:
+    compact = re.sub(r"\s+", " ", text or "").strip()
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1].rstrip() + "…"
+
+
+def _format_change_block(change: Change, repo_name: str) -> str:
+    pr_ref = f"#{change.pr_number}" if change.pr_number else change.sha[:7]
+    labels = ", ".join(change.pr_labels) if change.pr_labels else "none"
+    url = change.url or (
+        f"https://github.com/{repo_name}/pull/{change.pr_number}"
+        if change.pr_number
+        else f"https://github.com/{repo_name}/commit/{change.sha}"
+    )
+    body = _truncate(change.body, 400) or "No PR body provided"
+
+    return "\n".join(
+        [
+            f"- Ref: {pr_ref}",
+            f"  Title: {change.message}",
+            f"  Author: @{change.author}" if change.author else "  Author: unknown",
+            f"  Suggested category: {change.category}",
+            f"  Labels: {labels}",
+            f"  URL: {url}",
+            f"  Body: {body}",
+        ]
+    )
+
+
+def build_change_candidates(notes: ReleaseNotes) -> str:
+    """Build the structured candidate change list for the agent prompt."""
+    lines: list[str] = []
+    for category in CATEGORY_ORDER:
+        changes = notes.changes.get(category, [])
+        if not changes:
+            continue
+        lines.append(f"\nSuggested {category}:" )
+        for change in changes:
+            lines.append(_format_change_block(change, notes.repo_name))
+    return "\n".join(lines).strip()
+
+
+def build_new_contributors(notes: ReleaseNotes) -> str:
+    """Build the new-contributors section for the agent prompt."""
+    if not notes.new_contributors:
+        return "- None"
+
+    lines = []
+    for contributor in notes.new_contributors:
+        pr_text = f" in #{contributor.first_pr}" if contributor.first_pr else ""
+        lines.append(f"- @{contributor.username} made their first contribution{pr_text}")
+    return "\n".join(lines)
+
+
+def extract_markdown(text: str) -> str:
+    """Normalize the agent response into plain markdown."""
+    cleaned = text.strip()
+    fence_match = re.fullmatch(r"```(?:markdown)?\s*\n?(.*?)\n?```", cleaned, re.DOTALL)
+    if fence_match:
+        cleaned = fence_match.group(1).strip()
+    return cleaned
+
+
+def build_prompt(notes: ReleaseNotes, include_internal: bool, output_format: str) -> str:
+    """Build the prompt sent to the release-notes agent."""
+    return format_prompt(
+        repo_name=notes.repo_name,
+        tag=notes.tag,
+        previous_tag=notes.previous_tag,
+        date=notes.date,
+        commit_count=notes.commit_count,
+        include_internal=include_internal,
+        output_format=output_format,
+        full_changelog_url=(
+            f"https://github.com/{notes.repo_name}/compare/"
+            f"{notes.previous_tag}...{notes.tag}"
+        ),
+        change_candidates=build_change_candidates(notes),
+        new_contributors=build_new_contributors(notes),
+    )
+
+
+def run_generation(
+    agent: Agent,
+    prompt: str,
+    secrets: dict[str, str],
+) -> tuple[Conversation, str]:
+    """Run the agent and return the conversation plus generated markdown."""
+    conversation = Conversation(
+        agent=agent,
+        workspace=os.getcwd(),
+        secrets=secrets,
+    )
+
+    logger.info("Starting agent-based release note generation...")
+    conversation.send_message(prompt)
+    conversation.run()
+
+    response = get_agent_final_response(conversation.state.events)
+    if not response:
+        raise RuntimeError("Agent did not return release notes")
+
+    return conversation, extract_markdown(response)
+
+
+def log_cost_summary(conversation: Conversation) -> None:
+    """Print cost information for CI output."""
+    metrics = conversation.conversation_stats.get_combined_metrics()
+    print("\n=== Release Notes Cost Summary ===")
+    print(f"Total Cost: ${metrics.accumulated_cost:.6f}")
+    if metrics.accumulated_token_usage:
+        token_usage = metrics.accumulated_token_usage
+        print(f"Prompt Tokens: {token_usage.prompt_tokens}")
+        print(f"Completion Tokens: {token_usage.completion_tokens}")
+        if token_usage.cache_read_tokens > 0:
+            print(f"Cache Read Tokens: {token_usage.cache_read_tokens}")
+        if token_usage.cache_write_tokens > 0:
+            print(f"Cache Write Tokens: {token_usage.cache_write_tokens}")
+
+
+def main() -> None:
+    """Generate release notes with an agent and write outputs for GitHub Actions."""
+    config = validate_environment()
+
+    logger.info("Generating release notes for %s", config["repo_name"])
+    logger.info("Tag: %s", config["tag"])
+    logger.info("Previous tag: %s", config["previous_tag"] or "auto-detect")
+    logger.info("Include internal: %s", config["include_internal"])
+    logger.info("Output format: %s", config["output_format"])
+    logger.info("LLM model: %s", config["model"])
+
+    notes = generate_release_notes(
+        tag=config["tag"],
+        previous_tag=config["previous_tag"],
+        repo_name=config["repo_name"],
+        token=config["github_token"],
+        include_internal=config["include_internal"],
+    )
+
+    prompt = build_prompt(
+        notes=notes,
+        include_internal=config["include_internal"],
+        output_format=config["output_format"],
+    )
+
+    agent = create_agent(config)
+    conversation, markdown = run_generation(
+        agent=agent,
+        prompt=prompt,
+        secrets={
+            "LLM_API_KEY": config["api_key"],
+            "GITHUB_TOKEN": config["github_token"],
+        },
+    )
+
+    with open("release_notes.md", "w") as file:
+        file.write(markdown)
+
+    print("\n" + "=" * 60)
+    print("Generated Release Notes:")
+    print("=" * 60)
+    print(markdown)
+    print("=" * 60)
+
+    set_github_output("release_notes", markdown)
+    set_github_output("previous_tag", notes.previous_tag)
+    set_github_output("commit_count", str(notes.commit_count))
+    set_github_output("contributor_count", str(len(notes.contributors)))
+    set_github_output("new_contributor_count", str(len(notes.new_contributors)))
+
+    log_cost_summary(conversation)
+    logger.info("Release notes generated successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/release-notes/scripts/agent_script.py
+++ b/plugins/release-notes/scripts/agent_script.py
@@ -35,6 +35,7 @@ sys.path.insert(0, str(script_dir))
 
 from generate_release_notes import Change, ReleaseNotes, generate_release_notes, set_github_output  # noqa: E402
 from prompt import format_prompt  # noqa: E402
+from validate_release_notes import append_reference_coverage_appendix  # noqa: E402
 
 logger = get_logger(__name__)
 
@@ -261,6 +262,11 @@ def main() -> None:
             "LLM_API_KEY": config["api_key"],
             "GITHUB_TOKEN": config["github_token"],
         },
+    )
+    markdown = append_reference_coverage_appendix(
+        markdown,
+        notes,
+        include_internal=config["include_internal"],
     )
 
     with open("release_notes.md", "w") as file:

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -134,6 +134,8 @@ class Change:
     author: str
     pr_number: int | None = None
     pr_labels: list[str] = field(default_factory=list)
+    body: str = ""
+    url: str = ""
     category: str = "other"
 
     def to_markdown(self, repo_name: str) -> str:
@@ -441,11 +443,15 @@ def _process_commit(
     pr_number = None
     pr_labels: list[str] = []
     pr = get_pr_for_commit(repo_name, sha, token)
+    body = ""
+    url = ""
     if pr:
         pr_number = pr["number"]
         pr_labels = [label["name"] for label in pr.get("labels", [])]
         author = pr.get("user", {}).get("login", "") or author
         message = pr.get("title") or message
+        body = pr.get("body") or ""
+        url = pr.get("html_url") or ""
 
     return Change(
         message=message,
@@ -453,6 +459,8 @@ def _process_commit(
         author=author,
         pr_number=pr_number,
         pr_labels=pr_labels,
+        body=body,
+        url=url,
     )
 
 

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -136,6 +137,9 @@ class Change:
     pr_labels: list[str] = field(default_factory=list)
     body: str = ""
     url: str = ""
+    author_type: str = ""
+    pr_created_at: str = ""
+    pr_merged_at: str = ""
     category: str = "other"
 
     def to_markdown(self, repo_name: str) -> str:
@@ -380,20 +384,66 @@ def categorize_change(change: Change) -> str:
     return "other"
 
 
+def _parse_github_timestamp(timestamp: str) -> datetime:
+    """Parse a GitHub timestamp into a timezone-aware datetime."""
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def _is_bot_author(author: str, author_type: str = "") -> bool:
+    """Return True when the contributor is clearly a bot account."""
+    normalized_type = author_type.lower()
+    return normalized_type == "bot" or author.endswith("[bot]")
+
+
+def _search_merged_pull_requests_by_author(
+    repo_name: str, author: str, token: str
+) -> list[dict[str, Any]]:
+    """Return merged PRs in the repo authored by the given GitHub user."""
+    results: list[dict[str, Any]] = []
+    page = 1
+    query = f'repo:{repo_name} is:pr is:merged author:"{author}"'
+    encoded_query = urllib.parse.quote(query)
+
+    while True:
+        endpoint = (
+            f"/search/issues?q={encoded_query}&per_page=100&page={page}"
+            "&sort=created&order=asc"
+        )
+        response = github_api_request(endpoint, token)
+        items = response.get("items", [])
+        results.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+
+    return results
+
+
 def is_new_contributor(
-    author: str, repo_name: str, before_date: str, token: str
+    author: str,
+    repo_name: str,
+    before_timestamp: str,
+    token: str,
+    current_pr_number: int | None = None,
+    author_type: str = "",
 ) -> bool:
-    """Check if this is the author's first contribution to the repository."""
-    # Search for commits by this author before the given date
-    endpoint = (
-        f"/repos/{repo_name}/commits"
-        f"?author={author}&until={before_date}&per_page=1"
-    )
+    """Check whether a human author's earliest release PR is their first merged PR."""
+    if not author or _is_bot_author(author, author_type) or not before_timestamp:
+        return False
+
+    threshold = _parse_github_timestamp(before_timestamp)
+
     try:
-        commits = github_api_request(endpoint, token)
-        return len(commits) == 0
+        for pr in _search_merged_pull_requests_by_author(repo_name, author, token):
+            if current_pr_number and pr.get("number") == current_pr_number:
+                continue
+            closed_at = pr.get("closed_at")
+            if not closed_at:
+                continue
+            if _parse_github_timestamp(closed_at) < threshold:
+                return False
+        return True
     except Exception as e:
-        # Log but don't fail - contributor check is best-effort
         print(f"Warning: Could not check contributor history for {author}: {e}", file=sys.stderr)
         return False
 
@@ -445,13 +495,19 @@ def _process_commit(
     pr = get_pr_for_commit(repo_name, sha, token)
     body = ""
     url = ""
+    author_type = ""
+    pr_created_at = ""
+    pr_merged_at = ""
     if pr:
         pr_number = pr["number"]
         pr_labels = [label["name"] for label in pr.get("labels", [])]
         author = pr.get("user", {}).get("login", "") or author
+        author_type = pr.get("user", {}).get("type", "") or ""
         message = pr.get("title") or message
         body = pr.get("body") or ""
         url = pr.get("html_url") or ""
+        pr_created_at = pr.get("created_at") or ""
+        pr_merged_at = pr.get("merged_at") or ""
 
     return Change(
         message=message,
@@ -461,6 +517,9 @@ def _process_commit(
         pr_labels=pr_labels,
         body=body,
         url=url,
+        author_type=author_type,
+        pr_created_at=pr_created_at,
+        pr_merged_at=pr_merged_at,
     )
 
 
@@ -499,23 +558,54 @@ def _categorize_changes(
 def _process_contributors(
     changes_list: list[Change],
     repo_name: str,
-    tag_date: str,
     token: str,
 ) -> tuple[list[Contributor], list[Contributor]]:
-    """Extract contributors from changes and identify new contributors."""
+    """Extract contributors and identify first-time human PR contributors."""
     contributors: dict[str, Contributor] = {}
+    earliest_pr_by_author: dict[str, Change] = {}
     new_contributors: list[Contributor] = []
 
     for change in changes_list:
         author = change.author
-        if author and author not in contributors:
+        if not author:
+            continue
+
+        contrib = contributors.get(author)
+        if contrib is None:
             contrib = Contributor(username=author, first_pr=change.pr_number)
             contributors[author] = contrib
+        elif contrib.first_pr is None and change.pr_number:
+            contrib.first_pr = change.pr_number
 
-            # Check if new contributor
-            if is_new_contributor(author, repo_name, f"{tag_date}T00:00:00Z", token):
-                contrib.is_new = True
-                new_contributors.append(contrib)
+        if not change.pr_number:
+            continue
+
+        candidate_timestamp = change.pr_merged_at or change.pr_created_at
+        current = earliest_pr_by_author.get(author)
+        current_timestamp = (current.pr_merged_at or current.pr_created_at) if current else ""
+        if current is None or (
+            candidate_timestamp
+            and (not current_timestamp or candidate_timestamp < current_timestamp)
+        ):
+            earliest_pr_by_author[author] = change
+            contrib.first_pr = change.pr_number
+
+    for author, contrib in contributors.items():
+        first_pr_change = earliest_pr_by_author.get(author)
+        if not first_pr_change:
+            continue
+
+        first_pr_timestamp = first_pr_change.pr_merged_at or first_pr_change.pr_created_at
+        if is_new_contributor(
+            author,
+            repo_name,
+            first_pr_timestamp,
+            token,
+            current_pr_number=first_pr_change.pr_number,
+            author_type=first_pr_change.author_type,
+        ):
+            contrib.is_new = True
+            new_contributors.append(contrib)
 
     return list(contributors.values()), new_contributors
 
@@ -562,9 +652,7 @@ def generate_release_notes(
     categorized = _categorize_changes(changes)
 
     # Phase 4: Extract and identify contributors
-    contributors, new_contributors = _process_contributors(
-        changes, repo_name, tag_date, token
-    )
+    contributors, new_contributors = _process_contributors(changes, repo_name, token)
 
     return ReleaseNotes(
         tag=tag,

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -25,29 +25,42 @@ from datetime import datetime, timezone
 from typing import Any
 
 # Category definitions with emojis and patterns
+# Patterns match both conventional commit style (feat:, fix:) and bracket/paren style ([Feat]:, (Fix):)
 CATEGORIES = {
     "breaking": {
         "emoji": "⚠️",
         "title": "Breaking Changes",
-        "commit_patterns": [r"^BREAKING[\s\-:]", r"!:"],
+        "commit_patterns": [r"^BREAKING[\s\-:]", r"!:", r"^\[?BREAKING\]?[\s\-:]"],
         "labels": ["breaking-change", "breaking"],
     },
     "features": {
         "emoji": "✨",
         "title": "New Features",
-        "commit_patterns": [r"^feat(?:ure)?[\s\-:\(]"],
+        "commit_patterns": [
+            r"^feat(?:ure)?[\s\-:\(]",
+            r"^[\[\(]feat(?:ure)?[\]\)][\s\-:]*",  # [Feat]: or (Feat):
+        ],
         "labels": ["enhancement", "feature"],
     },
     "fixes": {
         "emoji": "🐛",
         "title": "Bug Fixes",
-        "commit_patterns": [r"^fix(?:es)?[\s\-:\(]", r"^bugfix[\s\-:\(]"],
+        "commit_patterns": [
+            r"^fix(?:es)?[\s\-:\(]",
+            r"^bugfix[\s\-:\(]",
+            r"^[\[\(]fix(?:es)?[\]\)][\s\-:]*",  # [Fix]: or (Fix):
+            r"^[\[\(]hotfix[\]\)][\s\-:]*",  # [Hotfix]: or (Hotfix):
+            r"^hotfix[\s\-:\(]",
+        ],
         "labels": ["bug", "bugfix"],
     },
     "docs": {
         "emoji": "📚",
         "title": "Documentation",
-        "commit_patterns": [r"^docs?[\s\-:\(]"],
+        "commit_patterns": [
+            r"^docs?[\s\-:\(]",
+            r"^[\[\(]docs?[\]\)][\s\-:]*",  # [Docs]: or (Docs):
+        ],
         "labels": ["documentation", "docs"],
     },
     "internal": {
@@ -61,6 +74,10 @@ CATEGORIES = {
             r"^build[\s\-:\(]",
             r"^style[\s\-:\(]",
             r"^perf[\s\-:\(]",
+            r"^[\[\(]chore[\]\)][\s\-:]*",  # [Chore]: or (Chore):
+            r"^[\[\(]ci[\]\)][\s\-:]*",
+            r"^[\[\(]refactor[\]\)][\s\-:]*",
+            r"^[\[\(]test[\]\)][\s\-:]*",
         ],
         "labels": ["internal", "chore", "ci", "dependencies"],
     },
@@ -81,10 +98,15 @@ class Change:
     def to_markdown(self, repo_name: str) -> str:
         """Format the change as a markdown list item."""
         # Clean up the message - remove conventional commit prefix
-        # Only match actual prefixes with required colon and whitespace delimiter
+        # Supports multiple formats:
+        #   - feat: message, fix(scope): message, feat!: breaking
+        #   - [Feat]: message, (Fix): message, [Chore]: message
         msg = self.message.strip()
         for pattern in [
-            r"^(feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING)(\(.+?\))?:\s+",
+            # Standard conventional commit: feat:, fix(scope):, feat!:
+            r"^(feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING|hotfix)(\(.+?\))?!?:\s+",
+            # Bracket/paren style: [Feat]:, (Fix):, [Hotfix]:
+            r"^[\[\(](feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING|hotfix)[\]\)][\s\-:]+",
         ]:
             msg = re.sub(pattern, "", msg, flags=re.IGNORECASE)
         msg = msg.strip()
@@ -93,9 +115,11 @@ class Change:
         if msg:
             msg = msg[0].upper() + msg[1:]
 
-        # Add PR link if available
+        # Add PR link if available and not already in the message
         if self.pr_number:
-            msg += f" (#{self.pr_number})"
+            pr_ref = f"#{self.pr_number}"
+            if pr_ref not in msg:
+                msg += f" ({pr_ref})"
 
         # Add author
         if self.author:
@@ -281,8 +305,6 @@ def get_pr_for_commit(
 
 def categorize_change(change: Change) -> str:
     """Determine the category for a change based on commit message and PR labels."""
-    message_lower = change.message.lower()
-
     # Check each category
     for category, info in CATEGORIES.items():
         # Check commit message patterns

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -14,8 +14,6 @@ Environment Variables:
     REPO_NAME: Repository name in format owner/repo (required)
 """
 
-from __future__ import annotations
-
 import json
 import os
 import re
@@ -83,9 +81,10 @@ class Change:
     def to_markdown(self, repo_name: str) -> str:
         """Format the change as a markdown list item."""
         # Clean up the message - remove conventional commit prefix
+        # Only match actual prefixes with required colon and whitespace delimiter
         msg = self.message.strip()
         for pattern in [
-            r"^(feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING)(\(.+?\))?[:\s]+",
+            r"^(feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING)(\(.+?\))?:\s+",
         ]:
             msg = re.sub(pattern, "", msg, flags=re.IGNORECASE)
         msg = msg.strip()
@@ -230,8 +229,8 @@ def find_previous_tag(
     current_tag: str, tags: list[dict[str, Any]]
 ) -> str | None:
     """Find the previous release tag before the current one."""
-    # Filter to only semver tags
-    semver_pattern = re.compile(r"^v?\d+\.\d+\.\d+")
+    # Filter to only semver tags (with optional pre-release/build metadata)
+    semver_pattern = re.compile(r"^v?\d+\.\d+\.\d+(?:[.-].*)?$")
     semver_tags = [t for t in tags if semver_pattern.match(t["name"])]
 
     # Find current tag index
@@ -274,8 +273,9 @@ def get_pr_for_commit(
                     return pr
             # If no merged PR, return the first one
             return prs[0]
-    except Exception:
-        pass
+    except Exception as e:
+        # Log but don't fail - PR data is optional
+        print(f"Warning: Could not fetch PR for commit {sha[:7]}: {e}", file=sys.stderr)
     return None
 
 
@@ -310,7 +310,9 @@ def is_new_contributor(
     try:
         commits = github_api_request(endpoint, token)
         return len(commits) == 0
-    except Exception:
+    except Exception as e:
+        # Log but don't fail - contributor check is best-effort
+        print(f"Warning: Could not check contributor history for {author}: {e}", file=sys.stderr)
         return False
 
 
@@ -337,8 +339,83 @@ def get_tag_date(repo_name: str, tag: str, token: str) -> str:
         # Parse and format the date
         dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
         return dt.strftime("%Y-%m-%d")
-    except Exception:
+    except Exception as e:
+        # Log but fall back to current date
+        print(f"Warning: Could not get tag date for {tag}: {e}", file=sys.stderr)
         return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _process_commit(
+    commit_data: dict[str, Any], repo_name: str, token: str
+) -> Change | None:
+    """Process a single commit into a Change object."""
+    sha = commit_data["sha"]
+    message = commit_data["commit"]["message"].split("\n")[0]  # First line only
+    author = commit_data.get("author", {}).get("login", "")
+
+    # Skip merge commits
+    if message.lower().startswith("merge "):
+        return None
+
+    # Get PR info
+    pr_number = None
+    pr_labels: list[str] = []
+    pr = get_pr_for_commit(repo_name, sha, token)
+    if pr:
+        pr_number = pr["number"]
+        pr_labels = [label["name"] for label in pr.get("labels", [])]
+        # Use PR author if commit author not available
+        if not author:
+            author = pr.get("user", {}).get("login", "")
+
+    return Change(
+        message=message,
+        sha=sha,
+        author=author,
+        pr_number=pr_number,
+        pr_labels=pr_labels,
+    )
+
+
+def _categorize_changes(
+    changes_list: list[Change],
+) -> dict[str, list[Change]]:
+    """Categorize a list of changes by type."""
+    categorized: dict[str, list[Change]] = {cat: [] for cat in CATEGORIES}
+    categorized["other"] = []
+
+    for change in changes_list:
+        change.category = categorize_change(change)
+        if change.category in categorized:
+            categorized[change.category].append(change)
+        else:
+            categorized["other"].append(change)
+
+    return categorized
+
+
+def _process_contributors(
+    changes_list: list[Change],
+    repo_name: str,
+    tag_date: str,
+    token: str,
+) -> tuple[list[Contributor], list[Contributor]]:
+    """Extract contributors from changes and identify new contributors."""
+    contributors: dict[str, Contributor] = {}
+    new_contributors: list[Contributor] = []
+
+    for change in changes_list:
+        author = change.author
+        if author and author not in contributors:
+            contrib = Contributor(username=author, first_pr=change.pr_number)
+            contributors[author] = contrib
+
+            # Check if new contributor
+            if is_new_contributor(author, repo_name, f"{tag_date}T00:00:00Z", token):
+                contrib.is_new = True
+                new_contributors.append(contrib)
+
+    return list(contributors.values()), new_contributors
 
 
 def generate_release_notes(
@@ -369,67 +446,28 @@ def generate_release_notes(
     commits = get_commits_between_tags(repo_name, previous_tag, tag, token)
     print(f"Found {len(commits)} commits")
 
-    # Process commits into changes
-    changes: dict[str, list[Change]] = {cat: [] for cat in CATEGORIES}
-    changes["other"] = []
-    contributors: dict[str, Contributor] = {}
-    new_contributors: list[Contributor] = []
+    # Phase 1: Process commits into Change objects
+    raw_changes = [
+        change
+        for c in commits
+        if (change := _process_commit(c, repo_name, token)) is not None
+    ]
 
-    for commit_data in commits:
-        sha = commit_data["sha"]
-        message = commit_data["commit"]["message"].split("\n")[0]  # First line only
-        author = commit_data.get("author", {}).get("login", "")
+    # Phase 2: Categorize changes
+    categorized = _categorize_changes(raw_changes)
 
-        # Skip merge commits
-        if message.lower().startswith("merge "):
-            continue
-
-        # Get PR info
-        pr_number = None
-        pr_labels: list[str] = []
-        pr = get_pr_for_commit(repo_name, sha, token)
-        if pr:
-            pr_number = pr["number"]
-            pr_labels = [label["name"] for label in pr.get("labels", [])]
-            # Use PR author if commit author not available
-            if not author:
-                author = pr.get("user", {}).get("login", "")
-
-        # Create change object
-        change = Change(
-            message=message,
-            sha=sha,
-            author=author,
-            pr_number=pr_number,
-            pr_labels=pr_labels,
-        )
-
-        # Categorize
-        change.category = categorize_change(change)
-
-        # Add to appropriate category
-        if change.category in changes:
-            changes[change.category].append(change)
-        else:
-            changes["other"].append(change)
-
-        # Track contributor
-        if author and author not in contributors:
-            contrib = Contributor(username=author, first_pr=pr_number)
-            contributors[author] = contrib
-
-            # Check if new contributor
-            if is_new_contributor(author, repo_name, f"{tag_date}T00:00:00Z", token):
-                contrib.is_new = True
-                new_contributors.append(contrib)
+    # Phase 3: Extract and identify contributors
+    contributors, new_contributors = _process_contributors(
+        raw_changes, repo_name, tag_date, token
+    )
 
     return ReleaseNotes(
         tag=tag,
         previous_tag=previous_tag,
         date=tag_date,
         repo_name=repo_name,
-        changes=changes,
-        contributors=list(contributors.values()),
+        changes=categorized,
+        contributors=contributors,
         new_contributors=new_contributors,
     )
 

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -83,6 +83,47 @@ CATEGORIES = {
     },
 }
 
+KEYWORD_PATTERNS = {
+    "docs": [
+        r"\bdocs?\b",
+        r"\bdocumentation\b",
+        r"\breadme\b",
+        r"\bchangelog\b",
+        r"\bguide\b",
+        r"\bopenapi\b",
+    ],
+    "internal": [
+        r"\bci\b",
+        r"\blint\b",
+        r"\btyping\b",
+        r"\brefactor\b",
+        r"\bdebug\b",
+        r"\bpre-commit\b",
+        r"\bdockerfile\b",
+        r"\bdependencies?\b",
+        r"\brelease\b",
+        r"\btool descriptions?\b",
+        r"\bmicroagents?\b",
+    ],
+    "fixes": [
+        r"\bfix(?:es|ed)?\b",
+        r"\bbug\b",
+        r"\berror\b",
+        r"\bfail(?:ed|ing)?\b",
+        r"\bissue\b",
+        r"\bcrash\b",
+        r"\btimeout\b",
+        r"\bleak\b",
+        r"\bmissing\b",
+        r"\berroneous\b",
+        r"\breconnect\b",
+        r"\breset\b",
+    ],
+    "features": [
+        r"^(add|allow|support|enable|implement|introduce|create|provide|improve)\b",
+    ],
+}
+
 
 @dataclass
 class Change:
@@ -145,6 +186,7 @@ class ReleaseNotes:
     previous_tag: str
     date: str
     repo_name: str
+    commit_count: int = 0
     changes: dict[str, list[Change]] = field(default_factory=dict)
     contributors: list[Contributor] = field(default_factory=list)
     new_contributors: list[Contributor] = field(default_factory=list)
@@ -168,14 +210,6 @@ class ReleaseNotes:
                     lines.append(change.to_markdown(self.repo_name))
                 lines.append("")
 
-        # Add uncategorized changes if any
-        other_changes = self.changes.get("other", [])
-        if other_changes:
-            lines.append("### Other Changes")
-            for change in other_changes:
-                lines.append(change.to_markdown(self.repo_name))
-            lines.append("")
-
         # Add new contributors section
         if self.new_contributors:
             lines.append("### 👥 New Contributors")
@@ -185,7 +219,6 @@ class ReleaseNotes:
             lines.append("")
 
         # Add full changelog link
-        owner, repo = self.repo_name.split("/")
         lines.append(
             f"**Full Changelog**: https://github.com/{self.repo_name}/compare/"
             f"{self.previous_tag}...{self.tag}"
@@ -280,7 +313,17 @@ def get_commits_between_tags(
     """Get all commits between two tags."""
     endpoint = f"/repos/{repo_name}/compare/{base_tag}...{head_tag}"
     response = github_api_request(endpoint, token)
-    return response.get("commits", [])
+    commits = response.get("commits", [])
+
+    total_commits = response.get("total_commits")
+    if isinstance(total_commits, int) and total_commits > len(commits):
+        print(
+            "Warning: GitHub compare API truncated the commit list; "
+            "release notes may be incomplete.",
+            file=sys.stderr,
+        )
+
+    return commits
 
 
 def get_pr_for_commit(
@@ -303,19 +346,34 @@ def get_pr_for_commit(
     return None
 
 
+def _matches_any_pattern(text: str, patterns: list[str]) -> bool:
+    """Return True if the text matches any of the provided regex patterns."""
+    return any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns)
+
+
 def categorize_change(change: Change) -> str:
     """Determine the category for a change based on commit message and PR labels."""
-    # Check each category
+    # Exact matches first: conventional commit prefixes are the strongest signal.
     for category, info in CATEGORIES.items():
-        # Check commit message patterns
-        for pattern in info["commit_patterns"]:
-            if re.search(pattern, change.message, re.IGNORECASE):
-                return category
+        if _matches_any_pattern(change.message, info["commit_patterns"]):
+            return category
 
-        # Check PR labels
-        for label in change.pr_labels:
-            if label.lower() in [l.lower() for l in info["labels"]]:
-                return category
+    # Strong keyword matches help suppress noisy internal-only PRs even when a
+    # repository applies broad labels like `bug` or `enhancement`.
+    for category in ["docs", "internal"]:
+        if _matches_any_pattern(change.message, KEYWORD_PATTERNS[category]):
+            return category
+
+    label_names = [label.lower() for label in change.pr_labels]
+    for category, info in CATEGORIES.items():
+        if any(label.lower() in label_names for label in info["labels"]):
+            return category
+
+    # Fallback heuristics make PR-title based release notes more useful while
+    # still preferring user-facing categories over noisy implementation details.
+    for category in ["fixes", "features"]:
+        if _matches_any_pattern(change.message, KEYWORD_PATTERNS[category]):
+            return category
 
     return "other"
 
@@ -386,9 +444,8 @@ def _process_commit(
     if pr:
         pr_number = pr["number"]
         pr_labels = [label["name"] for label in pr.get("labels", [])]
-        # Use PR author if commit author not available
-        if not author:
-            author = pr.get("user", {}).get("login", "")
+        author = pr.get("user", {}).get("login", "") or author
+        message = pr.get("title") or message
 
     return Change(
         message=message,
@@ -397,6 +454,21 @@ def _process_commit(
         pr_number=pr_number,
         pr_labels=pr_labels,
     )
+
+
+def _dedupe_changes(changes_list: list[Change]) -> list[Change]:
+    """Collapse multiple commits from the same PR into one release-note entry."""
+    deduped: list[Change] = []
+    seen_keys: set[str] = set()
+
+    for change in changes_list:
+        key = f"pr:{change.pr_number}" if change.pr_number else f"sha:{change.sha}"
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped.append(change)
+
+    return deduped
 
 
 def _categorize_changes(
@@ -475,12 +547,15 @@ def generate_release_notes(
         if (change := _process_commit(c, repo_name, token)) is not None
     ]
 
-    # Phase 2: Categorize changes
-    categorized = _categorize_changes(raw_changes)
+    # Phase 2: Collapse multiple commits from the same PR into a single entry.
+    changes = _dedupe_changes(raw_changes)
 
-    # Phase 3: Extract and identify contributors
+    # Phase 3: Categorize changes
+    categorized = _categorize_changes(changes)
+
+    # Phase 4: Extract and identify contributors
     contributors, new_contributors = _process_contributors(
-        raw_changes, repo_name, tag_date, token
+        changes, repo_name, tag_date, token
     )
 
     return ReleaseNotes(
@@ -488,6 +563,7 @@ def generate_release_notes(
         previous_tag=previous_tag,
         date=tag_date,
         repo_name=repo_name,
+        commit_count=len(commits),
         changes=categorized,
         contributors=contributors,
         new_contributors=new_contributors,
@@ -501,7 +577,7 @@ def set_github_output(name: str, value: str) -> None:
         with open(output_file, "a") as f:
             # Handle multiline values
             if "\n" in value:
-                delimiter = "EOF"
+                delimiter = f"EOF_{os.urandom(4).hex()}"
                 f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
             else:
                 f.write(f"{name}={value}\n")
@@ -550,7 +626,7 @@ def main():
     # Set GitHub Actions outputs
     set_github_output("release_notes", markdown)
     set_github_output("previous_tag", notes.previous_tag)
-    set_github_output("commit_count", str(sum(len(c) for c in notes.changes.values())))
+    set_github_output("commit_count", str(notes.commit_count))
     set_github_output("contributor_count", str(len(notes.contributors)))
     set_github_output("new_contributor_count", str(len(notes.new_contributors)))
 

--- a/plugins/release-notes/scripts/generate_release_notes.py
+++ b/plugins/release-notes/scripts/generate_release_notes.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""
+Release Notes Generator
+
+Generates consistent, well-structured release notes from git history.
+Categorizes changes based on conventional commit prefixes and PR labels.
+
+Environment Variables:
+    GITHUB_TOKEN: GitHub token for API access (required)
+    TAG: The release tag to generate notes for (required)
+    PREVIOUS_TAG: Override automatic detection of previous release (optional)
+    INCLUDE_INTERNAL: Include internal/infrastructure changes (default: false)
+    OUTPUT_FORMAT: Output format - 'release' or 'changelog' (default: release)
+    REPO_NAME: Repository name in format owner/repo (required)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# Category definitions with emojis and patterns
+CATEGORIES = {
+    "breaking": {
+        "emoji": "⚠️",
+        "title": "Breaking Changes",
+        "commit_patterns": [r"^BREAKING[\s\-:]", r"!:"],
+        "labels": ["breaking-change", "breaking"],
+    },
+    "features": {
+        "emoji": "✨",
+        "title": "New Features",
+        "commit_patterns": [r"^feat(?:ure)?[\s\-:\(]"],
+        "labels": ["enhancement", "feature"],
+    },
+    "fixes": {
+        "emoji": "🐛",
+        "title": "Bug Fixes",
+        "commit_patterns": [r"^fix(?:es)?[\s\-:\(]", r"^bugfix[\s\-:\(]"],
+        "labels": ["bug", "bugfix"],
+    },
+    "docs": {
+        "emoji": "📚",
+        "title": "Documentation",
+        "commit_patterns": [r"^docs?[\s\-:\(]"],
+        "labels": ["documentation", "docs"],
+    },
+    "internal": {
+        "emoji": "🏗️",
+        "title": "Internal/Infrastructure",
+        "commit_patterns": [
+            r"^chore[\s\-:\(]",
+            r"^ci[\s\-:\(]",
+            r"^refactor[\s\-:\(]",
+            r"^test[\s\-:\(]",
+            r"^build[\s\-:\(]",
+            r"^style[\s\-:\(]",
+            r"^perf[\s\-:\(]",
+        ],
+        "labels": ["internal", "chore", "ci", "dependencies"],
+    },
+}
+
+
+@dataclass
+class Change:
+    """Represents a single change/commit in the release."""
+
+    message: str
+    sha: str
+    author: str
+    pr_number: int | None = None
+    pr_labels: list[str] = field(default_factory=list)
+    category: str = "other"
+
+    def to_markdown(self, repo_name: str) -> str:
+        """Format the change as a markdown list item."""
+        # Clean up the message - remove conventional commit prefix
+        msg = self.message.strip()
+        for pattern in [
+            r"^(feat|fix|docs?|chore|ci|refactor|test|build|style|perf|BREAKING)(\(.+?\))?[:\s]+",
+        ]:
+            msg = re.sub(pattern, "", msg, flags=re.IGNORECASE)
+        msg = msg.strip()
+
+        # Capitalize first letter
+        if msg:
+            msg = msg[0].upper() + msg[1:]
+
+        # Add PR link if available
+        if self.pr_number:
+            msg += f" (#{self.pr_number})"
+
+        # Add author
+        if self.author:
+            msg += f" @{self.author}"
+
+        return f"- {msg}"
+
+
+@dataclass
+class Contributor:
+    """Represents a contributor to the release."""
+
+    username: str
+    first_pr: int | None = None
+    is_new: bool = False
+
+
+@dataclass
+class ReleaseNotes:
+    """Holds all data needed to generate release notes."""
+
+    tag: str
+    previous_tag: str
+    date: str
+    repo_name: str
+    changes: dict[str, list[Change]] = field(default_factory=dict)
+    contributors: list[Contributor] = field(default_factory=list)
+    new_contributors: list[Contributor] = field(default_factory=list)
+
+    def to_markdown(self, include_internal: bool = False) -> str:
+        """Generate the full release notes markdown."""
+        lines = [f"## [{self.tag}] - {self.date}", ""]
+
+        # Order of categories to display
+        category_order = ["breaking", "features", "fixes", "docs"]
+        if include_internal:
+            category_order.append("internal")
+
+        # Add categorized changes
+        for category in category_order:
+            changes = self.changes.get(category, [])
+            if changes:
+                cat_info = CATEGORIES[category]
+                lines.append(f"### {cat_info['emoji']} {cat_info['title']}")
+                for change in changes:
+                    lines.append(change.to_markdown(self.repo_name))
+                lines.append("")
+
+        # Add uncategorized changes if any
+        other_changes = self.changes.get("other", [])
+        if other_changes:
+            lines.append("### Other Changes")
+            for change in other_changes:
+                lines.append(change.to_markdown(self.repo_name))
+            lines.append("")
+
+        # Add new contributors section
+        if self.new_contributors:
+            lines.append("### 👥 New Contributors")
+            for contrib in self.new_contributors:
+                pr_text = f" in #{contrib.first_pr}" if contrib.first_pr else ""
+                lines.append(f"- @{contrib.username} made their first contribution{pr_text}")
+            lines.append("")
+
+        # Add full changelog link
+        owner, repo = self.repo_name.split("/")
+        lines.append(
+            f"**Full Changelog**: https://github.com/{self.repo_name}/compare/"
+            f"{self.previous_tag}...{self.tag}"
+        )
+
+        return "\n".join(lines)
+
+
+def get_env(name: str, default: str | None = None, required: bool = False) -> str:
+    """Get an environment variable."""
+    value = os.getenv(name, default)
+    if required and not value:
+        print(f"Error: {name} environment variable is required")
+        sys.exit(1)
+    return value or ""
+
+
+def github_api_request(
+    endpoint: str,
+    token: str,
+    method: str = "GET",
+    data: dict[str, Any] | None = None,
+) -> Any:
+    """Make a request to the GitHub API."""
+    url = f"https://api.github.com{endpoint}"
+    request = urllib.request.Request(url, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+
+    if data:
+        request.add_header("Content-Type", "application/json")
+        request.data = json.dumps(data).encode("utf-8")
+
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        details = (e.read() or b"").decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"GitHub API request failed: HTTP {e.code} {e.reason}. {details}"
+        ) from e
+
+
+def get_tags(repo_name: str, token: str) -> list[dict[str, Any]]:
+    """Get all tags from the repository, sorted by creation date."""
+    tags = []
+    page = 1
+    per_page = 100
+
+    while True:
+        endpoint = f"/repos/{repo_name}/tags?per_page={per_page}&page={page}"
+        page_tags = github_api_request(endpoint, token)
+        if not page_tags:
+            break
+        tags.extend(page_tags)
+        if len(page_tags) < per_page:
+            break
+        page += 1
+
+    return tags
+
+
+def find_previous_tag(
+    current_tag: str, tags: list[dict[str, Any]]
+) -> str | None:
+    """Find the previous release tag before the current one."""
+    # Filter to only semver tags
+    semver_pattern = re.compile(r"^v?\d+\.\d+\.\d+")
+    semver_tags = [t for t in tags if semver_pattern.match(t["name"])]
+
+    # Find current tag index
+    current_idx = None
+    for i, tag in enumerate(semver_tags):
+        if tag["name"] == current_tag:
+            current_idx = i
+            break
+
+    if current_idx is None:
+        return None
+
+    # Return the next tag (which is the previous release since tags are sorted newest first)
+    if current_idx + 1 < len(semver_tags):
+        return semver_tags[current_idx + 1]["name"]
+
+    return None
+
+
+def get_commits_between_tags(
+    repo_name: str, base_tag: str, head_tag: str, token: str
+) -> list[dict[str, Any]]:
+    """Get all commits between two tags."""
+    endpoint = f"/repos/{repo_name}/compare/{base_tag}...{head_tag}"
+    response = github_api_request(endpoint, token)
+    return response.get("commits", [])
+
+
+def get_pr_for_commit(
+    repo_name: str, sha: str, token: str
+) -> dict[str, Any] | None:
+    """Get the PR associated with a commit (if any)."""
+    endpoint = f"/repos/{repo_name}/commits/{sha}/pulls"
+    try:
+        prs = github_api_request(endpoint, token)
+        if prs:
+            # Return the first merged PR
+            for pr in prs:
+                if pr.get("merged_at"):
+                    return pr
+            # If no merged PR, return the first one
+            return prs[0]
+    except Exception:
+        pass
+    return None
+
+
+def categorize_change(change: Change) -> str:
+    """Determine the category for a change based on commit message and PR labels."""
+    message_lower = change.message.lower()
+
+    # Check each category
+    for category, info in CATEGORIES.items():
+        # Check commit message patterns
+        for pattern in info["commit_patterns"]:
+            if re.search(pattern, change.message, re.IGNORECASE):
+                return category
+
+        # Check PR labels
+        for label in change.pr_labels:
+            if label.lower() in [l.lower() for l in info["labels"]]:
+                return category
+
+    return "other"
+
+
+def is_new_contributor(
+    author: str, repo_name: str, before_date: str, token: str
+) -> bool:
+    """Check if this is the author's first contribution to the repository."""
+    # Search for commits by this author before the given date
+    endpoint = (
+        f"/repos/{repo_name}/commits"
+        f"?author={author}&until={before_date}&per_page=1"
+    )
+    try:
+        commits = github_api_request(endpoint, token)
+        return len(commits) == 0
+    except Exception:
+        return False
+
+
+def get_tag_date(repo_name: str, tag: str, token: str) -> str:
+    """Get the date when a tag was created."""
+    endpoint = f"/repos/{repo_name}/git/refs/tags/{tag}"
+    try:
+        ref = github_api_request(endpoint, token)
+        # Get the commit or tag object
+        obj_sha = ref["object"]["sha"]
+        obj_type = ref["object"]["type"]
+
+        if obj_type == "tag":
+            # Annotated tag - get the tag object
+            tag_endpoint = f"/repos/{repo_name}/git/tags/{obj_sha}"
+            tag_obj = github_api_request(tag_endpoint, token)
+            date_str = tag_obj["tagger"]["date"]
+        else:
+            # Lightweight tag - get the commit
+            commit_endpoint = f"/repos/{repo_name}/git/commits/{obj_sha}"
+            commit_obj = github_api_request(commit_endpoint, token)
+            date_str = commit_obj["committer"]["date"]
+
+        # Parse and format the date
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except Exception:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def generate_release_notes(
+    tag: str,
+    previous_tag: str | None,
+    repo_name: str,
+    token: str,
+    include_internal: bool = False,
+) -> ReleaseNotes:
+    """Generate release notes for the given tag."""
+    # Get all tags
+    tags = get_tags(repo_name, token)
+
+    # Find previous tag if not provided
+    if not previous_tag:
+        previous_tag = find_previous_tag(tag, tags)
+
+    if not previous_tag:
+        print(f"Warning: Could not find previous tag for {tag}")
+        previous_tag = tags[-1]["name"] if tags else "HEAD~100"
+
+    print(f"Generating release notes: {previous_tag} -> {tag}")
+
+    # Get tag date
+    tag_date = get_tag_date(repo_name, tag, token)
+
+    # Get commits between tags
+    commits = get_commits_between_tags(repo_name, previous_tag, tag, token)
+    print(f"Found {len(commits)} commits")
+
+    # Process commits into changes
+    changes: dict[str, list[Change]] = {cat: [] for cat in CATEGORIES}
+    changes["other"] = []
+    contributors: dict[str, Contributor] = {}
+    new_contributors: list[Contributor] = []
+
+    for commit_data in commits:
+        sha = commit_data["sha"]
+        message = commit_data["commit"]["message"].split("\n")[0]  # First line only
+        author = commit_data.get("author", {}).get("login", "")
+
+        # Skip merge commits
+        if message.lower().startswith("merge "):
+            continue
+
+        # Get PR info
+        pr_number = None
+        pr_labels: list[str] = []
+        pr = get_pr_for_commit(repo_name, sha, token)
+        if pr:
+            pr_number = pr["number"]
+            pr_labels = [label["name"] for label in pr.get("labels", [])]
+            # Use PR author if commit author not available
+            if not author:
+                author = pr.get("user", {}).get("login", "")
+
+        # Create change object
+        change = Change(
+            message=message,
+            sha=sha,
+            author=author,
+            pr_number=pr_number,
+            pr_labels=pr_labels,
+        )
+
+        # Categorize
+        change.category = categorize_change(change)
+
+        # Add to appropriate category
+        if change.category in changes:
+            changes[change.category].append(change)
+        else:
+            changes["other"].append(change)
+
+        # Track contributor
+        if author and author not in contributors:
+            contrib = Contributor(username=author, first_pr=pr_number)
+            contributors[author] = contrib
+
+            # Check if new contributor
+            if is_new_contributor(author, repo_name, f"{tag_date}T00:00:00Z", token):
+                contrib.is_new = True
+                new_contributors.append(contrib)
+
+    return ReleaseNotes(
+        tag=tag,
+        previous_tag=previous_tag,
+        date=tag_date,
+        repo_name=repo_name,
+        changes=changes,
+        contributors=list(contributors.values()),
+        new_contributors=new_contributors,
+    )
+
+
+def set_github_output(name: str, value: str) -> None:
+    """Set a GitHub Actions output variable."""
+    output_file = os.getenv("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            # Handle multiline values
+            if "\n" in value:
+                delimiter = "EOF"
+                f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
+            else:
+                f.write(f"{name}={value}\n")
+    else:
+        print(f"::set-output name={name}::{value}")
+
+
+def main():
+    """Main entry point."""
+    # Get configuration from environment
+    token = get_env("GITHUB_TOKEN", required=True)
+    tag = get_env("TAG", required=True)
+    previous_tag = get_env("PREVIOUS_TAG") or None
+    include_internal = get_env("INCLUDE_INTERNAL", "false").lower() == "true"
+    output_format = get_env("OUTPUT_FORMAT", "release")
+    repo_name = get_env("REPO_NAME", required=True)
+
+    print(f"Generating release notes for {repo_name}")
+    print(f"Tag: {tag}")
+    print(f"Previous tag: {previous_tag or 'auto-detect'}")
+    print(f"Include internal: {include_internal}")
+    print(f"Output format: {output_format}")
+
+    # Generate release notes
+    notes = generate_release_notes(
+        tag=tag,
+        previous_tag=previous_tag,
+        repo_name=repo_name,
+        token=token,
+        include_internal=include_internal,
+    )
+
+    # Generate markdown
+    markdown = notes.to_markdown(include_internal=include_internal)
+
+    # Write to file
+    with open("release_notes.md", "w") as f:
+        f.write(markdown)
+
+    print("\n" + "=" * 60)
+    print("Generated Release Notes:")
+    print("=" * 60)
+    print(markdown)
+    print("=" * 60)
+
+    # Set GitHub Actions outputs
+    set_github_output("release_notes", markdown)
+    set_github_output("previous_tag", notes.previous_tag)
+    set_github_output("commit_count", str(sum(len(c) for c in notes.changes.values())))
+    set_github_output("contributor_count", str(len(notes.contributors)))
+    set_github_output("new_contributor_count", str(len(notes.new_contributors)))
+
+    print("\nRelease notes generated successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/release-notes/scripts/prompt.py
+++ b/plugins/release-notes/scripts/prompt.py
@@ -13,7 +13,9 @@ Your job is editorial, not mechanical:
 - when `include_internal` is false, omit internal-only work unless it is important for users
 - use imperative mood
 - keep each bullet to one line
-- format bullet references as `(#123) @username`; if you group multiple PRs, include each reference explicitly, for example `(#123) @alice, (#124) @bob`
+- every change bullet must end with explicit references for each included item
+- format PR references as `(#123) @username`; if you group multiple PRs, include each reference explicitly, for example `(#123) @alice, (#124) @bob`
+- if you mention a standalone commit instead of a PR, format it as `(abc1234) @username`
 - include every new contributor listed below in the `### 👥 New Contributors` section
 - for breaking changes, briefly note the migration path when the provided context makes it clear
 

--- a/plugins/release-notes/scripts/prompt.py
+++ b/plugins/release-notes/scripts/prompt.py
@@ -15,6 +15,8 @@ Your job is editorial, not mechanical:
 - avoid maintainer-facing churn unless it materially changes how users adopt, run, or integrate the project
 - use `### 📚 Documentation` only for notable docs/reference/policy updates; public API additions still belong in `### ✨ New Features`
 - omit prompt wording, benchmark plumbing, workflow maintenance, and similar maintainer-only changes unless they materially alter observable user behavior
+- start with a short, conversational 1-2 sentence overview of the release before the categorized sections
+- if you add top-level highlight bullets, keep them to at most 3 and reserve them for the biggest user-facing changes
 - treat the suggested category as a hint, not a rule
 - when `include_internal` is false, omit internal-only work unless it is important for users
 - use imperative mood
@@ -29,6 +31,8 @@ Return markdown only. Do not wrap the result in a code fence.
 
 Required structure:
 - `## [{tag}] - {date}`
+- a short conversational overview paragraph immediately after the title
+- optional top-level highlight bullets (maximum 3) before the categorized sections
 - `### ⚠️ Breaking Changes` when applicable
 - `### ✨ New Features` when applicable
 - `### 🐛 Bug Fixes` when applicable

--- a/plugins/release-notes/scripts/prompt.py
+++ b/plugins/release-notes/scripts/prompt.py
@@ -1,0 +1,77 @@
+"""Prompt template for the release notes agent."""
+
+PROMPT = """Write official release notes for `{repo_name}` tag `{tag}`.
+
+Use the structured release data below as your primary source of truth. You may inspect the checked-out repository if it helps you judge significance or match release-note style, but do not ask follow-up questions.
+
+Your job is editorial, not mechanical:
+- decide which PRs are important enough to mention
+- group related PRs into a single bullet when they form one coherent feature or fix
+- omit trivial, repetitive, or low-signal changes from the final notes
+- prefer user impact over implementation detail
+- treat the suggested category as a hint, not a rule
+- when `include_internal` is false, omit internal-only work unless it is important for users
+- use imperative mood
+- keep each bullet to one line
+- format bullet references as `(#123) @username`; if you group multiple PRs, include each reference explicitly, for example `(#123) @alice, (#124) @bob`
+- include every new contributor listed below in the `### 👥 New Contributors` section
+- for breaking changes, briefly note the migration path when the provided context makes it clear
+
+Return markdown only. Do not wrap the result in a code fence.
+
+Required structure:
+- `## [{tag}] - {date}`
+- `### ⚠️ Breaking Changes` when applicable
+- `### ✨ New Features` when applicable
+- `### 🐛 Bug Fixes` when applicable
+- `### 📚 Documentation` only when notable
+- `### 🏗️ Internal/Infrastructure` only when `include_internal` is true and the changes are worth mentioning
+- `### 👥 New Contributors` when there are any
+- `**Full Changelog**: {full_changelog_url}` at the end
+
+Release metadata:
+- Repository: {repo_name}
+- Current tag: {tag}
+- Previous tag: {previous_tag}
+- Release date: {date}
+- Commits in range: {commit_count}
+- Include internal section: {include_internal}
+- Output format: {output_format}
+
+Candidate changes:
+{change_candidates}
+
+New contributors:
+{new_contributors}
+
+Full changelog URL:
+{full_changelog_url}
+"""
+
+
+def format_prompt(
+    *,
+    repo_name: str,
+    tag: str,
+    previous_tag: str,
+    date: str,
+    commit_count: int,
+    include_internal: bool,
+    output_format: str,
+    full_changelog_url: str,
+    change_candidates: str,
+    new_contributors: str,
+) -> str:
+    """Format the release-notes prompt."""
+    return PROMPT.format(
+        repo_name=repo_name,
+        tag=tag,
+        previous_tag=previous_tag,
+        date=date,
+        commit_count=commit_count,
+        include_internal=str(include_internal).lower(),
+        output_format=output_format,
+        full_changelog_url=full_changelog_url,
+        change_candidates=change_candidates,
+        new_contributors=new_contributors,
+    )

--- a/plugins/release-notes/scripts/prompt.py
+++ b/plugins/release-notes/scripts/prompt.py
@@ -7,8 +7,14 @@ Use the structured release data below as your primary source of truth. You may i
 Your job is editorial, not mechanical:
 - decide which PRs are important enough to mention
 - group related PRs into a single bullet when they form one coherent feature or fix
+- for larger releases, aggressively compress the notes into a shorter set of higher-signal bullets instead of listing one bullet per PR
+- if a section would have more than 5 bullets, merge same-theme items until the section is scannable
 - omit trivial, repetitive, or low-signal changes from the final notes
 - prefer user impact over implementation detail
+- prioritize public APIs, user-visible capabilities, security fixes, supported integrations/models, and operational changes users directly invoke
+- avoid maintainer-facing churn unless it materially changes how users adopt, run, or integrate the project
+- use `### 📚 Documentation` only for notable docs/reference/policy updates; public API additions still belong in `### ✨ New Features`
+- omit prompt wording, benchmark plumbing, workflow maintenance, and similar maintainer-only changes unless they materially alter observable user behavior
 - treat the suggested category as a hint, not a rule
 - when `include_internal` is false, omit internal-only work unless it is important for users
 - use imperative mood

--- a/plugins/release-notes/scripts/prompt.py
+++ b/plugins/release-notes/scripts/prompt.py
@@ -10,10 +10,11 @@ Your job is editorial, not mechanical:
 - for larger releases, aggressively compress the notes into a shorter set of higher-signal bullets instead of listing one bullet per PR
 - if a section would have more than 5 bullets, merge same-theme items until the section is scannable
 - omit trivial, repetitive, or low-signal changes from the final notes
-- prefer user impact over implementation detail
+- prefer end-user impact over implementation detail
 - prioritize public APIs, user-visible capabilities, security fixes, supported integrations/models, and operational changes users directly invoke
-- avoid maintainer-facing churn unless it materially changes how users adopt, run, or integrate the project
-- use `### 📚 Documentation` only for notable docs/reference/policy updates; public API additions still belong in `### ✨ New Features`
+- treat toolkit-maintainer or contributor-facing changes as secondary unless they materially change how end users or client developers adopt, run, or integrate the project
+- changes that mostly affect CI, internal prompts, benchmarks, workflow inputs, refactors, contributor ergonomics, or toolkit implementation details should stay in the small/internal appendix unless they are unusually significant
+- use `### 📚 Documentation` only for notable docs/reference/policy updates that matter to users or client developers; public API additions still belong in `### ✨ New Features`
 - omit prompt wording, benchmark plumbing, workflow maintenance, and similar maintainer-only changes unless they materially alter observable user behavior
 - start with a short, conversational 1-2 sentence overview of the release before the categorized sections
 - if you add top-level highlight bullets, keep them to at most 3 and reserve them for the biggest user-facing changes

--- a/plugins/release-notes/scripts/validate_release_notes.py
+++ b/plugins/release-notes/scripts/validate_release_notes.py
@@ -12,16 +12,8 @@ from generate_release_notes import CATEGORIES, ReleaseNotes, generate_release_no
 PR_REF_PATTERN = re.compile(r"#(\d+)\b")
 COMMIT_REF_PATTERN = re.compile(r"\(([0-9a-f]{7,40})\)")
 NEW_CONTRIBUTORS_HEADING = "### 👥 New Contributors"
-COVERAGE_HEADING = "### 🔎 Complete PR and Author Reference Coverage"
+COVERAGE_HEADING = "### 🔎 Small Fixes/Internal Changes"
 REFERENCE_CATEGORY_ORDER = ["breaking", "features", "fixes", "docs", "internal", "other"]
-REFERENCE_CATEGORY_LABELS = {
-    "breaking": "Breaking-change refs",
-    "features": "Feature/API refs",
-    "fixes": "Bug-fix refs",
-    "docs": "Documentation refs",
-    "internal": "Internal/infrastructure refs",
-    "other": "Additional refs",
-}
 
 
 @dataclass
@@ -40,7 +32,6 @@ class ValidationContext:
     """Parsed validation context for a single release note run."""
 
     reference_authors: dict[str, str]
-    reference_categories: dict[str, str]
     reference_order: list[str]
     change_section_headings: set[str]
 
@@ -68,7 +59,6 @@ def build_validation_context(
     del include_internal  # Coverage should include every candidate the release may cite.
 
     reference_authors: dict[str, str] = {}
-    reference_categories: dict[str, str] = {}
     reference_order: list[str] = []
     change_section_headings = {
         f"### {CATEGORIES[category]['emoji']} {CATEGORIES[category]['title']}"
@@ -81,12 +71,10 @@ def build_validation_context(
             if ref in reference_authors:
                 continue
             reference_authors[ref] = change.author
-            reference_categories[ref] = category
             reference_order.append(ref)
 
     return ValidationContext(
         reference_authors=reference_authors,
-        reference_categories=reference_categories,
         reference_order=reference_order,
         change_section_headings=change_section_headings,
     )
@@ -171,11 +159,14 @@ def missing_references(
     return [ref for ref in context.reference_order if ref not in scan.covered_refs]
 
 
+def _format_reference_token(ref: str) -> str:
+    return ref if ref.startswith("#") else f"({ref})"
+
+
 def append_reference_coverage_appendix(
     markdown: str,
     notes: ReleaseNotes,
     include_internal: bool = False,
-    chunk_size: int = 8,
 ) -> str:
     """Append a compact appendix covering any PRs/authors omitted by the agent."""
     context = build_validation_context(notes, include_internal=include_internal)
@@ -184,21 +175,18 @@ def append_reference_coverage_appendix(
     if not missing_refs:
         return markdown
 
-    grouped: dict[str, list[str]] = {category: [] for category in REFERENCE_CATEGORY_ORDER}
+    refs_by_author: dict[str, list[str]] = {}
+    author_order: list[str] = []
     for ref in missing_refs:
         author = context.reference_authors[ref]
-        formatted_ref = f"({ref}) @{author}" if not ref.startswith("#") else f"({ref}) @{author}"
-        grouped[context.reference_categories[ref]].append(formatted_ref)
+        if author not in refs_by_author:
+            refs_by_author[author] = []
+            author_order.append(author)
+        refs_by_author[author].append(_format_reference_token(ref))
 
     appendix_lines = [COVERAGE_HEADING]
-    for category in REFERENCE_CATEGORY_ORDER:
-        refs = grouped[category]
-        if not refs:
-            continue
-        label = REFERENCE_CATEGORY_LABELS[category]
-        for index in range(0, len(refs), chunk_size):
-            chunk = refs[index : index + chunk_size]
-            appendix_lines.append(f"- {label}: {', '.join(chunk)}")
+    for author in author_order:
+        appendix_lines.append(f"- @{author}: {', '.join(refs_by_author[author])}")
 
     base_lines = markdown.rstrip().splitlines()
     for index, line in enumerate(base_lines):

--- a/plugins/release-notes/scripts/validate_release_notes.py
+++ b/plugins/release-notes/scripts/validate_release_notes.py
@@ -40,17 +40,15 @@ def build_validation_context(
     notes: ReleaseNotes, include_internal: bool = False
 ) -> ValidationContext:
     """Build the reference and section metadata used for validation."""
-    enabled_categories = ["breaking", "features", "fixes", "docs"]
-    if include_internal:
-        enabled_categories.append("internal")
+    del include_internal  # Validation should cover every candidate the agent may cite.
 
     reference_authors: dict[str, str] = {}
     change_section_headings = {
         f"### {CATEGORIES[category]['emoji']} {CATEGORIES[category]['title']}"
-        for category in enabled_categories
+        for category in CATEGORIES
     }
 
-    for category in enabled_categories:
+    for category in list(CATEGORIES) + ["other"]:
         for change in notes.changes.get(category, []):
             if change.pr_number:
                 reference_authors[f"#{change.pr_number}"] = change.author

--- a/plugins/release-notes/scripts/validate_release_notes.py
+++ b/plugins/release-notes/scripts/validate_release_notes.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Validate attribution coverage in generated release notes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+
+from generate_release_notes import CATEGORIES, ReleaseNotes, generate_release_notes, get_env
+
+PR_REF_PATTERN = re.compile(r"#(\d+)\b")
+COMMIT_REF_PATTERN = re.compile(r"\(([0-9a-f]{7,40})\)")
+NEW_CONTRIBUTORS_HEADING = "### 👥 New Contributors"
+
+
+@dataclass
+class CoverageSummary:
+    """Summary of attribution coverage found in release notes."""
+
+    bullet_count: int
+    referenced_prs: list[int]
+    referenced_authors: list[str]
+    referenced_commits: list[str]
+
+
+@dataclass
+class ValidationContext:
+    """Parsed validation context for a single release note run."""
+
+    reference_authors: dict[str, str]
+    change_section_headings: set[str]
+
+
+class ReleaseNotesValidationError(ValueError):
+    """Raised when generated release notes violate attribution rules."""
+
+
+def build_validation_context(
+    notes: ReleaseNotes, include_internal: bool = False
+) -> ValidationContext:
+    """Build the reference and section metadata used for validation."""
+    enabled_categories = ["breaking", "features", "fixes", "docs"]
+    if include_internal:
+        enabled_categories.append("internal")
+
+    reference_authors: dict[str, str] = {}
+    change_section_headings = {
+        f"### {CATEGORIES[category]['emoji']} {CATEGORIES[category]['title']}"
+        for category in enabled_categories
+    }
+
+    for category in enabled_categories:
+        for change in notes.changes.get(category, []):
+            if change.pr_number:
+                reference_authors[f"#{change.pr_number}"] = change.author
+            else:
+                reference_authors[change.sha[:7].lower()] = change.author
+
+    return ValidationContext(
+        reference_authors=reference_authors,
+        change_section_headings=change_section_headings,
+    )
+
+
+def _extract_bullet_references(
+    bullet: str, reference_authors: dict[str, str]
+) -> list[str]:
+    refs = [f"#{match}" for match in PR_REF_PATTERN.findall(bullet)]
+
+    for match in COMMIT_REF_PATTERN.findall(bullet):
+        ref = match.lower()
+        if ref in reference_authors and ref not in refs:
+            refs.append(ref)
+
+    return refs
+
+
+def validate_release_notes_markdown(
+    markdown: str,
+    notes: ReleaseNotes,
+    include_internal: bool = False,
+) -> CoverageSummary:
+    """Validate that every included change lists explicit refs and authors."""
+    context = build_validation_context(notes, include_internal=include_internal)
+    errors: list[str] = []
+    current_heading = ""
+    bullet_count = 0
+    referenced_prs: set[int] = set()
+    referenced_authors: set[str] = set()
+    referenced_commits: set[str] = set()
+
+    for raw_line in markdown.splitlines():
+        line = raw_line.strip()
+        if line.startswith("### "):
+            current_heading = line
+            continue
+
+        if not line.startswith("- "):
+            continue
+
+        if current_heading == NEW_CONTRIBUTORS_HEADING:
+            continue
+
+        if current_heading not in context.change_section_headings:
+            continue
+
+        bullet_count += 1
+        refs = _extract_bullet_references(line, context.reference_authors)
+        if not refs:
+            errors.append(f"Bullet missing explicit PR/commit references: {line}")
+            continue
+
+        unknown_refs = [ref for ref in refs if ref not in context.reference_authors]
+        if unknown_refs:
+            errors.append(
+                f"Bullet references unknown PR/commit {', '.join(sorted(unknown_refs))}: {line}"
+            )
+            continue
+
+        for ref in refs:
+            author = context.reference_authors.get(ref, "")
+            if author and f"@{author}" not in line:
+                errors.append(f"Bullet mentioning {ref} is missing @{author}: {line}")
+                continue
+
+            if ref.startswith("#"):
+                referenced_prs.add(int(ref[1:]))
+            else:
+                referenced_commits.add(ref)
+
+            if author:
+                referenced_authors.add(author)
+
+    if errors:
+        raise ReleaseNotesValidationError("\n".join(errors))
+
+    return CoverageSummary(
+        bullet_count=bullet_count,
+        referenced_prs=sorted(referenced_prs),
+        referenced_authors=sorted(referenced_authors),
+        referenced_commits=sorted(referenced_commits),
+    )
+
+
+def format_coverage_summary(summary: CoverageSummary) -> str:
+    """Render a compact multi-line validation summary for logs and evidence."""
+    prs = ", ".join(f"#{pr}" for pr in summary.referenced_prs) or "none"
+    authors = ", ".join(f"@{author}" for author in summary.referenced_authors) or "none"
+    commits = ", ".join(summary.referenced_commits) or "none"
+    return "\n".join(
+        [
+            "Release notes attribution coverage validated.",
+            f"- Change bullets checked: {summary.bullet_count}",
+            f"- PRs referenced: {prs}",
+            f"- Authors referenced: {authors}",
+            f"- Standalone commits referenced: {commits}",
+        ]
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate PR and author attribution in generated release notes."
+    )
+    parser.add_argument(
+        "--markdown-file",
+        default="release_notes.md",
+        help="Path to the generated release notes markdown file.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Validate generated release notes using the same GitHub metadata inputs."""
+    args = parse_args()
+    token = get_env("GITHUB_TOKEN", required=True)
+    tag = get_env("TAG", required=True)
+    previous_tag = get_env("PREVIOUS_TAG") or None
+    include_internal = get_env("INCLUDE_INTERNAL", "false").lower() == "true"
+    repo_name = get_env("REPO_NAME", required=True)
+
+    notes = generate_release_notes(
+        tag=tag,
+        previous_tag=previous_tag,
+        repo_name=repo_name,
+        token=token,
+        include_internal=include_internal,
+    )
+
+    with open(args.markdown_file) as file:
+        markdown = file.read()
+
+    summary = validate_release_notes_markdown(
+        markdown,
+        notes,
+        include_internal=include_internal,
+    )
+    print(format_coverage_summary(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/release-notes/scripts/validate_release_notes.py
+++ b/plugins/release-notes/scripts/validate_release_notes.py
@@ -11,6 +11,7 @@ from generate_release_notes import CATEGORIES, ReleaseNotes, generate_release_no
 
 PR_REF_PATTERN = re.compile(r"#(\d+)\b")
 COMMIT_REF_PATTERN = re.compile(r"\(([0-9a-f]{7,40})\)")
+USER_HANDLE_PATTERN = re.compile(r"@([A-Za-z0-9][A-Za-z0-9_\-\[\]]*)")
 NEW_CONTRIBUTORS_HEADING = "### 👥 New Contributors"
 COVERAGE_HEADING = "### 🔎 Small Fixes/Internal Changes"
 REFERENCE_CATEGORY_ORDER = ["breaking", "features", "fixes", "docs", "internal", "other"]
@@ -34,6 +35,7 @@ class ValidationContext:
     reference_authors: dict[str, str]
     reference_order: list[str]
     change_section_headings: set[str]
+    expected_new_contributors: dict[str, int | None]
 
 
 class ReleaseNotesValidationError(ValueError):
@@ -48,6 +50,7 @@ class MentionScanResult:
     referenced_prs: set[int]
     referenced_authors: set[str]
     referenced_commits: set[str]
+    found_new_contributors: dict[str, int | None]
     bullet_count: int
     errors: list[str]
 
@@ -60,6 +63,9 @@ def build_validation_context(
 
     reference_authors: dict[str, str] = {}
     reference_order: list[str] = []
+    expected_new_contributors = {
+        contributor.username: contributor.first_pr for contributor in notes.new_contributors
+    }
     change_section_headings = {
         f"### {CATEGORIES[category]['emoji']} {CATEGORIES[category]['title']}"
         for category in CATEGORIES
@@ -77,6 +83,7 @@ def build_validation_context(
         reference_authors=reference_authors,
         reference_order=reference_order,
         change_section_headings=change_section_headings,
+        expected_new_contributors=expected_new_contributors,
     )
 
 
@@ -97,6 +104,7 @@ def _scan_reference_mentions(markdown: str, context: ValidationContext) -> Menti
     referenced_prs: set[int] = set()
     referenced_authors: set[str] = set()
     referenced_commits: set[str] = set()
+    found_new_contributors: dict[str, int | None] = {}
     errors: list[str] = []
     bullet_count = 0
 
@@ -119,6 +127,27 @@ def _scan_reference_mentions(markdown: str, context: ValidationContext) -> Menti
                 errors.append(f"Bullet missing explicit PR/commit references: {line}")
                 continue
 
+        if is_new_contributor_bullet:
+            usernames = USER_HANDLE_PATTERN.findall(line)
+            if len(usernames) != 1:
+                errors.append(
+                    "New contributor bullet must mention exactly one contributor handle: "
+                    f"{line}"
+                )
+            else:
+                username = usernames[0]
+                expected_first_pr = context.expected_new_contributors.get(username)
+                if username not in context.expected_new_contributors:
+                    errors.append(f"Unknown new contributor @{username}: {line}")
+                elif username in found_new_contributors:
+                    errors.append(f"Duplicate new contributor @{username}: {line}")
+                else:
+                    found_new_contributors[username] = expected_first_pr
+                    if expected_first_pr is not None and f"#{expected_first_pr}" not in refs:
+                        errors.append(
+                            f"New contributor @{username} must reference #{expected_first_pr}: {line}"
+                        )
+
         for ref in refs:
             author = context.reference_authors.get(ref)
             if not author:
@@ -135,14 +164,15 @@ def _scan_reference_mentions(markdown: str, context: ValidationContext) -> Menti
             else:
                 referenced_commits.add(ref)
 
-        if is_new_contributor_bullet and not refs:
-            continue
+        if is_new_contributor_bullet and not refs and context.expected_new_contributors:
+            errors.append(f"New contributor bullet missing PR reference: {line}")
 
     return MentionScanResult(
         covered_refs=covered_refs,
         referenced_prs=referenced_prs,
         referenced_authors=referenced_authors,
         referenced_commits=referenced_commits,
+        found_new_contributors=found_new_contributors,
         bullet_count=bullet_count,
         errors=errors,
     )
@@ -206,12 +236,22 @@ def validate_release_notes_markdown(
     context = build_validation_context(notes, include_internal=include_internal)
     scan = _scan_reference_mentions(markdown, context)
     missing_refs = [ref for ref in context.reference_order if ref not in scan.covered_refs]
+    missing_new_contributors = [
+        username
+        for username in context.expected_new_contributors
+        if username not in scan.found_new_contributors
+    ]
 
     errors = list(scan.errors)
     if missing_refs:
         errors.append(
             "Release notes are missing PR/commit coverage for: "
             + ", ".join(missing_refs)
+        )
+    if missing_new_contributors:
+        errors.append(
+            "Release notes are missing new contributor coverage for: "
+            + ", ".join(f"@{username}" for username in missing_new_contributors)
         )
 
     if errors:

--- a/plugins/release-notes/scripts/validate_release_notes.py
+++ b/plugins/release-notes/scripts/validate_release_notes.py
@@ -12,6 +12,16 @@ from generate_release_notes import CATEGORIES, ReleaseNotes, generate_release_no
 PR_REF_PATTERN = re.compile(r"#(\d+)\b")
 COMMIT_REF_PATTERN = re.compile(r"\(([0-9a-f]{7,40})\)")
 NEW_CONTRIBUTORS_HEADING = "### 👥 New Contributors"
+COVERAGE_HEADING = "### 🔎 Complete PR and Author Reference Coverage"
+REFERENCE_CATEGORY_ORDER = ["breaking", "features", "fixes", "docs", "internal", "other"]
+REFERENCE_CATEGORY_LABELS = {
+    "breaking": "Breaking-change refs",
+    "features": "Feature/API refs",
+    "fixes": "Bug-fix refs",
+    "docs": "Documentation refs",
+    "internal": "Internal/infrastructure refs",
+    "other": "Additional refs",
+}
 
 
 @dataclass
@@ -22,6 +32,7 @@ class CoverageSummary:
     referenced_prs: list[int]
     referenced_authors: list[str]
     referenced_commits: list[str]
+    required_reference_count: int
 
 
 @dataclass
@@ -29,6 +40,8 @@ class ValidationContext:
     """Parsed validation context for a single release note run."""
 
     reference_authors: dict[str, str]
+    reference_categories: dict[str, str]
+    reference_order: list[str]
     change_section_headings: set[str]
 
 
@@ -36,57 +49,68 @@ class ReleaseNotesValidationError(ValueError):
     """Raised when generated release notes violate attribution rules."""
 
 
+@dataclass
+class MentionScanResult:
+    """Collected ref/author coverage from markdown."""
+
+    covered_refs: set[str]
+    referenced_prs: set[int]
+    referenced_authors: set[str]
+    referenced_commits: set[str]
+    bullet_count: int
+    errors: list[str]
+
+
 def build_validation_context(
     notes: ReleaseNotes, include_internal: bool = False
 ) -> ValidationContext:
     """Build the reference and section metadata used for validation."""
-    del include_internal  # Validation should cover every candidate the agent may cite.
+    del include_internal  # Coverage should include every candidate the release may cite.
 
     reference_authors: dict[str, str] = {}
+    reference_categories: dict[str, str] = {}
+    reference_order: list[str] = []
     change_section_headings = {
         f"### {CATEGORIES[category]['emoji']} {CATEGORIES[category]['title']}"
         for category in CATEGORIES
     }
 
-    for category in list(CATEGORIES) + ["other"]:
+    for category in REFERENCE_CATEGORY_ORDER:
         for change in notes.changes.get(category, []):
-            if change.pr_number:
-                reference_authors[f"#{change.pr_number}"] = change.author
-            else:
-                reference_authors[change.sha[:7].lower()] = change.author
+            ref = f"#{change.pr_number}" if change.pr_number else change.sha[:7].lower()
+            if ref in reference_authors:
+                continue
+            reference_authors[ref] = change.author
+            reference_categories[ref] = category
+            reference_order.append(ref)
 
     return ValidationContext(
         reference_authors=reference_authors,
+        reference_categories=reference_categories,
+        reference_order=reference_order,
         change_section_headings=change_section_headings,
     )
 
 
-def _extract_bullet_references(
-    bullet: str, reference_authors: dict[str, str]
-) -> list[str]:
-    refs = [f"#{match}" for match in PR_REF_PATTERN.findall(bullet)]
+def _extract_explicit_references(text: str) -> list[str]:
+    refs = [f"#{match}" for match in PR_REF_PATTERN.findall(text)]
+    refs.extend(match.lower() for match in COMMIT_REF_PATTERN.findall(text))
 
-    for match in COMMIT_REF_PATTERN.findall(bullet):
-        ref = match.lower()
-        if ref in reference_authors and ref not in refs:
-            refs.append(ref)
-
-    return refs
+    deduped: list[str] = []
+    for ref in refs:
+        if ref not in deduped:
+            deduped.append(ref)
+    return deduped
 
 
-def validate_release_notes_markdown(
-    markdown: str,
-    notes: ReleaseNotes,
-    include_internal: bool = False,
-) -> CoverageSummary:
-    """Validate that every included change lists explicit refs and authors."""
-    context = build_validation_context(notes, include_internal=include_internal)
-    errors: list[str] = []
+def _scan_reference_mentions(markdown: str, context: ValidationContext) -> MentionScanResult:
     current_heading = ""
-    bullet_count = 0
+    covered_refs: set[str] = set()
     referenced_prs: set[int] = set()
     referenced_authors: set[str] = set()
     referenced_commits: set[str] = set()
+    errors: list[str] = []
+    bullet_count = 0
 
     for raw_line in markdown.splitlines():
         line = raw_line.strip()
@@ -97,47 +121,120 @@ def validate_release_notes_markdown(
         if not line.startswith("- "):
             continue
 
-        if current_heading == NEW_CONTRIBUTORS_HEADING:
-            continue
+        refs = _extract_explicit_references(line)
+        is_change_bullet = current_heading in context.change_section_headings
+        is_new_contributor_bullet = current_heading == NEW_CONTRIBUTORS_HEADING
 
-        if current_heading not in context.change_section_headings:
-            continue
-
-        bullet_count += 1
-        refs = _extract_bullet_references(line, context.reference_authors)
-        if not refs:
-            errors.append(f"Bullet missing explicit PR/commit references: {line}")
-            continue
-
-        unknown_refs = [ref for ref in refs if ref not in context.reference_authors]
-        if unknown_refs:
-            errors.append(
-                f"Bullet references unknown PR/commit {', '.join(sorted(unknown_refs))}: {line}"
-            )
-            continue
+        if is_change_bullet:
+            bullet_count += 1
+            if not refs:
+                errors.append(f"Bullet missing explicit PR/commit references: {line}")
+                continue
 
         for ref in refs:
-            author = context.reference_authors.get(ref, "")
-            if author and f"@{author}" not in line:
+            author = context.reference_authors.get(ref)
+            if not author:
+                errors.append(f"Bullet references unknown PR/commit {ref}: {line}")
+                continue
+            if f"@{author}" not in line:
                 errors.append(f"Bullet mentioning {ref} is missing @{author}: {line}")
                 continue
 
+            covered_refs.add(ref)
+            referenced_authors.add(author)
             if ref.startswith("#"):
                 referenced_prs.add(int(ref[1:]))
             else:
                 referenced_commits.add(ref)
 
-            if author:
-                referenced_authors.add(author)
+        if is_new_contributor_bullet and not refs:
+            continue
+
+    return MentionScanResult(
+        covered_refs=covered_refs,
+        referenced_prs=referenced_prs,
+        referenced_authors=referenced_authors,
+        referenced_commits=referenced_commits,
+        bullet_count=bullet_count,
+        errors=errors,
+    )
+
+
+def missing_references(
+    markdown: str,
+    notes: ReleaseNotes,
+    include_internal: bool = False,
+) -> list[str]:
+    """Return required refs that are not yet covered in the markdown."""
+    context = build_validation_context(notes, include_internal=include_internal)
+    scan = _scan_reference_mentions(markdown, context)
+    return [ref for ref in context.reference_order if ref not in scan.covered_refs]
+
+
+def append_reference_coverage_appendix(
+    markdown: str,
+    notes: ReleaseNotes,
+    include_internal: bool = False,
+    chunk_size: int = 8,
+) -> str:
+    """Append a compact appendix covering any PRs/authors omitted by the agent."""
+    context = build_validation_context(notes, include_internal=include_internal)
+    scan = _scan_reference_mentions(markdown, context)
+    missing_refs = [ref for ref in context.reference_order if ref not in scan.covered_refs]
+    if not missing_refs:
+        return markdown
+
+    grouped: dict[str, list[str]] = {category: [] for category in REFERENCE_CATEGORY_ORDER}
+    for ref in missing_refs:
+        author = context.reference_authors[ref]
+        formatted_ref = f"({ref}) @{author}" if not ref.startswith("#") else f"({ref}) @{author}"
+        grouped[context.reference_categories[ref]].append(formatted_ref)
+
+    appendix_lines = [COVERAGE_HEADING]
+    for category in REFERENCE_CATEGORY_ORDER:
+        refs = grouped[category]
+        if not refs:
+            continue
+        label = REFERENCE_CATEGORY_LABELS[category]
+        for index in range(0, len(refs), chunk_size):
+            chunk = refs[index : index + chunk_size]
+            appendix_lines.append(f"- {label}: {', '.join(chunk)}")
+
+    base_lines = markdown.rstrip().splitlines()
+    for index, line in enumerate(base_lines):
+        if line.startswith("**Full Changelog**:"):
+            combined = base_lines[:index] + [""] + appendix_lines + [""] + base_lines[index:]
+            return "\n".join(combined) + "\n"
+
+    return "\n".join(base_lines + [""] + appendix_lines + [""])
+
+
+def validate_release_notes_markdown(
+    markdown: str,
+    notes: ReleaseNotes,
+    include_internal: bool = False,
+) -> CoverageSummary:
+    """Validate that every included change lists explicit refs and authors."""
+    context = build_validation_context(notes, include_internal=include_internal)
+    scan = _scan_reference_mentions(markdown, context)
+    missing_refs = [ref for ref in context.reference_order if ref not in scan.covered_refs]
+
+    errors = list(scan.errors)
+    if missing_refs:
+        errors.append(
+            "Release notes are missing PR/commit coverage for: "
+            + ", ".join(missing_refs)
+        )
 
     if errors:
         raise ReleaseNotesValidationError("\n".join(errors))
 
     return CoverageSummary(
-        bullet_count=bullet_count,
-        referenced_prs=sorted(referenced_prs),
-        referenced_authors=sorted(referenced_authors),
-        referenced_commits=sorted(referenced_commits),
+        bullet_count=scan.bullet_count,
+        referenced_prs=sorted(scan.referenced_prs),
+        referenced_authors=sorted(scan.referenced_authors),
+        referenced_commits=sorted(scan.referenced_commits),
+        required_reference_count=len(context.reference_order),
     )
 
 
@@ -150,6 +247,7 @@ def format_coverage_summary(summary: CoverageSummary) -> str:
         [
             "Release notes attribution coverage validated.",
             f"- Change bullets checked: {summary.bullet_count}",
+            f"- Covered references: {len(summary.referenced_prs) + len(summary.referenced_commits)}/{summary.required_reference_count}",
             f"- PRs referenced: {prs}",
             f"- Authors referenced: {authors}",
             f"- Standalone commits referenced: {commits}",

--- a/plugins/release-notes/skills/releasenotes
+++ b/plugins/release-notes/skills/releasenotes
@@ -1,0 +1,1 @@
+../../../skills/releasenotes

--- a/plugins/release-notes/workflows/release-notes.yml
+++ b/plugins/release-notes/workflows/release-notes.yml
@@ -1,0 +1,75 @@
+---
+name: Generate Release Notes
+
+on:
+    # Trigger on release tags matching semver pattern
+    push:
+        tags:
+            - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+    # Allow manual triggering with tag input
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: 'The release tag to generate notes for'
+                required: true
+                type: string
+            previous-tag:
+                description: 'Override automatic detection of previous release tag'
+                required: false
+                type: string
+            include-internal:
+                description: 'Include internal/infrastructure changes'
+                required: false
+                type: boolean
+                default: false
+
+permissions:
+    contents: write
+
+jobs:
+    generate-release-notes:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0  # Full history for tag comparison
+
+            - name: Determine tag
+              id: get-tag
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+                  else
+                    echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Generate Release Notes
+              id: release-notes
+              uses: OpenHands/extensions/plugins/release-notes@main
+              with:
+                  tag: ${{ steps.get-tag.outputs.tag }}
+                  previous-tag: ${{ github.event.inputs.previous-tag || '' }}
+                  include-internal: ${{ github.event.inputs.include-internal || 'false' }}
+                  output-format: release
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Display generated notes
+              run: |
+                  echo "## Release Notes for ${{ steps.get-tag.outputs.tag }}"
+                  echo ""
+                  echo "Previous tag: ${{ steps.release-notes.outputs.previous-tag }}"
+                  echo "Commits: ${{ steps.release-notes.outputs.commit-count }}"
+                  echo "Contributors: ${{ steps.release-notes.outputs.contributor-count }}"
+                  echo "New contributors: ${{ steps.release-notes.outputs.new-contributor-count }}"
+                  echo ""
+                  echo "---"
+                  cat release_notes.md
+
+            - name: Upload release notes artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: release-notes-${{ steps.get-tag.outputs.tag }}
+                  path: release_notes.md
+                  retention-days: 30

--- a/plugins/release-notes/workflows/release-notes.yml
+++ b/plugins/release-notes/workflows/release-notes.yml
@@ -53,6 +53,7 @@ jobs:
                   previous-tag: ${{ github.event.inputs.previous-tag || '' }}
                   include-internal: ${{ github.event.inputs.include-internal || 'false' }}
                   output-format: release
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Display generated notes

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -404,7 +404,12 @@ class TestPrompt:
         assert "Write official release notes for `owner/repo` tag `v1.2.0`." in prompt
         assert "decide which PRs are important enough to mention" in prompt
         assert "group related PRs into a single bullet" in prompt
+        assert "aggressively compress the notes into a shorter set of higher-signal bullets" in prompt
+        assert "if a section would have more than 5 bullets" in prompt
         assert "omit trivial, repetitive, or low-signal changes" in prompt
+        assert "prioritize public APIs, user-visible capabilities, security fixes" in prompt
+        assert "public API additions still belong in `### ✨ New Features`" in prompt
+        assert "omit prompt wording, benchmark plumbing, workflow maintenance" in prompt
         assert "every change bullet must end with explicit references" in prompt
         assert "format PR references as `(#123) @username`" in prompt
         assert "include every new contributor listed below" in prompt
@@ -558,6 +563,32 @@ class TestValidation:
 
         assert "PRs referenced: #42, #43" in summary
         assert "Authors referenced: @alice, @bob" in summary
+
+    def test_validate_release_notes_allows_agent_to_recategorize_other_candidates(self):
+        """The validator should allow refs for candidates the agent re-categorizes."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "other": [
+                    Change(message="Export public API", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Export public API (#42) @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        summary = validate_release_notes_markdown(markdown, notes)
+
+        assert summary.referenced_prs == [42]
+        assert summary.referenced_authors == ["alice"]
 
 
 class TestCategories:

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -19,8 +19,10 @@ from generate_release_notes import (
     ReleaseNotes,
     _dedupe_changes,
     _process_commit,
+    _process_contributors,
     categorize_change,
     get_commits_between_tags,
+    is_new_contributor,
 )
 from prompt import format_prompt
 from validate_release_notes import (
@@ -353,7 +355,9 @@ class TestProcessingHelpers:
             "body": "Adds a new settings page for managing preferences.",
             "html_url": "https://github.com/owner/repo/pull/42",
             "labels": [{"name": "enhancement"}],
-            "user": {"login": "pr-author"},
+            "user": {"login": "pr-author", "type": "User"},
+            "created_at": "2026-03-05T12:00:00Z",
+            "merged_at": "2026-03-06T09:30:00Z",
         }
         commit = {
             "sha": "abc123",
@@ -370,6 +374,9 @@ class TestProcessingHelpers:
         assert change.pr_labels == ["enhancement"]
         assert change.body == "Adds a new settings page for managing preferences."
         assert change.url == "https://github.com/owner/repo/pull/42"
+        assert change.author_type == "User"
+        assert change.pr_created_at == "2026-03-05T12:00:00Z"
+        assert change.pr_merged_at == "2026-03-06T09:30:00Z"
 
     @patch("generate_release_notes.github_api_request")
     def test_get_commits_between_tags_warns_on_truncation(self, mock_github_api_request, capsys):
@@ -383,6 +390,106 @@ class TestProcessingHelpers:
 
         assert commits == [{"sha": "abc"}]
         assert "truncated the commit list" in capsys.readouterr().err
+
+    @patch("generate_release_notes._search_merged_pull_requests_by_author")
+    def test_is_new_contributor_rejects_prior_merged_pr(self, mock_search):
+        """A contributor is not new if they already merged a PR earlier."""
+        mock_search.return_value = [
+            {"number": 41, "closed_at": "2026-03-01T10:00:00Z"},
+            {"number": 42, "closed_at": "2026-03-06T09:30:00Z"},
+        ]
+
+        assert not is_new_contributor(
+            "pr-author",
+            "owner/repo",
+            "2026-03-06T09:30:00Z",
+            "token",
+            current_pr_number=42,
+            author_type="User",
+        )
+
+    @patch("generate_release_notes._search_merged_pull_requests_by_author")
+    def test_is_new_contributor_accepts_first_merged_pr(self, mock_search):
+        """A contributor is new when the only merged PR found is the current one."""
+        mock_search.return_value = [{"number": 42, "closed_at": "2026-03-06T09:30:00Z"}]
+
+        assert is_new_contributor(
+            "pr-author",
+            "owner/repo",
+            "2026-03-06T09:30:00Z",
+            "token",
+            current_pr_number=42,
+            author_type="User",
+        )
+
+    @patch("generate_release_notes._search_merged_pull_requests_by_author")
+    def test_is_new_contributor_ignores_bot_accounts(self, mock_search):
+        """Bot-authored PRs should never appear in new contributors."""
+        assert not is_new_contributor(
+            "dependabot[bot]",
+            "owner/repo",
+            "2026-03-06T09:30:00Z",
+            "token",
+            current_pr_number=42,
+            author_type="Bot",
+        )
+        mock_search.assert_not_called()
+
+    @patch("generate_release_notes.is_new_contributor")
+    def test_process_contributors_uses_earliest_release_pr_per_author(self, mock_is_new):
+        """Contributor detection should use the author's earliest PR in the release."""
+        mock_is_new.side_effect = lambda author, *_args, **_kwargs: author == "alice"
+        changes = [
+            Change(
+                message="Later PR",
+                sha="bbb2222",
+                author="alice",
+                pr_number=43,
+                author_type="User",
+                pr_created_at="2026-03-10T12:00:00Z",
+                pr_merged_at="2026-03-11T12:00:00Z",
+            ),
+            Change(
+                message="Earlier PR",
+                sha="aaa1111",
+                author="alice",
+                pr_number=42,
+                author_type="User",
+                pr_created_at="2026-03-05T12:00:00Z",
+                pr_merged_at="2026-03-06T09:30:00Z",
+            ),
+            Change(
+                message="Bot PR",
+                sha="ccc3333",
+                author="dependabot[bot]",
+                pr_number=44,
+                author_type="Bot",
+                pr_created_at="2026-03-07T12:00:00Z",
+                pr_merged_at="2026-03-08T12:00:00Z",
+            ),
+        ]
+
+        contributors, new_contributors = _process_contributors(changes, "owner/repo", "token")
+
+        assert [contributor.username for contributor in contributors] == ["alice", "dependabot[bot]"]
+        assert [contributor.first_pr for contributor in contributors] == [42, 44]
+        assert [contributor.username for contributor in new_contributors] == ["alice"]
+        mock_is_new.assert_any_call(
+            "alice",
+            "owner/repo",
+            "2026-03-06T09:30:00Z",
+            "token",
+            current_pr_number=42,
+            author_type="User",
+        )
+        mock_is_new.assert_any_call(
+            "dependabot[bot]",
+            "owner/repo",
+            "2026-03-08T12:00:00Z",
+            "token",
+            current_pr_number=44,
+            author_type="Bot",
+        )
 
 
 class TestPrompt:
@@ -409,7 +516,10 @@ class TestPrompt:
         assert "aggressively compress the notes into a shorter set of higher-signal bullets" in prompt
         assert "if a section would have more than 5 bullets" in prompt
         assert "omit trivial, repetitive, or low-signal changes" in prompt
+        assert "prefer end-user impact over implementation detail" in prompt
         assert "prioritize public APIs, user-visible capabilities, security fixes" in prompt
+        assert "treat toolkit-maintainer or contributor-facing changes as secondary" in prompt
+        assert "should stay in the small/internal appendix unless they are unusually significant" in prompt
         assert "public API additions still belong in `### ✨ New Features`" in prompt
         assert "omit prompt wording, benchmark plumbing, workflow maintenance" in prompt
         assert "start with a short, conversational 1-2 sentence overview" in prompt
@@ -528,6 +638,96 @@ class TestValidation:
 
         assert summary.referenced_commits == ["abc1234"]
         assert summary.referenced_authors == ["alice"]
+
+    def test_validate_release_notes_accepts_accurate_new_contributor_section(self):
+        """The validator should allow the exact expected new contributor entry."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "fixes": [
+                    Change(message="Fix reconnect bug", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+            new_contributors=[Contributor(username="alice", first_pr=42, is_new=True)],
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### 🐛 Bug Fixes
+- Fix reconnect bug (#42) @alice
+
+### 👥 New Contributors
+- @alice made their first contribution in #42
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        summary = validate_release_notes_markdown(markdown, notes)
+
+        assert summary.referenced_prs == [42]
+        assert summary.referenced_authors == ["alice"]
+
+    def test_validate_release_notes_rejects_inaccurate_new_contributor_entry(self):
+        """The validator should reject incorrect or hallucinated first-contribution bullets."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "fixes": [
+                    Change(message="Fix reconnect bug", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+            new_contributors=[Contributor(username="alice", first_pr=42, is_new=True)],
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### 🐛 Bug Fixes
+- Fix reconnect bug (#42) @alice
+
+### 👥 New Contributors
+- @alice made their first contribution in #99
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        with pytest.raises(
+            ReleaseNotesValidationError,
+            match=r"must reference #42",
+        ):
+            validate_release_notes_markdown(markdown, notes)
+
+
+    def test_validate_release_notes_rejects_missing_new_contributor_section(self):
+        """Expected new contributors must appear in the dedicated section."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "fixes": [
+                    Change(message="Fix reconnect bug", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+            new_contributors=[Contributor(username="alice", first_pr=42, is_new=True)],
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### 🐛 Bug Fixes
+- Fix reconnect bug (#42) @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        with pytest.raises(
+            ReleaseNotesValidationError,
+            match=r"missing new contributor coverage for: @alice",
+        ):
+            validate_release_notes_markdown(markdown, notes)
 
     def test_format_coverage_summary_lists_prs_and_authors(self):
         """Coverage summary output is suitable for logs and evidence."""

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -23,6 +23,11 @@ from generate_release_notes import (
     get_commits_between_tags,
 )
 from prompt import format_prompt
+from validate_release_notes import (
+    ReleaseNotesValidationError,
+    format_coverage_summary,
+    validate_release_notes_markdown,
+)
 
 
 class TestChange:
@@ -400,10 +405,159 @@ class TestPrompt:
         assert "decide which PRs are important enough to mention" in prompt
         assert "group related PRs into a single bullet" in prompt
         assert "omit trivial, repetitive, or low-signal changes" in prompt
+        assert "every change bullet must end with explicit references" in prompt
+        assert "format PR references as `(#123) @username`" in prompt
         assert "include every new contributor listed below" in prompt
         assert "Current tag: v1.2.0" in prompt
         assert "Full changelog URL:" in prompt
 
+
+class TestValidation:
+    """Tests for release notes attribution validation."""
+
+    def test_validate_release_notes_accepts_grouped_prs_with_authors(self):
+        """Grouped bullets are allowed when every PR and author is listed."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "features": [
+                    Change(message="Add dark mode", sha="abc1234", author="alice", pr_number=42),
+                    Change(message="Add theme presets", sha="def5678", author="bob", pr_number=43),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Add appearance improvements (#42) @alice, (#43) @bob
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        summary = validate_release_notes_markdown(markdown, notes)
+
+        assert summary.bullet_count == 1
+        assert summary.referenced_prs == [42, 43]
+        assert summary.referenced_authors == ["alice", "bob"]
+
+    def test_validate_release_notes_rejects_missing_author(self):
+        """Each referenced PR must include the matching author handle."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "fixes": [
+                    Change(message="Fix reconnect bug", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### 🐛 Bug Fixes
+- Fix reconnect bug (#42)
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        with pytest.raises(ReleaseNotesValidationError, match=r"missing @alice"):
+            validate_release_notes_markdown(markdown, notes)
+
+    def test_validate_release_notes_rejects_missing_refs(self):
+        """Each change bullet must contain explicit references."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "features": [
+                    Change(message="Add dark mode", sha="abc1234", author="alice", pr_number=42),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Add dark mode @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        with pytest.raises(
+            ReleaseNotesValidationError,
+            match=r"Bullet missing explicit PR/commit references",
+        ):
+            validate_release_notes_markdown(markdown, notes)
+
+    def test_validate_release_notes_accepts_standalone_commit_refs(self):
+        """Standalone commits can be referenced by short SHA plus author."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "docs": [
+                    Change(message="Update docs", sha="abc1234fedcba", author="alice"),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### 📚 Documentation
+- Update docs (abc1234) @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        summary = validate_release_notes_markdown(markdown, notes)
+
+        assert summary.referenced_commits == ["abc1234"]
+        assert summary.referenced_authors == ["alice"]
+
+    def test_format_coverage_summary_lists_prs_and_authors(self):
+        """Coverage summary output is suitable for logs and evidence."""
+        summary = format_coverage_summary(
+            validate_release_notes_markdown(
+                """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Add dark mode (#42) @alice, (#43) @bob
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+""",
+                ReleaseNotes(
+                    tag="v1.2.0",
+                    previous_tag="v1.1.0",
+                    date="2026-03-07",
+                    repo_name="owner/repo",
+                    changes={
+                        "features": [
+                            Change(
+                                message="Add dark mode",
+                                sha="abc1234",
+                                author="alice",
+                                pr_number=42,
+                            ),
+                            Change(
+                                message="Add theme presets",
+                                sha="def5678",
+                                author="bob",
+                                pr_number=43,
+                            ),
+                        ]
+                    },
+                ),
+            )
+        )
+
+        assert "PRs referenced: #42, #43" in summary
+        assert "Authors referenced: @alice, @bob" in summary
 
 
 class TestCategories:
@@ -486,6 +640,17 @@ class TestPluginStructure:
             / "release-notes.yml"
         )
         assert workflow.is_file()
+
+    def test_validator_script_exists(self):
+        """Test that the attribution validator script exists."""
+        validator = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "scripts"
+            / "validate_release_notes.py"
+        )
+        assert validator.is_file()
 
     def test_agent_script_exists(self):
         """Test that the agent orchestration script exists."""

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -1,0 +1,360 @@
+"""Tests for the release notes generator plugin."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the plugin scripts directory to the path
+plugin_dir = Path(__file__).parent.parent / "plugins" / "release-notes" / "scripts"
+sys.path.insert(0, str(plugin_dir))
+
+from generate_release_notes import (
+    CATEGORIES,
+    Change,
+    Contributor,
+    ReleaseNotes,
+    categorize_change,
+)
+
+
+class TestChange:
+    """Tests for the Change dataclass."""
+
+    def test_to_markdown_basic(self):
+        """Test basic markdown formatting."""
+        change = Change(
+            message="Add new feature",
+            sha="abc123",
+            author="testuser",
+        )
+        result = change.to_markdown("owner/repo")
+        assert result == "- Add new feature @testuser"
+
+    def test_to_markdown_with_pr(self):
+        """Test markdown formatting with PR number."""
+        change = Change(
+            message="Resolve memory leak",
+            sha="abc123",
+            author="testuser",
+            pr_number=42,
+        )
+        result = change.to_markdown("owner/repo")
+        assert result == "- Resolve memory leak (#42) @testuser"
+
+    def test_to_markdown_strips_conventional_commit_prefix(self):
+        """Test that conventional commit prefixes are stripped."""
+        change = Change(
+            message="feat: Add new feature",
+            sha="abc123",
+            author="testuser",
+            pr_number=42,
+        )
+        result = change.to_markdown("owner/repo")
+        assert "feat:" not in result
+        assert "Add new feature" in result
+
+    def test_to_markdown_strips_scoped_prefix(self):
+        """Test that scoped conventional commit prefixes are stripped."""
+        change = Change(
+            message="fix(api): Resolve timeout issue",
+            sha="abc123",
+            author="testuser",
+        )
+        result = change.to_markdown("owner/repo")
+        assert "fix(api):" not in result
+        assert "Resolve timeout issue" in result
+
+    def test_to_markdown_capitalizes_first_letter(self):
+        """Test that the first letter is capitalized."""
+        change = Change(
+            message="fix: lower case message",
+            sha="abc123",
+            author="testuser",
+        )
+        result = change.to_markdown("owner/repo")
+        assert "Lower case message" in result
+
+
+class TestCategorizeChange:
+    """Tests for the categorize_change function."""
+
+    def test_categorize_feat_prefix(self):
+        """Test categorization of feat: prefix."""
+        change = Change(message="feat: Add new API", sha="abc", author="user")
+        assert categorize_change(change) == "features"
+
+    def test_categorize_feature_prefix(self):
+        """Test categorization of feature: prefix."""
+        change = Change(message="feature: Add new API", sha="abc", author="user")
+        assert categorize_change(change) == "features"
+
+    def test_categorize_fix_prefix(self):
+        """Test categorization of fix: prefix."""
+        change = Change(message="fix: Resolve crash", sha="abc", author="user")
+        assert categorize_change(change) == "fixes"
+
+    def test_categorize_docs_prefix(self):
+        """Test categorization of docs: prefix."""
+        change = Change(message="docs: Update README", sha="abc", author="user")
+        assert categorize_change(change) == "docs"
+
+    def test_categorize_chore_prefix(self):
+        """Test categorization of chore: prefix."""
+        change = Change(message="chore: Update dependencies", sha="abc", author="user")
+        assert categorize_change(change) == "internal"
+
+    def test_categorize_ci_prefix(self):
+        """Test categorization of ci: prefix."""
+        change = Change(message="ci: Add GitHub Actions", sha="abc", author="user")
+        assert categorize_change(change) == "internal"
+
+    def test_categorize_breaking_prefix(self):
+        """Test categorization of BREAKING: prefix."""
+        change = Change(message="BREAKING: Remove deprecated API", sha="abc", author="user")
+        assert categorize_change(change) == "breaking"
+
+    def test_categorize_by_label_enhancement(self):
+        """Test categorization by enhancement label."""
+        change = Change(
+            message="Add feature",
+            sha="abc",
+            author="user",
+            pr_labels=["enhancement"],
+        )
+        assert categorize_change(change) == "features"
+
+    def test_categorize_by_label_bug(self):
+        """Test categorization by bug label."""
+        change = Change(
+            message="Fix something",
+            sha="abc",
+            author="user",
+            pr_labels=["bug"],
+        )
+        assert categorize_change(change) == "fixes"
+
+    def test_categorize_by_label_breaking_change(self):
+        """Test categorization by breaking-change label."""
+        change = Change(
+            message="Change API",
+            sha="abc",
+            author="user",
+            pr_labels=["breaking-change"],
+        )
+        assert categorize_change(change) == "breaking"
+
+    def test_categorize_uncategorized(self):
+        """Test uncategorized changes fall to other."""
+        change = Change(message="Random change", sha="abc", author="user")
+        assert categorize_change(change) == "other"
+
+    def test_commit_prefix_takes_precedence_over_label(self):
+        """Test that commit prefix categorization takes precedence."""
+        change = Change(
+            message="feat: Add feature",
+            sha="abc",
+            author="user",
+            pr_labels=["bug"],  # Conflicting label
+        )
+        # Should be categorized as feature based on prefix
+        assert categorize_change(change) == "features"
+
+
+class TestReleaseNotes:
+    """Tests for the ReleaseNotes dataclass."""
+
+    def test_to_markdown_basic(self):
+        """Test basic release notes generation."""
+        notes = ReleaseNotes(
+            tag="v1.0.0",
+            previous_tag="v0.9.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={
+                "features": [
+                    Change(message="Add feature", sha="abc", author="user1", pr_number=1)
+                ],
+                "fixes": [
+                    Change(message="Fix bug", sha="def", author="user2", pr_number=2)
+                ],
+            },
+        )
+        markdown = notes.to_markdown()
+
+        assert "## [v1.0.0] - 2026-03-06" in markdown
+        assert "### ✨ New Features" in markdown
+        assert "### 🐛 Bug Fixes" in markdown
+        assert "Add feature (#1) @user1" in markdown
+        assert "(#2) @user2" in markdown  # Fix bug becomes Bug due to prefix stripping
+        assert "compare/v0.9.0...v1.0.0" in markdown
+
+    def test_to_markdown_with_breaking_changes(self):
+        """Test release notes with breaking changes."""
+        notes = ReleaseNotes(
+            tag="v2.0.0",
+            previous_tag="v1.0.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={
+                "breaking": [
+                    Change(message="Remove API", sha="abc", author="user", pr_number=1)
+                ],
+            },
+        )
+        markdown = notes.to_markdown()
+
+        assert "### ⚠️ Breaking Changes" in markdown
+        assert "Remove API" in markdown
+
+    def test_to_markdown_with_new_contributors(self):
+        """Test release notes with new contributors."""
+        notes = ReleaseNotes(
+            tag="v1.0.0",
+            previous_tag="v0.9.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={},
+            new_contributors=[
+                Contributor(username="newuser", first_pr=42, is_new=True),
+            ],
+        )
+        markdown = notes.to_markdown()
+
+        assert "### 👥 New Contributors" in markdown
+        assert "@newuser made their first contribution in #42" in markdown
+
+    def test_to_markdown_internal_excluded_by_default(self):
+        """Test that internal changes are excluded by default."""
+        notes = ReleaseNotes(
+            tag="v1.0.0",
+            previous_tag="v0.9.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={
+                "internal": [
+                    Change(message="Update CI", sha="abc", author="user", pr_number=1)
+                ],
+            },
+        )
+        markdown = notes.to_markdown(include_internal=False)
+
+        assert "Internal" not in markdown
+
+    def test_to_markdown_internal_included_when_requested(self):
+        """Test that internal changes are included when requested."""
+        notes = ReleaseNotes(
+            tag="v1.0.0",
+            previous_tag="v0.9.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={
+                "internal": [
+                    Change(message="Update CI", sha="abc", author="user", pr_number=1)
+                ],
+            },
+        )
+        markdown = notes.to_markdown(include_internal=True)
+
+        assert "### 🏗️ Internal/Infrastructure" in markdown
+        assert "Update CI" in markdown
+
+
+class TestCategories:
+    """Tests for the CATEGORIES constant."""
+
+    def test_all_categories_have_required_fields(self):
+        """Test that all categories have the required fields."""
+        required_fields = ["emoji", "title", "commit_patterns", "labels"]
+        for category, info in CATEGORIES.items():
+            for field in required_fields:
+                assert field in info, f"Category {category} missing {field}"
+
+    def test_breaking_category_exists(self):
+        """Test that the breaking category exists."""
+        assert "breaking" in CATEGORIES
+        assert CATEGORIES["breaking"]["emoji"] == "⚠️"
+
+    def test_features_category_exists(self):
+        """Test that the features category exists."""
+        assert "features" in CATEGORIES
+        assert CATEGORIES["features"]["emoji"] == "✨"
+
+    def test_fixes_category_exists(self):
+        """Test that the fixes category exists."""
+        assert "fixes" in CATEGORIES
+        assert CATEGORIES["fixes"]["emoji"] == "🐛"
+
+    def test_docs_category_exists(self):
+        """Test that the docs category exists."""
+        assert "docs" in CATEGORIES
+        assert CATEGORIES["docs"]["emoji"] == "📚"
+
+    def test_internal_category_exists(self):
+        """Test that the internal category exists."""
+        assert "internal" in CATEGORIES
+        assert CATEGORIES["internal"]["emoji"] == "🏗️"
+
+
+class TestPluginStructure:
+    """Tests for the plugin directory structure."""
+
+    def test_plugin_directory_exists(self):
+        """Test that the plugin directory exists."""
+        plugin_dir = Path(__file__).parent.parent / "plugins" / "release-notes"
+        assert plugin_dir.is_dir()
+
+    def test_skill_md_exists(self):
+        """Test that SKILL.md exists."""
+        skill_md = Path(__file__).parent.parent / "plugins" / "release-notes" / "SKILL.md"
+        assert skill_md.is_file()
+
+    def test_readme_exists(self):
+        """Test that README.md exists."""
+        readme = Path(__file__).parent.parent / "plugins" / "release-notes" / "README.md"
+        assert readme.is_file()
+
+    def test_action_yml_exists(self):
+        """Test that action.yml exists."""
+        action = Path(__file__).parent.parent / "plugins" / "release-notes" / "action.yml"
+        assert action.is_file()
+
+    def test_script_exists(self):
+        """Test that the generator script exists."""
+        script = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "scripts"
+            / "generate_release_notes.py"
+        )
+        assert script.is_file()
+
+    def test_workflow_exists(self):
+        """Test that the workflow file exists."""
+        workflow = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "workflows"
+            / "release-notes.yml"
+        )
+        assert workflow.is_file()
+
+    def test_skills_symlink_exists(self):
+        """Test that the skills symlink exists."""
+        symlink = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "skills"
+            / "releasenotes"
+        )
+        assert symlink.exists()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -412,6 +412,8 @@ class TestPrompt:
         assert "prioritize public APIs, user-visible capabilities, security fixes" in prompt
         assert "public API additions still belong in `### ✨ New Features`" in prompt
         assert "omit prompt wording, benchmark plumbing, workflow maintenance" in prompt
+        assert "start with a short, conversational 1-2 sentence overview" in prompt
+        assert "optional top-level highlight bullets (maximum 3)" in prompt
         assert "every change bullet must end with explicit references" in prompt
         assert "format PR references as `(#123) @username`" in prompt
         assert "include every new contributor listed below" in prompt
@@ -635,10 +637,13 @@ class TestValidation:
                 ],
                 "internal": [
                     Change(message="Update CI", sha="def5678", author="bob", pr_number=43),
+                    Change(message="Refactor workflow", sha="fedcba9", author="bob", pr_number=44),
                 ],
             },
         )
         markdown = """## [v1.2.0] - 2026-03-07
+
+This release focuses on polish and delivery improvements.
 
 ### ✨ New Features
 - Add dark mode (#42) @alice
@@ -648,10 +653,11 @@ class TestValidation:
 
         augmented = append_reference_coverage_appendix(markdown, notes)
 
-        assert "### 🔎 Complete PR and Author Reference Coverage" in augmented
-        assert "(#43) @bob" in augmented
+        assert "### 🔎 Small Fixes/Internal Changes" in augmented
+        assert "- @bob: #43, #44" in augmented
+        assert augmented.count("@bob") == 1
         summary = validate_release_notes_markdown(augmented, notes)
-        assert summary.referenced_prs == [42, 43]
+        assert summary.referenced_prs == [42, 43, 44]
 
 
 class TestCategories:

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -25,7 +25,9 @@ from generate_release_notes import (
 from prompt import format_prompt
 from validate_release_notes import (
     ReleaseNotesValidationError,
+    append_reference_coverage_appendix,
     format_coverage_summary,
+    missing_references,
     validate_release_notes_markdown,
 )
 
@@ -589,6 +591,67 @@ class TestValidation:
 
         assert summary.referenced_prs == [42]
         assert summary.referenced_authors == ["alice"]
+
+    def test_validate_release_notes_rejects_missing_pr_coverage(self):
+        """Validation fails if any release-range PR is omitted entirely."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "features": [
+                    Change(message="Add dark mode", sha="abc1234", author="alice", pr_number=42),
+                    Change(message="Add theme presets", sha="def5678", author="bob", pr_number=43),
+                ]
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Add dark mode (#42) @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        with pytest.raises(
+            ReleaseNotesValidationError,
+            match=r"missing PR/commit coverage for: #43",
+        ):
+            validate_release_notes_markdown(markdown, notes)
+
+        assert missing_references(markdown, notes) == ["#43"]
+
+    def test_append_reference_coverage_appendix_adds_missing_refs(self):
+        """A deterministic appendix covers PRs the agent chose not to mention."""
+        notes = ReleaseNotes(
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            repo_name="owner/repo",
+            changes={
+                "features": [
+                    Change(message="Add dark mode", sha="abc1234", author="alice", pr_number=42),
+                ],
+                "internal": [
+                    Change(message="Update CI", sha="def5678", author="bob", pr_number=43),
+                ],
+            },
+        )
+        markdown = """## [v1.2.0] - 2026-03-07
+
+### ✨ New Features
+- Add dark mode (#42) @alice
+
+**Full Changelog**: https://github.com/owner/repo/compare/v1.1.0...v1.2.0
+"""
+
+        augmented = append_reference_coverage_appendix(markdown, notes)
+
+        assert "### 🔎 Complete PR and Author Reference Coverage" in augmented
+        assert "(#43) @bob" in augmented
+        summary = validate_release_notes_markdown(augmented, notes)
+        assert summary.referenced_prs == [42, 43]
 
 
 class TestCategories:

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -22,6 +22,7 @@ from generate_release_notes import (
     categorize_change,
     get_commits_between_tags,
 )
+from prompt import format_prompt
 
 
 class TestChange:
@@ -342,6 +343,8 @@ class TestProcessingHelpers:
         mock_get_pr_for_commit.return_value = {
             "number": 42,
             "title": "Add settings page",
+            "body": "Adds a new settings page for managing preferences.",
+            "html_url": "https://github.com/owner/repo/pull/42",
             "labels": [{"name": "enhancement"}],
             "user": {"login": "pr-author"},
         }
@@ -358,6 +361,8 @@ class TestProcessingHelpers:
         assert change.author == "pr-author"
         assert change.pr_number == 42
         assert change.pr_labels == ["enhancement"]
+        assert change.body == "Adds a new settings page for managing preferences."
+        assert change.url == "https://github.com/owner/repo/pull/42"
 
     @patch("generate_release_notes.github_api_request")
     def test_get_commits_between_tags_warns_on_truncation(self, mock_github_api_request, capsys):
@@ -371,6 +376,33 @@ class TestProcessingHelpers:
 
         assert commits == [{"sha": "abc"}]
         assert "truncated the commit list" in capsys.readouterr().err
+
+
+class TestPrompt:
+    """Tests for the release-notes agent prompt."""
+
+    def test_format_prompt_includes_editorial_instructions(self):
+        """Test that the prompt tells the agent to make editorial judgments."""
+        prompt = format_prompt(
+            repo_name="owner/repo",
+            tag="v1.2.0",
+            previous_tag="v1.1.0",
+            date="2026-03-07",
+            commit_count=12,
+            include_internal=False,
+            output_format="release",
+            full_changelog_url="https://github.com/owner/repo/compare/v1.1.0...v1.2.0",
+            change_candidates="- Ref: #42\n  Title: Add dark mode",
+            new_contributors="- @new-user made their first contribution in #42",
+        )
+
+        assert "Write official release notes for `owner/repo` tag `v1.2.0`." in prompt
+        assert "decide which PRs are important enough to mention" in prompt
+        assert "group related PRs into a single bullet" in prompt
+        assert "omit trivial, repetitive, or low-signal changes" in prompt
+        assert "include every new contributor listed below" in prompt
+        assert "Current tag: v1.2.0" in prompt
+        assert "Full changelog URL:" in prompt
 
 
 
@@ -454,6 +486,28 @@ class TestPluginStructure:
             / "release-notes.yml"
         )
         assert workflow.is_file()
+
+    def test_agent_script_exists(self):
+        """Test that the agent orchestration script exists."""
+        script = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "scripts"
+            / "agent_script.py"
+        )
+        assert script.is_file()
+
+    def test_prompt_script_exists(self):
+        """Test that the prompt template exists."""
+        prompt = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "release-notes"
+            / "scripts"
+            / "prompt.py"
+        )
+        assert prompt.is_file()
 
     def test_skills_symlink_exists(self):
         """Test that the skills symlink exists."""

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -17,7 +17,10 @@ from generate_release_notes import (
     Change,
     Contributor,
     ReleaseNotes,
+    _dedupe_changes,
+    _process_commit,
     categorize_change,
+    get_commits_between_tags,
 )
 
 
@@ -163,6 +166,42 @@ class TestCategorizeChange:
         # Should be categorized as feature based on prefix
         assert categorize_change(change) == "features"
 
+    def test_keyword_categorizes_docs(self):
+        """Test docs keyword fallback categorization."""
+        change = Change(
+            message="Update documentation with new examples",
+            sha="abc",
+            author="user",
+        )
+        assert categorize_change(change) == "docs"
+
+    def test_keyword_categorizes_internal_before_feature(self):
+        """Test internal keyword fallback takes precedence over generic feature verbs."""
+        change = Change(
+            message="Add extensive typing to controller directory",
+            sha="abc",
+            author="user",
+        )
+        assert categorize_change(change) == "internal"
+
+    def test_keyword_categorizes_fixes(self):
+        """Test fix keyword fallback categorization."""
+        change = Change(
+            message="Resolve timeout error in session reconnect",
+            sha="abc",
+            author="user",
+        )
+        assert categorize_change(change) == "fixes"
+
+    def test_keyword_categorizes_features(self):
+        """Test feature keyword fallback categorization."""
+        change = Change(
+            message="Add VS Code tab alongside the terminal",
+            sha="abc",
+            author="user",
+        )
+        assert categorize_change(change) == "features"
+
 
 class TestReleaseNotes:
     """Tests for the ReleaseNotes dataclass."""
@@ -261,6 +300,78 @@ class TestReleaseNotes:
 
         assert "### 🏗️ Internal/Infrastructure" in markdown
         assert "Update CI" in markdown
+
+    def test_to_markdown_omits_other_changes(self):
+        """Test that uncategorized changes are omitted for a more concise summary."""
+        notes = ReleaseNotes(
+            tag="v1.0.0",
+            previous_tag="v0.9.0",
+            date="2026-03-06",
+            repo_name="owner/repo",
+            changes={
+                "other": [
+                    Change(message="Random internal cleanup", sha="abc", author="user")
+                ],
+            },
+        )
+        markdown = notes.to_markdown()
+
+        assert "Other Changes" not in markdown
+        assert "Random internal cleanup" not in markdown
+
+
+class TestProcessingHelpers:
+    """Tests for processing helpers."""
+
+    def test_dedupe_changes_collapses_multiple_commits_from_same_pr(self):
+        """Test that only one entry is kept per PR."""
+        changes = [
+            Change(message="First commit", sha="abc", author="user", pr_number=10),
+            Change(message="Second commit", sha="def", author="user", pr_number=10),
+            Change(message="Standalone commit", sha="ghi", author="user"),
+        ]
+
+        deduped = _dedupe_changes(changes)
+
+        assert [change.pr_number for change in deduped] == [10, None]
+        assert [change.sha for change in deduped] == ["abc", "ghi"]
+
+    @patch("generate_release_notes.get_pr_for_commit")
+    def test_process_commit_prefers_pr_title_and_author(self, mock_get_pr_for_commit):
+        """Test that PR metadata is preferred for user-facing release note entries."""
+        mock_get_pr_for_commit.return_value = {
+            "number": 42,
+            "title": "Add settings page",
+            "labels": [{"name": "enhancement"}],
+            "user": {"login": "pr-author"},
+        }
+        commit = {
+            "sha": "abc123",
+            "commit": {"message": "feat: Low-level implementation detail\n\nMore text"},
+            "author": {"login": "commit-author"},
+        }
+
+        change = _process_commit(commit, "owner/repo", "token")
+
+        assert change is not None
+        assert change.message == "Add settings page"
+        assert change.author == "pr-author"
+        assert change.pr_number == 42
+        assert change.pr_labels == ["enhancement"]
+
+    @patch("generate_release_notes.github_api_request")
+    def test_get_commits_between_tags_warns_on_truncation(self, mock_github_api_request, capsys):
+        """Test that compare API truncation is surfaced to users."""
+        mock_github_api_request.return_value = {
+            "total_commits": 300,
+            "commits": [{"sha": "abc"}],
+        }
+
+        commits = get_commits_between_tags("owner/repo", "v1.0.0", "v1.1.0", "token")
+
+        assert commits == [{"sha": "abc"}]
+        assert "truncated the commit list" in capsys.readouterr().err
+
 
 
 class TestCategories:


### PR DESCRIPTION
## Summary

Adds a `release-notes` plugin that uses an OpenHands agent to write concise, user-focused release notes for OpenHands repositories.

Closes #97

## Details

### Design Decisions
- **Agent-authored release notes**: the action uses an OpenHands agent to decide which changes matter, write a short conversational overview, and summarize the most significant work in the main sections
- **Deterministic GitHub context**: commit/PR metadata, labels, bodies, contributors, and tag ranges are still collected deterministically and passed to the agent as structured context
- **Post-generation coverage enforcement**: a validator script rebuilds the same tag-range context and fails the workflow if any release-range PR/commit or matching author handle is missing from the final markdown
- **Deterministic small-changes appendix**: when the agent keeps the top sections concise, `agent_script.py` appends a compact `### 🔎 Small Fixes/Internal Changes` section grouped by author so every PR/author is still referenced somewhere in the output
- **Compression guidance for larger releases**: the prompt tells the agent to keep the high-level summary short and limit top-level highlight bullets to the biggest user-facing changes
- **End-user-first editorial guidance**: maintainer-only/tooling churn is pushed into the small/internal appendix unless it materially changes how end users or client developers adopt, run, or integrate the project
- **Composite GitHub Action**: implemented as a reusable composite action for easy integration
- **Automatic tag detection**: finds the previous release tag automatically to determine the commit range
- **Optional internal section**: internal/infrastructure changes remain opt-in for the main editorial sections; omitted items still appear in the appendix when needed
- **Accurate new contributor detection**: first-time human contributors are derived from merged PR history, bots are excluded, and the validator now rejects incorrect or missing new-contributor entries

### Plugin Structure
```text
plugins/release-notes/
├── README.md
├── SKILL.md
├── action.yml
├── scripts/
│   ├── agent_script.py
│   ├── generate_release_notes.py
│   ├── prompt.py
│   └── validate_release_notes.py
└── workflows/release-notes.yml
```

### Categories Generated
- Short conversational overview
- Optional top-level key highlights
- ⚠️ Breaking Changes
- ✨ New Features
- 🐛 Bug Fixes
- 📚 Documentation
- 🏗️ Internal/Infrastructure (optional main section)
- 👥 New Contributors
- 🔎 Small Fixes/Internal Changes (deterministic appendix when needed)

## Testing

Added/updated tests covering:
- prompt instructions for agent-based editorial decisions, conversational top summaries, large-release compression guidance, and end-user vs maintainer-only prioritization
- categorization hints and PR metadata capture used for contributor detection
- attribution validation for grouped bullets, missing PR refs, missing authors, standalone commits, and agent recategorization of `other` candidates
- exact new-contributor validation, including rejecting wrong first-PR claims and missing new-contributor coverage
- full-coverage validation that fails when any release-range PR is omitted
- deterministic appendix generation that restores complete PR/author coverage without forcing the main sections to list one bullet per PR
- author-grouped appendix formatting so usernames are listed once per appendix line
- markdown generation behavior
- plugin structure validation

```text
62 passed in 0.13s
84 passed in 2.93s
```

## Evidence

**Historical verification link:** [View earlier conversation](https://app.all-hands.dev/conversations/e5b4dba66acc4fc987ec8597437c51da)

### What changed in this follow-up

Commit `1512e02` (`Fix release note contributor attribution`) addresses the remaining accuracy gap by:
- switching new-contributor detection from commit-author history to merged PR history
- excluding bot accounts from the `### 👥 New Contributors` section
- validating that every expected new contributor appears in that section with the correct first PR
- strengthening the prompt so maintainer-only/tooling changes stay in `### 🔎 Small Fixes/Internal Changes` unless they are materially relevant to end users or client developers

### Final live run against `OpenHands/software-agent-sdk` tag `v1.15.0`

This is a substantial recent release with **83 commits** in range. After deterministic PR deduplication, that release resolves to **70 PR-backed changes** and **15 unique authors** that must be covered in the final markdown.

```text
Generating release notes: v1.14.0 -> v1.15.0
Found 83 commits
Release notes attribution coverage validated.
- Change bullets checked: 26
- Covered references: 70/70
- PRs referenced: #1880, #1990, #2190, #2230, #2276, #2277, #2324, #2360, #2382, #2383, #2390, #2409, #2414, #2420, #2427, #2430, #2432, #2433, #2434, #2435, #2442, #2443, #2445, #2448, #2450, #2451, #2452, #2455, #2457, #2458, #2460, #2464, #2465, #2475, #2476, #2479, #2480, #2483, #2484, #2487, #2493, #2497, #2500, #2501, #2502, #2504, #2507, #2508, #2512, #2517, #2518, #2519, #2520, #2521, #2522, #2524, #2529, #2535, #2536, #2541, #2542, #2546, #2547, #2549, #2557, #2558, #2559, #2561, #2563, #2567
- Authors referenced: @VascoSch92, @adityasoni9998, @aivong-openhands, @all-hands-bot, @dependabot[bot], @enyst, @ixchio, @jpshackelford, @juanmichelini, @mayeco, @neubig, @rbren, @simonrosenberg, @xingyaoww, @yitao-li
- Standalone commits referenced: none
```

**New contributor section from the generated notes:**
```markdown
### 👥 New Contributors

- @yitao-li made their first contribution in #2414
```

**Direct verification of the corrected edge case:**
- `dependabot[bot]` is no longer listed as a new contributor
- GitHub merged-PR history for `dependabot[bot]` in `OpenHands/software-agent-sdk` shows many earlier merged PRs before `#2448`, so the old claim was incorrect
- GitHub merged-PR history for `yitao-li` in `OpenHands/software-agent-sdk` shows exactly one merged PR, `#2414`, so the current line is accurate

**Full generated release notes from the validated live run:**
```markdown
## [v1.15.0] - 2026-03-26

This release brings parallel tool execution for significant performance improvements, ACP Agent support on the remote runtime API, and expanded model coverage including GPT-5.4, Gemini 3.1, and MiniMax-M2.7. It also includes critical security fixes for LiteLLM and the rich library.

### ✨ New Features

- Enable parallel tool execution with `TOOL_CONCURRENCY_LIMIT` environment variable for concurrent tool calls within agent steps, defaulting to 1 for backward compatibility (#2390) @VascoSch92
- Add ACP Agent support to RemoteRuntime API via dedicated `/api/acp/conversations` endpoints while preserving existing REST contract stability (#2465) @simonrosenberg
- Add credential inheritance to `OpenHandsCloudWorkspace` via `get_llm()` and `get_secrets()` methods for SDK-created conversations to inherit SaaS user credentials (#2409) @xingyaoww
- Add verified model support for GPT-5.4 (#2487) @juanmichelini, Gemini 3.1 (#2276) @mayeco, and MiniMax-M2.7 (#2500) @juanmichelini
- Add `entry_command` field to `PluginManifest` for default plugin invocation (#2230) @jpshackelford and `url` field to `PluginAuthor` for Claude Code schema parity (#2546) @jpshackelford

### 🐛 Bug Fixes

- Pin LiteLLM to exactly 1.80.10 to mitigate malicious wheel vulnerability in 1.82.8 (#2558) @rbren
- Fix Qwen3.5-Flash low submission rate by improving JSON argument parsing and adding corrective feedback for stuck conversations (#2512) @juanmichelini
- Fix Apptainer workspace cleanup to properly kill zombie child processes (#2450) @adityasoni9998
- Fix browser action timeouts to return `BrowserObservation` errors instead of fatal `TimeoutError` exceptions (#2455) @neubig
- Fix ACP telemetry race conditions by synchronizing writes onto a single path and refreshing remote conversation state before `run()` returns (#2460) @simonrosenberg
- Fix preflight check to validate `reasoning_content` for thinking models that output to reasoning instead of content (#2420) @juanmichelini
- Fix Kimi thinking models to stop sending unsupported `reasoning_effort` parameter (#2549) @enyst
- Use `asyncio.Event()` for thread-safe initialization state in server details router (#2383) @ixchio
- Upgrade rich package to 14.3.3 to address denial-of-service vulnerability in 14.3.2 (#2414) @yitao-li

### 📚 Documentation

- Establish docstring standards for MDX compatibility and fix key docstrings to prevent rendering issues in Mintlify (#2452) @rbren

### 👥 New Contributors

- @yitao-li made their first contribution in #2414


### 🔎 Small Fixes/Internal Changes
- @simonrosenberg: #2190, #2535, #2536, #2542, #2493, #2529, #2557, #2559, #2561, #2563, #2522
- @VascoSch92: #2502, #2547, #2480
- @enyst: #2432, #2508, #2507, #2524, #2457, #1990, #2433, #2434, #2435, #2442, #2443, #2445, #2451, #2464
- @rbren: #2458
- @neubig: #2430, #2382, #2360
- @dependabot[bot]: #2448, #2475, #2484, #2497, #2520, #2517, #2519, #2521, #2518
- @juanmichelini: #2483, #2324
- @aivong-openhands: #2501, #2427
- @all-hands-bot: #2567
- @mayeco: #2277

**Full Changelog**: https://github.com/OpenHands/software-agent-sdk/compare/v1.14.0...v1.15.0
```

### Requirement check against issue #97 + follow-up feedback
- ✅ **Friendlier top section**: the release notes open with a short conversational summary and fewer, higher-signal bullets
- ✅ **Complete release-range coverage**: the final markdown references **70/70** PR-backed changes in the release range
- ✅ **All authors listed**: the final markdown references all **15** authors associated with those release-range PRs
- ✅ **No missing PRs even when summarized**: lower-signal/internal items still appear in `### 🔎 Small Fixes/Internal Changes`, grouped by author but preserving every PR number
- ✅ **Accurate new contributors**: the generated `### 👥 New Contributors` section now lists only `@yitao-li` for `#2414`, excludes `dependabot[bot]`, and is validated against merged PR history
- ✅ **End-user vs internal separation**: client-visible/public API changes remain in the main sections; maintainer-only/tooling churn is pushed into the small/internal section unless materially user-relevant
- ✅ **Structured output**: categorized sections are still present and the full changelog link remains at the end

**Interpretation note:** the completeness requirement is enforced at the deduplicated **PR/standalone-commit** level, not at the raw commit count, because multiple commits can belong to the same merged PR. For this SDK release, `83` raw commits reduced to `70` release-range PR-backed changes, and the validator proves all `70` are referenced.

## Checklist

- [x] Tests pass
- [x] Evidence gathered from a live run against a real repository
- [x] Documentation included (`README.md`)
- [x] Review feedback addressed

_This PR description was updated by OpenHands, an AI assistant, on behalf of the user._
