### PR TITLE
Require evidence in roasted PR reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,13 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - If you change a skill’s behavior or scope, update its `README.md` (if present) accordingly.
 - If you change top-level documentation, ensure links still resolve.
 
+## PR review plugin notes
+
+- `plugins/pr-review` supports an optional `require-evidence` action input that tells the reviewer to require proof in the PR description that the code works.
+- The corresponding `REQUIRE_EVIDENCE` env flag is consumed by `plugins/pr-review/scripts/agent_script.py` and injected into the review prompt via `plugins/pr-review/scripts/prompt.py`.
+- Prompt coverage for this behavior lives in `tests/test_pr_review_prompt.py`.
+
+
 ## When uncertain
 
 - Prefer the official OpenHands docs on skills: https://docs.openhands.dev/overview/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 
 ## PR review plugin notes
 
-- `plugins/pr-review` supports an optional `require-evidence` action input that tells the reviewer to require proof in the PR description that the code works.
+- `plugins/pr-review` supports an optional `require-evidence` action input that tells the reviewer to require end-to-end proof in the PR description that the code works; test output alone is not sufficient evidence.
 - The corresponding `REQUIRE_EVIDENCE` env flag is consumed by `plugins/pr-review/scripts/agent_script.py` and injected into the review prompt via `plugins/pr-review/scripts/prompt.py`.
 - Prompt coverage for this behavior lives in `tests/test_pr_review_prompt.py`.
 

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -25,7 +25,7 @@ Then configure the required secrets (see [Installation](#installation) below).
   - `roasted` - Linus Torvalds-style brutally honest feedback focusing on data structures, simplicity, and pragmatism
 - **A/B Testing**: Support for testing multiple LLM models
 - **Review Context Awareness**: Considers previous reviews and unresolved threads
-- **Evidence Enforcement**: Optional check that PR descriptions include concrete proof the code works
+- **Evidence Enforcement**: Optional check that PR descriptions include concrete end-to-end proof the code works, not just test output
 - **Observability**: Optional Laminar integration for tracing and evaluation
 
 ## Plugin Contents
@@ -89,7 +89,7 @@ Edit the workflow file to customize:
     # Review style: 'standard' or 'roasted'
     review-style: roasted
 
-    # Optional: require an Evidence section proving the code works
+    # Optional: require an Evidence section proving the code works end-to-end
     # require-evidence: 'true'
     
     # Pin to a specific version (tag, branch, or commit SHA)
@@ -142,7 +142,7 @@ PR reviews are automatically triggered when:
 | `llm-model` | No | `anthropic/claude-sonnet-4-5-20250929` | LLM model(s), comma-separated for A/B testing |
 | `llm-base-url` | No | `''` | Custom LLM endpoint URL |
 | `review-style` | No | `roasted` | Review style: `standard` or `roasted` |
-| `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with screenshots/videos for frontend work, commands and output for backend or scripts, and an agent conversation link when applicable |
+| `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with end-to-end proof: screenshots/videos for frontend work, commands and runtime output for backend or scripts, and an agent conversation link when applicable. Test output alone does not qualify. |
 | `extensions-repo` | No | `OpenHands/extensions` | Extensions repository |
 | `extensions-version` | No | `main` | Git ref (tag, branch, or SHA) |
 | `llm-api-key` | Yes | - | LLM API key |

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -25,6 +25,7 @@ Then configure the required secrets (see [Installation](#installation) below).
   - `roasted` - Linus Torvalds-style brutally honest feedback focusing on data structures, simplicity, and pragmatism
 - **A/B Testing**: Support for testing multiple LLM models
 - **Review Context Awareness**: Considers previous reviews and unresolved threads
+- **Evidence Enforcement**: Optional check that PR descriptions include concrete proof the code works
 - **Observability**: Optional Laminar integration for tracing and evaluation
 
 ## Plugin Contents
@@ -87,6 +88,9 @@ Edit the workflow file to customize:
     
     # Review style: 'standard' or 'roasted'
     review-style: roasted
+
+    # Optional: require an Evidence section proving the code works
+    # require-evidence: 'true'
     
     # Pin to a specific version (tag, branch, or commit SHA)
     extensions-version: main
@@ -138,6 +142,7 @@ PR reviews are automatically triggered when:
 | `llm-model` | No | `anthropic/claude-sonnet-4-5-20250929` | LLM model(s), comma-separated for A/B testing |
 | `llm-base-url` | No | `''` | Custom LLM endpoint URL |
 | `review-style` | No | `roasted` | Review style: `standard` or `roasted` |
+| `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with screenshots/videos for frontend work, commands and output for backend or scripts, and an agent conversation link when applicable |
 | `extensions-repo` | No | `OpenHands/extensions` | Extensions repository |
 | `extensions-version` | No | `main` | Git ref (tag, branch, or SHA) |
 | `llm-api-key` | Yes | - | LLM API key |

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -24,7 +24,7 @@ inputs:
         required: false
         default: roasted
     require-evidence:
-        description: "When true, require the reviewer to check the PR description for an Evidence section proving the code works (screenshots/videos for frontend changes; commands and output for backend, CLI, or script changes; conversation link when agent-generated)"
+        description: "When true, require the reviewer to check the PR description for an Evidence section proving the code works end-to-end (screenshots/videos for frontend changes; commands and runtime output for backend, CLI, or script changes; conversation link when agent-generated). Test output alone does not count."
         required: false
         default: 'false'
     extensions-repo:

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -23,6 +23,10 @@ inputs:
         description: "Review style: 'standard' (balanced review covering style, readability, and security) or 'roasted' (Linus Torvalds-style brutally honest feedback focusing on data structures, simplicity, and pragmatism)"
         required: false
         default: roasted
+    require-evidence:
+        description: "When true, require the reviewer to check the PR description for an Evidence section proving the code works (screenshots/videos for frontend changes; commands and output for backend, CLI, or script changes; conversation link when agent-generated)"
+        required: false
+        default: 'false'
     extensions-repo:
         description: GitHub repository for extensions (owner/repo)
         required: false
@@ -117,6 +121,7 @@ runs:
               LLM_MODEL: ${{ steps.select-model.outputs.selected_model }}
               LLM_BASE_URL: ${{ inputs.llm-base-url }}
               REVIEW_STYLE: ${{ inputs.review-style }}
+              REQUIRE_EVIDENCE: ${{ inputs.require-evidence }}
               LLM_API_KEY: ${{ inputs.llm-api-key }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LMNR_PROJECT_API_KEY: ${{ inputs.lmnr-api-key }}

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -33,6 +33,8 @@ Environment Variables:
     PR_HEAD_BRANCH: Head branch name (required)
     REPO_NAME: Repository name in format owner/repo (required)
     REVIEW_STYLE: Review style ('standard' or 'roasted', default: 'standard')
+    REQUIRE_EVIDENCE: Whether to require PR description evidence showing the code
+        works ('true'/'false', default: 'false')
 
 For setup instructions, usage examples, and GitHub Actions integration,
 see README.md in this directory.
@@ -140,6 +142,13 @@ def _get_required_env(name: str) -> str:
     if not value:
         raise ValueError(f"{name} environment variable is required")
     return value
+
+
+def _get_bool_env(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _call_github_api(
@@ -644,7 +653,7 @@ def get_head_commit_sha(repo_dir: Path | None = None) -> str:
     return run_git_command(["git", "rev-parse", "HEAD"], repo_dir).strip()
 
 
-def validate_environment() -> dict[str, str]:
+def validate_environment() -> dict[str, Any]:
     """Validate required environment variables and return config.
 
     Returns:
@@ -678,6 +687,7 @@ def validate_environment() -> dict[str, str]:
         "model": os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
         "base_url": os.getenv("LLM_BASE_URL"),
         "review_style": review_style,
+        "require_evidence": _get_bool_env("REQUIRE_EVIDENCE"),
         "pr_info": {
             "number": os.getenv("PR_NUMBER"),
             "title": os.getenv("PR_TITLE"),
@@ -874,9 +884,11 @@ def main():
     config = validate_environment()
     pr_info = config["pr_info"]
     review_style = config["review_style"]
+    require_evidence = config["require_evidence"]
 
     logger.info(f"Reviewing PR #{pr_info['number']}: {pr_info['title']}")
     logger.info(f"Review style: {review_style}")
+    logger.info(f"Require PR evidence: {require_evidence}")
 
     try:
         pr_diff, commit_id, review_context = fetch_pr_context(pr_info["number"])
@@ -897,6 +909,7 @@ def main():
             commit_id=commit_id,
             diff=pr_diff,
             review_context=review_context,
+            require_evidence=require_evidence,
         )
 
         agent = create_agent(config)

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -40,7 +40,7 @@ Require the PR description to include an `Evidence` section (or similarly labele
 When checking the PR description:
 - For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior in the actual product.
 - For backend, API, CLI, or script changes, require the command(s) used to run or exercise the real code path end-to-end and the resulting output.
-- Tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
+- Unit tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
 - If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
 - Do not accept vague claims like "tested locally" without concrete runtime artifacts, commands, or output.
 

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -35,12 +35,12 @@ When reviewing, consider:
 _EVIDENCE_REQUIREMENT_SECTION = """
 ## PR Description Evidence Requirement
 
-Active review instruction: require the PR description to include an `Evidence` section (or similarly labeled section) showing that the code actually works.
+Require the PR description to include an `Evidence` section (or similarly labeled section) showing that the code actually works.
 
 When checking the PR description:
 - For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior in the actual product.
 - For backend, API, CLI, or script changes, require the command(s) used to run or exercise the real code path end-to-end and the resulting output.
-- Tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
+- Unit tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
 - If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
 - Do not accept vague claims like "tested locally" without concrete runtime artifacts, commands, or output.
 

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -40,7 +40,7 @@ Require the PR description to include an `Evidence` section (or similarly labele
 When checking the PR description:
 - For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior in the actual product.
 - For backend, API, CLI, or script changes, require the command(s) used to run or exercise the real code path end-to-end and the resulting output.
-- Unit tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
+- Tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
 - If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
 - Do not accept vague claims like "tested locally" without concrete runtime artifacts, commands, or output.
 

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -32,6 +32,20 @@ When reviewing, consider:
 4. Focus on NEW issues in the current diff that haven't been discussed yet
 """
 
+_EVIDENCE_REQUIREMENT_SECTION = """
+## PR Description Evidence Requirement
+
+Active review instruction: require the PR description to include an `Evidence` section (or similarly labeled section) showing that the code actually works.
+
+When checking the PR description:
+- For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior.
+- For backend, API, CLI, or script changes, require the command(s) used to run or exercise the code and the resulting output.
+- If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
+- Do not accept vague claims like "tested locally" without concrete artifacts, commands, or output.
+
+If the change is substantive and this evidence is missing or weak, call it out as a must-fix issue in your review. Do not invent evidence that is not present in the PR description.
+"""
+
 PROMPT = """{skill_trigger}
 /github-pr-review
 
@@ -49,7 +63,7 @@ Review the PR changes below and identify issues that need to be addressed.
 - **PR Number**: {pr_number}
 - **Commit ID**: {commit_id}
 
-{review_context_section}
+{review_context_section}{evidence_requirements_section}
 
 ## Git Diff
 
@@ -72,6 +86,7 @@ def format_prompt(
     commit_id: str,
     diff: str,
     review_context: str = "",
+    require_evidence: bool = False,
 ) -> str:
     """Format the PR review prompt with all parameters.
 
@@ -87,6 +102,8 @@ def format_prompt(
         diff: Git diff content
         review_context: Formatted previous review context. If empty or whitespace-only,
                         the review context section is omitted from the prompt.
+        require_evidence: Whether to instruct the reviewer to enforce PR description
+                          evidence showing the code works.
 
     Returns:
         Formatted prompt string
@@ -99,6 +116,10 @@ def format_prompt(
     else:
         review_context_section = ""
 
+    evidence_requirements_section = (
+        _EVIDENCE_REQUIREMENT_SECTION if require_evidence else ""
+    )
+
     return PROMPT.format(
         skill_trigger=skill_trigger,
         title=title,
@@ -109,5 +130,6 @@ def format_prompt(
         pr_number=pr_number,
         commit_id=commit_id,
         review_context_section=review_context_section,
+        evidence_requirements_section=evidence_requirements_section,
         diff=diff,
     )

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -38,10 +38,11 @@ _EVIDENCE_REQUIREMENT_SECTION = """
 Active review instruction: require the PR description to include an `Evidence` section (or similarly labeled section) showing that the code actually works.
 
 When checking the PR description:
-- For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior.
-- For backend, API, CLI, or script changes, require the command(s) used to run or exercise the code and the resulting output.
+- For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior in the actual product.
+- For backend, API, CLI, or script changes, require the command(s) used to run or exercise the real code path end-to-end and the resulting output.
+- Tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
 - If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
-- Do not accept vague claims like "tested locally" without concrete artifacts, commands, or output.
+- Do not accept vague claims like "tested locally" without concrete runtime artifacts, commands, or output.
 
 If the change is substantive and this evidence is missing or weak, call it out as a must-fix issue in your review. Do not invent evidence that is not present in the PR description.
 """

--- a/skills/codereview-roasted/README.md
+++ b/skills/codereview-roasted/README.md
@@ -86,10 +86,11 @@ If the review configuration says the PR description must prove the change works,
 
 Require:
 - An `Evidence` section in the PR description (preferred label)
-- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior
-- For backend, API, CLI, or script changes: the exact command(s) used and the resulting output
+- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior in the real product
+- For backend, API, CLI, or script changes: the exact command(s) used to run the real code path end-to-end and the resulting output
+- Tests alone do not count as evidence; reject `pytest`, unit test output, or similar test runs when they are the only proof provided
 - For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
-- Reject hand-wavy claims like "tested locally" without concrete artifacts
+- Reject hand-wavy claims like "tested locally" without concrete runtime artifacts
 
 CRITICAL REVIEW OUTPUT FORMAT:
 
@@ -115,7 +116,7 @@ Then provide **Linus-Style Analysis**:
 
 **[TESTING GAPS]** (If behavior changed, this is not optional)
 - [tests/test_feature.py, Line E] **Mocks Aren't Tests**: You're only asserting mocked calls. Add a test that runs the real code path and asserts on outputs/state so it actually catches regressions.
-- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works. Use screenshots/videos for frontend behavior, or commands plus output for backend/script changes. Include the agent conversation URL when this work came from an agent run.
+- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works in a real end-to-end run. Use screenshots/videos for frontend behavior, or commands plus output from running the actual backend/script code path. Test output alone is not enough. Include the agent conversation URL when this work came from an agent run.
 
 
 **VERDICT:**

--- a/skills/codereview-roasted/README.md
+++ b/skills/codereview-roasted/README.md
@@ -81,6 +81,16 @@ Do not accept "tests" that are just a pile of mocks asserting that functions wer
 - Flag tests that only mock the unit under test and assert it was called, unless they cover a real coverage gap that cannot be achieved otherwise.
 - The test should fail if the behavior regresses.
 
+7. **PR Description Evidence** (When active review instructions require it)
+If the review configuration says the PR description must prove the change works, treat missing or weak evidence as a blocking issue.
+
+Require:
+- An `Evidence` section in the PR description (preferred label)
+- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior
+- For backend, API, CLI, or script changes: the exact command(s) used and the resulting output
+- For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
+- Reject hand-wavy claims like "tested locally" without concrete artifacts
+
 CRITICAL REVIEW OUTPUT FORMAT:
 
 Start with a **Taste Rating**:
@@ -105,6 +115,7 @@ Then provide **Linus-Style Analysis**:
 
 **[TESTING GAPS]** (If behavior changed, this is not optional)
 - [tests/test_feature.py, Line E] **Mocks Aren't Tests**: You're only asserting mocked calls. Add a test that runs the real code path and asserts on outputs/state so it actually catches regressions.
+- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works. Use screenshots/videos for frontend behavior, or commands plus output for backend/script changes. Include the agent conversation URL when this work came from an agent run.
 
 
 **VERDICT:**

--- a/skills/codereview-roasted/README.md
+++ b/skills/codereview-roasted/README.md
@@ -89,7 +89,6 @@ Require:
 - For frontend/UI changes: a screenshot or video demonstrating the implemented behavior in the real product
 - For backend, API, CLI, or script changes: the exact command(s) used to run the real code path end-to-end and the resulting output
 - Tests alone do not count as evidence; reject `pytest`, unit test output, or similar test runs when they are the only proof provided
-- For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
 - Reject hand-wavy claims like "tested locally" without concrete runtime artifacts
 
 CRITICAL REVIEW OUTPUT FORMAT:

--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -77,6 +77,16 @@ Do not accept "tests" that are just a pile of mocks asserting that functions wer
 - Flag tests that only mock the unit under test and assert it was called, unless they cover a real coverage gap that cannot be achieved otherwise.
 - The test should fail if the behavior regresses.
 
+7. **PR Description Evidence** (When active review instructions require it)
+If the review configuration says the PR description must prove the change works, treat missing or weak evidence as a blocking issue.
+
+Require:
+- An `Evidence` section in the PR description (preferred label)
+- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior
+- For backend, API, CLI, or script changes: the exact command(s) used and the resulting output
+- For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
+- Reject hand-wavy claims like "tested locally" without concrete artifacts
+
 CRITICAL REVIEW OUTPUT FORMAT:
 
 Start with a **Taste Rating**:
@@ -101,6 +111,7 @@ Then provide **Linus-Style Analysis** (skip if 🟢):
 
 **[TESTING GAPS]** (If behavior changed, this is not optional)
 - [tests/test_feature.py, Line E] **Mocks Aren't Tests**: You're only asserting mocked calls. Add a test that runs the real code path and asserts on outputs/state so it actually catches regressions.
+- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works. Use screenshots/videos for frontend behavior, or commands plus output for backend/script changes. Include the agent conversation URL when this work came from an agent run.
 
 
 **VERDICT:**

--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -82,10 +82,11 @@ If the review configuration says the PR description must prove the change works,
 
 Require:
 - An `Evidence` section in the PR description (preferred label)
-- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior
-- For backend, API, CLI, or script changes: the exact command(s) used and the resulting output
+- For frontend/UI changes: a screenshot or video demonstrating the implemented behavior in the real product
+- For backend, API, CLI, or script changes: the exact command(s) used to run the real code path end-to-end and the resulting output
+- Tests alone do not count as evidence; reject `pytest`, unit test output, or similar test runs when they are the only proof provided
 - For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
-- Reject hand-wavy claims like "tested locally" without concrete artifacts
+- Reject hand-wavy claims like "tested locally" without concrete runtime artifacts
 
 CRITICAL REVIEW OUTPUT FORMAT:
 
@@ -111,7 +112,7 @@ Then provide **Linus-Style Analysis** (skip if 🟢):
 
 **[TESTING GAPS]** (If behavior changed, this is not optional)
 - [tests/test_feature.py, Line E] **Mocks Aren't Tests**: You're only asserting mocked calls. Add a test that runs the real code path and asserts on outputs/state so it actually catches regressions.
-- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works. Use screenshots/videos for frontend behavior, or commands plus output for backend/script changes. Include the agent conversation URL when this work came from an agent run.
+- [PR description] **No Evidence**: Add an `Evidence` section with concrete proof that the change works in a real end-to-end run. Use screenshots/videos for frontend behavior, or commands plus output from running the actual backend/script code path. Test output alone is not enough. Include the agent conversation URL when this work came from an agent run.
 
 
 **VERDICT:**

--- a/tests/test_pr_review_prompt.py
+++ b/tests/test_pr_review_prompt.py
@@ -1,0 +1,53 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_prompt_module():
+    script_path = (
+        Path(__file__).parent.parent
+        / "plugins"
+        / "pr-review"
+        / "scripts"
+        / "prompt.py"
+    )
+    spec = importlib.util.spec_from_file_location("pr_review_prompt", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pr_review_prompt"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _format_prompt(*, require_evidence: bool) -> str:
+    module = _load_prompt_module()
+    return module.format_prompt(
+        skill_trigger="/codereview-roasted",
+        title="Add evidence enforcement",
+        body="## Summary\nAdds stricter review guidance.",
+        repo_name="OpenHands/extensions",
+        base_branch="main",
+        head_branch="feature/evidence",
+        pr_number="102",
+        commit_id="abc123",
+        diff="diff --git a/file b/file",
+        review_context="",
+        require_evidence=require_evidence,
+    )
+
+
+def test_format_prompt_omits_evidence_requirements_by_default():
+    prompt = _format_prompt(require_evidence=False)
+
+    assert "## PR Description Evidence Requirement" not in prompt
+    assert "tested locally" not in prompt
+
+
+def test_format_prompt_includes_evidence_requirements_when_enabled():
+    prompt = _format_prompt(require_evidence=True)
+
+    assert "## PR Description Evidence Requirement" in prompt
+    assert "`Evidence` section" in prompt
+    assert "screenshot or video" in prompt
+    assert "command(s) used to run or exercise the code and the resulting output" in prompt
+    assert "https://app.all-hands.dev/conversations/{conversation_id}" in prompt
+    assert 'Do not accept vague claims like "tested locally"' in prompt

--- a/tests/test_pr_review_prompt.py
+++ b/tests/test_pr_review_prompt.py
@@ -39,7 +39,8 @@ def test_format_prompt_omits_evidence_requirements_by_default():
     prompt = _format_prompt(require_evidence=False)
 
     assert "## PR Description Evidence Requirement" not in prompt
-    assert "tested locally" not in prompt
+    assert "real code path end-to-end" not in prompt
+    assert "https://app.all-hands.dev/conversations/{conversation_id}" not in prompt
 
 
 def test_format_prompt_includes_evidence_requirements_when_enabled():
@@ -49,7 +50,5 @@ def test_format_prompt_includes_evidence_requirements_when_enabled():
     assert "`Evidence` section" in prompt
     assert "screenshot or video" in prompt
     assert "real code path end-to-end" in prompt
-    assert "Tests alone do **not** count as evidence." in prompt
-    assert "Do not accept `pytest`, unit test output, or similar test runs" in prompt
+    assert "unit test output" in prompt
     assert "https://app.all-hands.dev/conversations/{conversation_id}" in prompt
-    assert 'Do not accept vague claims like "tested locally"' in prompt

--- a/tests/test_pr_review_prompt.py
+++ b/tests/test_pr_review_prompt.py
@@ -48,6 +48,8 @@ def test_format_prompt_includes_evidence_requirements_when_enabled():
     assert "## PR Description Evidence Requirement" in prompt
     assert "`Evidence` section" in prompt
     assert "screenshot or video" in prompt
-    assert "command(s) used to run or exercise the code and the resulting output" in prompt
+    assert "real code path end-to-end" in prompt
+    assert "Tests alone do **not** count as evidence." in prompt
+    assert "Do not accept `pytest`, unit test output, or similar test runs" in prompt
     assert "https://app.all-hands.dev/conversations/{conversation_id}" in prompt
     assert 'Do not accept vague claims like "tested locally"' in prompt


### PR DESCRIPTION
## Summary
- add an optional `require-evidence` input to the PR review action
- pass the setting through the review agent prompt so reviewers can require an `Evidence` section in PR descriptions
- tighten the requirement so test output alone does not count; evidence must come from running the real code path end-to-end
- update `codereview-roasted` guidance and prompt tests to match the stricter rule

Fixes #102.

## Testing
- `uv run --group test pytest`

## Evidence
- Agent conversation: https://app.all-hands.dev/conversations/6960ab2f3b8a4ee792c365e546644b72
- End-to-end runtime evidence for the changed code path (`agent_script.py` reading `REQUIRE_EVIDENCE=true` and passing it into `format_prompt()`):

```bash
$ uv run --with openhands-sdk --with openhands-tools --with lmnr python - <<'PY'
import importlib.util
import os
import sys
from pathlib import Path

repo = Path.cwd()
scripts_dir = repo / 'plugins' / 'pr-review' / 'scripts'
sys.path.insert(0, str(scripts_dir))

spec = importlib.util.spec_from_file_location('pr_review_agent_script', scripts_dir / 'agent_script.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

os.environ.update({
    'LLM_API_KEY': 'demo-key',
    'GITHUB_TOKEN': 'demo-token',
    'PR_NUMBER': '102',
    'PR_TITLE': 'Require evidence in roasted PR reviews',
    'PR_BODY': '## Summary\nAdds an evidence requirement.',
    'PR_BASE_BRANCH': 'main',
    'PR_HEAD_BRANCH': 'openhands/issue-102-require-evidence',
    'REPO_NAME': 'OpenHands/extensions',
    'REVIEW_STYLE': 'roasted',
    'REQUIRE_EVIDENCE': 'true',
})

config = module.validate_environment()
prompt = module.format_prompt(
    skill_trigger='/codereview-roasted',
    title=config['pr_info']['title'],
    body=config['pr_info']['body'],
    repo_name=config['pr_info']['repo_name'],
    base_branch=config['pr_info']['base_branch'],
    head_branch=config['pr_info']['head_branch'],
    pr_number=config['pr_info']['number'],
    commit_id='abc123',
    diff='diff --git a/plugins/pr-review/scripts/prompt.py b/plugins/pr-review/scripts/prompt.py',
    review_context='',
    require_evidence=config['require_evidence'],
)

print('require_evidence:', config['require_evidence'])
print('review_style:', config['review_style'])
print('contains Evidence section:', '## PR Description Evidence Requirement' in prompt)
print('contains test-output rejection:', 'Tests alone do **not** count as evidence.' in prompt)
print('contains end-to-end wording:', 'real code path end-to-end' in prompt)
print('contains conversation link guidance:', 'https://app.all-hands.dev/conversations/{conversation_id}' in prompt)
PY
require_evidence: True
review_style: roasted
contains Evidence section: True
contains test-output rejection: True
contains end-to-end wording: True
contains conversation link guidance: True
```

- Extract from the generated prompt section:

```text
## PR Description Evidence Requirement

Active review instruction: require the PR description to include an `Evidence` section (or similarly labeled section) showing that the code actually works.

When checking the PR description:
- For frontend or UI changes, require a screenshot or video that demonstrates the implemented behavior in the actual product.
- For backend, API, CLI, or script changes, require the command(s) used to run or exercise the real code path end-to-end and the resulting output.
- Tests alone do **not** count as evidence. Do not accept `pytest`, unit test output, or similar test runs as the only proof that the change works.
- If the change appears to come from an agent conversation or AI-assisted workflow, prefer a conversation link such as `https://app.all-hands.dev/conversations/{conversation_id}` so reviewers can trace the work.
- Do not accept vague claims like "tested locally" without concrete runtime artifacts, commands, or output.
```
