### PR TITLE
fix(pr-review): skip installing project dependencies during review

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -133,7 +133,7 @@ runs:
               REPO_NAME: ${{ github.repository }}
           run: |
               cd pr-repo
-              uv run --with openhands-sdk --with openhands-tools --with lmnr \
+              uv run --no-project --with openhands-sdk --with openhands-tools --with lmnr \
                 python ../extensions/plugins/pr-review/scripts/agent_script.py
 
         - name: Upload logs as artifact


### PR DESCRIPTION
## Summary

- Add `--no-project` flag to `uv run` in the PR review action so it **only installs the three required packages** (`openhands-sdk`, `openhands-tools`, `lmnr`) instead of all dependencies from the reviewed project's `pyproject.toml`.

## Problem

When the action runs `cd pr-repo && uv run --with ...`, `uv` detects the project's `pyproject.toml` in the current directory and installs **all** project dependencies first. For projects with heavy deps (e.g. opencv, mediapipe, torch), this adds significant time and can even fail if native build tools are missing.

## Fix

```diff
- uv run --with openhands-sdk --with openhands-tools --with lmnr \
+ uv run --no-project --with openhands-sdk --with openhands-tools --with lmnr \
```

The review agent only reads source files and calls the LLM API — it never imports or runs the project code, so project dependencies are unnecessary. The `--no-project` flag tells `uv` to ignore the local `pyproject.toml` while still keeping `pr-repo/` as the working directory for file access.

Ref: https://docs.astral.sh/uv/reference/cli/#uv-run--no-project