### PR TITLE
Add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,8 @@ See [`AGENTS.md`](AGENTS.md) for the rules agents should follow when editing/add
 
 Many thanks to all individual contributors
 
-[![](https://assets.openhands.dev/readme/20260401-openhands-extensions-contributors.svg)](https://github.com/OpenHands/extensions/graphs/contributors)
+<p align="center">
+  <a href="https://github.com/OpenHands/extensions/graphs/contributors">
+    <img src="https://assets.openhands.dev/readme/20260401-openhands-extensions-contributors.svg" />
+  </a>
+</p>

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Browse available plugins in [`plugins/`](plugins/).
 
 See [`AGENTS.md`](AGENTS.md) for the rules agents should follow when editing/adding skills and plugins.
 
-## Contributors
+<hr>
 
-Many thanks to all individual contributors
+### Thank You to Our Contributors
 
 <p align="center">
   <a href="https://github.com/OpenHands/extensions/graphs/contributors">

--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ Many thanks to all individual contributors
 
 <p align="center">
   <a href="https://github.com/OpenHands/extensions/graphs/contributors">
-    <img src="https://assets.openhands.dev/readme/20260401-openhands-extensions-contributors.svg" />
+    <img src="https://assets.openhands.dev/readme/openhands-extensions-contributors.svg" />
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ Browse available plugins in [`plugins/`](plugins/).
 ## Agent Instructions
 
 See [`AGENTS.md`](AGENTS.md) for the rules agents should follow when editing/adding skills and plugins.
+
+## Contributors
+
+Many thanks to all individual contributors
+
+[![](https://assets.openhands.dev/readme/20260401-openhands-extensions-contributors.svg)](https://github.com/OpenHands/extensions/graphs/contributors)


### PR DESCRIPTION
Adds a contributors section to the README with an SVG graphic showing all contributors.

---
Production Preview
<img width="1594" height="247" alt="image" src="https://github.com/user-attachments/assets/306a656a-4006-4e72-9011-fe4aaee32230" />

<img width="1592" height="262" alt="image" src="https://github.com/user-attachments/assets/a7d29bc8-35e0-4fca-8a98-20a4bd97e719" />


---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fccd497a-0a31-4a58-aa02-36f1edf4a707)