### PR TITLE
fix(pr-review): preserve deletion suggestions in thread context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 
 - `plugins/pr-review` supports an optional `require-evidence` action input that tells the reviewer to require end-to-end proof in the PR description that the code works; test output alone is not sufficient evidence.
 - The corresponding `REQUIRE_EVIDENCE` env flag is consumed by `plugins/pr-review/scripts/agent_script.py` and injected into the review prompt via `plugins/pr-review/scripts/prompt.py`.
+- GitHub review suggestions that only delete lines can look empty in `PullRequestReviewComment.body`; the rendered content is available via `bodyText`/`bodyHTML`, so review-context formatting should fall back there before treating a suggestion as empty.
 - Prompt coverage for this behavior lives in `tests/test_pr_review_prompt.py`.
 
 

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -126,6 +126,7 @@ query($owner: String!, $repo: String!, $pr_number: Int!, $cursor: String) {
                             id
                             author { login }
                             body
+                            bodyText
                             createdAt
                         }
                     }
@@ -501,6 +502,53 @@ def format_review_context(
     return "\n".join(sections)
 
 
+def _is_empty_suggestion_block(body: str) -> bool:
+    """Return True when a suggestion fence contains no visible replacement text."""
+    lines = body.splitlines()
+    return (
+        len(lines) >= 2
+        and lines[0].strip() == "```suggestion"
+        and lines[-1].strip() == "```"
+        and all(not line.strip() for line in lines[1:-1])
+    )
+
+
+def _normalize_review_comment_text(text: str) -> str:
+    """Normalize GitHub review comment text for prompt readability."""
+    normalized_lines = [line.rstrip() for line in text.splitlines()]
+    cleaned_lines: list[str] = []
+    previous_blank = False
+
+    for line in normalized_lines:
+        is_blank = not line.strip()
+        if is_blank:
+            if previous_blank:
+                continue
+            cleaned_lines.append("")
+        else:
+            cleaned_lines.append(line)
+        previous_blank = is_blank
+
+    return "\n".join(cleaned_lines).strip()
+
+
+def _get_review_comment_body(comment: dict[str, Any]) -> str:
+    """Get the best available comment text for review context.
+
+    GitHub stores deletion-only suggestions as an empty ```suggestion``` block in
+    `body`, but exposes the rendered suggestion content in `bodyText`/`bodyHTML`.
+    Prefer the original markdown when it contains real text, and fall back to the
+    normalized plain-text rendering when the raw body would look empty to the agent.
+    """
+    body = _normalize_review_comment_text(comment.get("body") or "")
+    body_text = _normalize_review_comment_text(comment.get("bodyText") or "")
+
+    if not body or _is_empty_suggestion_block(body):
+        return body_text or body
+
+    return body
+
+
 def _format_thread(thread: dict[str, Any]) -> list[str]:
     """Format a single review thread.
 
@@ -533,7 +581,7 @@ def _format_thread(thread: dict[str, Any]) -> list[str]:
     for comment in comments:
         author_data = comment.get("author") or {}
         author = author_data.get("login", "unknown")
-        body = (comment.get("body") or "").strip()
+        body = _get_review_comment_body(comment)
 
         if body:
             # Truncate individual comments if too long

--- a/tests/test_pr_review_review_context.py
+++ b/tests/test_pr_review_review_context.py
@@ -1,0 +1,165 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _ensure_package(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _load_agent_script_module():
+    _ensure_package("openhands")
+    _ensure_package("openhands.sdk")
+    _ensure_package("openhands.sdk.context")
+    _ensure_package("openhands.sdk.git")
+    _ensure_package("openhands.tools")
+    _ensure_package("openhands.tools.preset")
+
+    lmnr = types.ModuleType("lmnr")
+
+    class _Laminar:
+        @staticmethod
+        def get_trace_id():
+            return None
+
+        @staticmethod
+        def get_laminar_span_context():
+            return None
+
+        @staticmethod
+        def flush():
+            return None
+
+        @staticmethod
+        def start_as_current_span(*args, **kwargs):
+            class _ContextManager:
+                def __enter__(self):
+                    return None
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+
+            return _ContextManager()
+
+        @staticmethod
+        def set_trace_metadata(metadata):
+            return None
+
+    lmnr.Laminar = _Laminar
+    sys.modules["lmnr"] = lmnr
+
+    sdk = types.ModuleType("openhands.sdk")
+    sdk.LLM = object
+    sdk.Agent = object
+    sdk.AgentContext = object
+    sdk.Conversation = object
+
+    class _Logger:
+        def info(self, *args, **kwargs):
+            return None
+
+        def warning(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+        def debug(self, *args, **kwargs):
+            return None
+
+    sdk.get_logger = lambda name: _Logger()
+    sys.modules["openhands.sdk"] = sdk
+
+    context_skills = types.ModuleType("openhands.sdk.context.skills")
+    context_skills.load_project_skills = lambda cwd: []
+    sys.modules["openhands.sdk.context.skills"] = context_skills
+
+    conversation = types.ModuleType("openhands.sdk.conversation")
+    conversation.get_agent_final_response = lambda events: ""
+    sys.modules["openhands.sdk.conversation"] = conversation
+
+    git_utils = types.ModuleType("openhands.sdk.git.utils")
+    git_utils.run_git_command = lambda command, repo_dir: "deadbeef"
+    sys.modules["openhands.sdk.git.utils"] = git_utils
+
+    tools_preset = types.ModuleType("openhands.tools.preset.default")
+    tools_preset.get_default_condenser = lambda llm: None
+    tools_preset.get_default_tools = lambda enable_browser=False: []
+    sys.modules["openhands.tools.preset.default"] = tools_preset
+
+    script_path = (
+        Path(__file__).parent.parent
+        / "plugins"
+        / "pr-review"
+        / "scripts"
+        / "agent_script.py"
+    )
+    spec = importlib.util.spec_from_file_location("pr_review_agent_script", script_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pr_review_agent_script"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_review_comment_body_uses_body_text_for_empty_suggestion_block():
+    module = _load_agent_script_module()
+
+    body = module._get_review_comment_body(
+        {
+            "body": "```suggestion\n```",
+            "bodyText": (
+                "Suggested change\n"
+                "      \n"
+                "- Do **NOT** approve the PR.\n"
+                "      \n"
+                "- Leave a **COMMENT** review with the exact package details."
+            ),
+        }
+    )
+
+    assert body == (
+        "Suggested change\n\n"
+        "- Do **NOT** approve the PR.\n\n"
+        "- Leave a **COMMENT** review with the exact package details."
+    )
+
+
+def test_format_thread_includes_rendered_suggestion_text_in_review_context():
+    module = _load_agent_script_module()
+
+    lines = module._format_thread(
+        {
+            "path": ".agents/skills/custom-codereview-guide.md",
+            "line": 96,
+            "isOutdated": False,
+            "isResolved": False,
+            "comments": {
+                "nodes": [
+                    {
+                        "author": {"login": "enyst"},
+                        "body": "```suggestion\n```",
+                        "bodyText": (
+                            "Suggested change\n"
+                            "\n"
+                            "- Do **NOT** approve the PR.\n"
+                            "\n"
+                            "- Explain that Dependabot ignores the freshness guardrail."
+                        ),
+                    }
+                ]
+            },
+        }
+    )
+
+    formatted = "\n".join(lines)
+
+    assert "**.agents/skills/custom-codereview-guide.md:96** - ⚠️ UNRESOLVED" in formatted
+    assert "Suggested change" in formatted
+    assert "- Do **NOT** approve the PR." in formatted
+    assert "Dependabot ignores the freshness guardrail" in formatted
+    assert "```suggestion" not in formatted


### PR DESCRIPTION
## Summary
- fetch `bodyText` for review thread comments in the PR review plugin
- treat deletion-only GitHub suggestions as non-empty when `body` is just an empty suggestion fence
- add focused tests covering the review-context fallback path

## Validation
- `uv run --group test pytest tests/test_pr_review_review_context.py tests/test_pr_review_prompt.py`

## Context
GitHub stores deletion-only suggestions with an effectively empty `PullRequestReviewComment.body`, while the rendered suggested deletion is available in `bodyText`/`bodyHTML`. This caused the reviewer agent to misread deletion suggestions as empty review feedback.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._