### PR TITLE
codereview-roasted: instruct agent to check system clock for CVE date validation

### DIFF
--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -68,6 +68,8 @@ Focus on real security risks, not theoretical ones:
 - Memory safety issues in unsafe languages
 - Concurrency bugs that cause data corruption
 
+**Important**: When evaluating CVEs or security advisories, always check the system clock (`date`) to determine the current year. Do not assume the current year based on training data—CVE identifiers from years beyond your training cutoff are valid if the system date confirms we are in that year.
+
 6. **Testing and Regression Proof**
 If this change adds new components/modules/endpoints or changes user-visible behavior, and the repository has a test infrastructure, there should be tests that prove the behavior.
 


### PR DESCRIPTION
## Problem

The codereview-roasted skill can become suspicious of CVEs from years beyond the LLM's training data cutoff. For example, an agent trained on 2025 data might incorrectly flag CVE-2026-* identifiers as invalid or suspicious.

## Solution

Added an explicit instruction in the Security and Correctness section telling the agent to check the system clock (`date`) before evaluating CVE identifiers. This ensures the agent uses the actual current year rather than assuming based on training data.

## Changes

- Added instruction to check system date when evaluating CVEs or security advisories
- Clarifies that CVE identifiers from years beyond training cutoff are valid if system date confirms we are in that year