### PR TITLE
fix: Add lockfile sync instructions to vulnerability remediation prompt

### DIFF
--- a/plugins/vulnerability-remediation/scripts/scan_and_remediate.py
+++ b/plugins/vulnerability-remediation/scripts/scan_and_remediate.py
@@ -177,11 +177,26 @@ def create_remediation_prompt(vuln: Vulnerability, repo_name: str) -> str:
 
 1. **Analyze** the vulnerability and understand what needs to be fixed
 2. **Update** the package to the fixed version ({vuln.fixed_version}) in the appropriate dependency file
-3. **Verify** the change doesn't break the build (run any available build/test commands)
-4. **Create a branch** named `fix/{vuln.vuln_id.lower()}`
-5. **Commit** your changes with a clear message explaining the security fix
-6. **Push** the branch to origin
-7. **Create a Pull Request** using the GitHub CLI:
+3. **CRITICAL: Sync/regenerate lockfiles**
+   After updating the version in the manifest file, you MUST run the appropriate package manager sync command to update lockfiles with correct versions and hashes. Do NOT manually edit lockfiles.
+
+   Based on the package manager detected:
+   - **uv (pyproject.toml + uv.lock)**: Run `uv lock --upgrade-package {vuln.package_name}` or `uv sync`
+   - **Poetry (pyproject.toml + poetry.lock)**: Run `poetry lock --no-update` or `poetry update {vuln.package_name}`
+   - **npm (package.json + package-lock.json)**: Run `npm install` or `npm update {vuln.package_name}`
+   - **yarn (package.json + yarn.lock)**: Run `yarn install` or `yarn upgrade {vuln.package_name}`
+   - **pnpm (package.json + pnpm-lock.yaml)**: Run `pnpm install` or `pnpm update {vuln.package_name}`
+   - **pip (requirements.txt)**: Update the version directly in requirements.txt
+   - **Go (go.mod + go.sum)**: Run `go mod tidy`
+   - **Cargo (Cargo.toml + Cargo.lock)**: Run `cargo update -p {vuln.package_name}`
+   - **Maven (pom.xml)**: Update the version directly in pom.xml
+   - **Gradle**: Update the version in build.gradle/build.gradle.kts
+
+4. **Verify** the change doesn't break the build (run any available build/test commands)
+5. **Create a branch** named `fix/{vuln.vuln_id.lower()}`
+6. **Commit** your changes with a clear message explaining the security fix
+7. **Push** the branch to origin
+8. **Create a Pull Request** using the GitHub CLI:
    ```bash
    gh pr create --title "fix: {vuln.vuln_id} - Update {vuln.package_name} to {vuln.fixed_version}" \\
      --body "## Security Fix
@@ -201,6 +216,7 @@ This PR addresses {vuln.vuln_id} ({vuln.severity} severity).
 
 ## Important Notes
 - Do NOT modify any code beyond what's necessary for the fix
+- Do NOT manually edit lockfiles - always use the package manager commands above
 - If the package update requires other dependency changes, include them
 - If you encounter conflicts or issues, document them in the PR description
 - Always test that the fix doesn't break the build before creating the PR


### PR DESCRIPTION
## Summary

Ports the critical lockfile regeneration instructions from [OpenHands/vulnerability-fixer#42](https://github.com/OpenHands/vulnerability-fixer/pull/42) to ensure the agent properly syncs lockfiles after updating dependency versions.

## Problem

The vulnerability remediation agent was not properly syncing lockfiles after updating dependency versions in manifest files. It would just update the version number but leave the lockfile with old hashes.

This issue was observed in [OpenHands/OpenHands#13013](https://github.com/OpenHands/OpenHands/pull/13013) where:
- **UV lockfile**: Missing version update, wrong hashes (old hashes instead of new version)
- **Poetry lockfile**: Wrong hashes (old hashes instead of new version)

## Changes

Updated `create_remediation_prompt()` in `scan_and_remediate.py` to include:

1. **New Step 3: CRITICAL - Sync/regenerate lockfiles** with explicit instructions to run the appropriate package manager sync command after updating versions

2. Instructions for common package managers:
   - **uv**: `uv lock --upgrade-package <package>` or `uv sync`
   - **Poetry**: `poetry lock --no-update` or `poetry update <package>`
   - **npm**: `npm install` or `npm update <package>`
   - **yarn**: `yarn install` or `yarn upgrade <package>`
   - **pnpm**: `pnpm install` or `pnpm update <package>`
   - **pip**: Update the version directly in requirements.txt
   - **Go**: `go mod tidy`
   - **Cargo**: `cargo update -p <package>`
   - **Maven/Gradle**: Update version directly

3. Emphasis that lockfiles should NOT be manually edited

## Related

- Fixes the gap identified when comparing PR #96 with the source vulnerability-fixer repo
- Ports changes from https://github.com/OpenHands/vulnerability-fixer/pull/42
