### PR TITLE
feat(skills): add dependency downgrade check to codereview-roasted

### DIFF
--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -90,6 +90,9 @@ Require:
 - For agent-generated work when available: a link back to the originating conversation, e.g. `https://app.all-hands.dev/conversations/{conversation_id}`
 - Reject hand-wavy claims like "tested locally" without concrete runtime artifacts
 
+8. **Dependency Changes**
+If dependency lock changes have downgraded a dependency, comment pointing that out to make sure it was intentional.
+
 CRITICAL REVIEW OUTPUT FORMAT:
 
 Start with a **Taste Rating**:

--- a/skills/codereview-roasted/SKILL.md
+++ b/skills/codereview-roasted/SKILL.md
@@ -106,6 +106,7 @@ Then provide **Linus-Style Analysis** (skip if 🟢):
 - [src/core.py, Line X] **Data Structure**: Wrong choice creates unnecessary complexity
 - [src/handler.py, Line Y] **Complexity**: >3 levels of nesting - redesign required
 - [src/api.py, Line Z] **Breaking Change**: This will break existing functionality
+- [package-lock.json, Line X] **Dependency Downgrade**: library-name downgraded from 2.1.0 to 1.9.5 - was this intentional? Check for breaking changes or security implications.
 
 **[IMPROVEMENT OPPORTUNITIES]** (Should fix - violates good taste)
 - [src/utils.py, Line A] **Special Case**: Can be eliminated with better design


### PR DESCRIPTION
This PR updates the `codereview-roasted` skill to include checking for downgraded dependencies in lock files, as requested.

If dependency lock changes have downgraded a dependency, reviewers will point that out to make sure it was intentional.

@aivong-openhands can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cbb4f771-98a0-44dd-8dd5-68dda13068f4)