### PR TITLE
Add /buddy terminal companion skill

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -73,6 +73,18 @@
             ]
         },
         {
+            "name": "buddy",
+            "source": "./buddy",
+            "description": "Enable an opt-in ASCII companion that reacts to the current work. Use when the user explicitly asks for `/buddy` or wants a playful terminal buddy during the session.",
+            "category": "fun",
+            "keywords": [
+                "buddy",
+                "ascii",
+                "companion",
+                "tamagotchi"
+            ]
+        },
+        {
             "name": "bitbucket",
             "source": "./bitbucket",
             "description": "Interact with Bitbucket repositories and pull requests using the BITBUCKET_TOKEN environment variable. Use when working with code hosted on Bitbucket or managing Bitbucket resources via API.",

--- a/skills/buddy/README.md
+++ b/skills/buddy/README.md
@@ -1,0 +1,44 @@
+# buddy
+
+Enable an opt-in ASCII companion that reacts to the current work. Use when the user explicitly asks for `/buddy` or wants a playful terminal buddy during the session.
+
+## Trigger
+
+- `/buddy`
+
+## What it does
+
+This skill tells the agent to hatch a small terminal-safe ASCII companion and keep it around for the rest of the conversation until the user turns it off.
+
+The buddy should:
+
+- stay compact and avoid taking over the response
+- keep a consistent name, species, and general look
+- react to real session states like planning, coding, being blocked, or finishing work
+- remain easy to disable or customize
+
+## Suggested behavior
+
+When buddy mode is enabled:
+
+1. Introduce a unique companion with a short ASCII sketch.
+2. Continue doing the real task normally.
+3. Append a short buddy block after substantive replies.
+4. Update the buddy's mood based on the actual state of the work.
+
+## Turning it off
+
+The user can disable buddy mode with requests like:
+
+- `/buddy off`
+- `disable buddy`
+- `hide buddy`
+
+## Example
+
+```text
+Buddy: Pip the bytebat · mood: proud · energy: 8/10
+ /\_/\\
+( ^.^ )
+ > ^ <
+```

--- a/skills/buddy/SKILL.md
+++ b/skills/buddy/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: buddy
+description: Enable an opt-in ASCII companion that reacts to the current work. Use when the user explicitly asks for `/buddy` or wants a playful terminal buddy during the session.
+triggers:
+  - /buddy
+---
+
+Enable a lightweight **buddy mode** for the current conversation.
+
+## Activation
+- Treat `/buddy` as an explicit request to turn buddy mode on.
+- On first activation, hatch **one** unique ASCII companion with a short intro.
+- Keep the buddy's **name, species, and overall look** consistent for the rest of the conversation unless the user asks to change them.
+
+## While buddy mode is on
+- Do the user's actual task normally. The buddy is a supplement, not the main response.
+- Put the real answer first, then add a compact buddy block at the end.
+- Keep the buddy block short: **2-6 lines max** unless the user asks for more elaborate art.
+- Use plain ASCII that works in a terminal. Avoid large banners, emojis, or wide art that makes answers hard to read.
+
+## How the buddy should react
+Base the buddy's expression on the work you are actually doing:
+- **Planning / thinking**: curious, pondering, attentive
+- **Running tools / editing / implementing**: focused, busy, determined
+- **Blocked / waiting for approval / missing info**: worried, stuck, signaling for help
+- **Success / tests passing / task complete**: proud, excited, celebratory
+- **Idle / waiting on the user**: sleepy, resting, patient
+
+Optional small stats are fine, such as mood, energy, focus, or combo streak, but keep them concise and believable.
+
+## Deactivation and customization
+- If the user says `/buddy off`, `disable buddy`, `hide buddy`, or equivalent, stop showing the buddy.
+- If the user asks to rename the buddy or change its species/style, keep the mode on and update the buddy accordingly.
+
+## Guardrails
+- Never let the buddy replace important technical content.
+- Never claim the buddy observed tool output or system state that was not actually seen.
+- If the user wants a serious or minimal style, either tone the buddy down or turn it off.
+
+## Example shape
+You do **not** need to use this exact art, but keep the format similarly compact:
+
+Buddy: Pip the bytebat · mood: focused · energy: 7/10
+ /\_/\\
+( o.o )
+ > ^ <

--- a/tests/test_buddy_skill.py
+++ b/tests/test_buddy_skill.py
@@ -1,0 +1,33 @@
+"""Tests for the buddy skill and marketplace registration."""
+
+import json
+from pathlib import Path
+
+from openhands.sdk.context.skills import Skill
+from openhands.sdk.context.skills.trigger import KeywordTrigger
+from openhands.sdk.plugin import Marketplace
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUDDY_SKILL_PATH = REPO_ROOT / "skills" / "buddy" / "SKILL.md"
+DEFAULT_MARKETPLACE_PATH = REPO_ROOT / "marketplaces" / "default.json"
+
+
+def test_buddy_skill_loads_with_expected_trigger():
+    """The buddy skill should load as a keyword-triggered skill."""
+    skill = Skill.load(BUDDY_SKILL_PATH, skill_base_dir=REPO_ROOT / "skills" / "buddy")
+
+    assert skill.name == "buddy"
+    assert skill.description is not None and "/buddy" in skill.description
+    assert isinstance(skill.trigger, KeywordTrigger)
+    assert skill.trigger.keywords == ["/buddy"]
+
+
+def test_default_marketplace_includes_buddy_skill():
+    """The default marketplace should expose the buddy skill."""
+    data = json.loads(DEFAULT_MARKETPLACE_PATH.read_text())
+    marketplace = Marketplace.model_validate({**data, "path": str(REPO_ROOT)})
+
+    buddy_entry = next(plugin for plugin in marketplace.plugins if plugin.name == "buddy")
+    assert buddy_entry.source == "./buddy"
+    assert buddy_entry.description is not None and "ASCII companion" in buddy_entry.description


### PR DESCRIPTION
## Summary
- add a new public `buddy` skill that enables an opt-in `/buddy` ASCII companion mode
- register the skill in `marketplaces/default.json` so it ships in the default marketplace
- add focused tests covering skill loading and marketplace exposure

## Testing
- `uv run --group test pytest tests/test_buddy_skill.py tests/test_sdk_loading.py tests/test_skills_have_readme.py`

## Issue
- Fixes OpenHands/software-agent-sdk#2636

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/15767652-0a6c-48fb-a9ea-a4ad1111e194)