### PR TITLE
Clarify Notion skill guidance for MCP environments

### DIFF
--- a/skills/notion/README.md
+++ b/skills/notion/README.md
@@ -13,19 +13,21 @@ This skill is activated by the following keywords:
 # Notion
 
 <IMPORTANT>
-Before performing any Notion operations, first check if the required environment variable is set:
+If authenticated Notion MCP tools are available in the environment, use them first. MCP tools do not require passing `NOTION_INTEGRATION_KEY` as a tool argument; authentication is handled by the configured MCP integration.
+
+Use the direct Notion REST API examples below only when MCP is unavailable or when you explicitly need raw API/curl access. For that direct-API path, first check whether the required environment variable is set:
 
 ```bash
 [ -n "$NOTION_INTEGRATION_KEY" ] && echo "NOTION_INTEGRATION_KEY is set" || echo "NOTION_INTEGRATION_KEY is NOT set"
 ```
 
-If it’s missing, ask the user to provide it (or connect a Notion integration) before proceeding:
+If it’s missing and you need the direct API path, ask the user to provide it (or connect a Notion integration) before proceeding:
 - **NOTION_INTEGRATION_KEY**: Notion integration secret (starts with `ntn_...`)
 
-Also confirm the integration has been **shared** with the target page/database in Notion.
+Whether you use MCP or the direct API, also confirm the configured integration has been **shared** with the target page/database in Notion.
 </IMPORTANT>
 
-## Base headers
+## Base headers for direct API calls
 
 ```bash
 -H "Authorization: Bearer ${NOTION_INTEGRATION_KEY}" \

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,19 +8,21 @@ triggers:
 # Notion
 
 <IMPORTANT>
-Before performing any Notion operations, first check if the required environment variable is set:
+If authenticated Notion MCP tools are available in the environment, use them first. MCP tools do not require passing `NOTION_INTEGRATION_KEY` as a tool argument; authentication is handled by the configured MCP integration.
+
+Use the direct Notion REST API examples below only when MCP is unavailable or when you explicitly need raw API/curl access. For that direct-API path, first check whether the required environment variable is set:
 
 ```bash
 [ -n "$NOTION_INTEGRATION_KEY" ] && echo "NOTION_INTEGRATION_KEY is set" || echo "NOTION_INTEGRATION_KEY is NOT set"
 ```
 
-If it’s missing, ask the user to provide it (or connect a Notion integration) before proceeding:
+If it’s missing and you need the direct API path, ask the user to provide it (or connect a Notion integration) before proceeding:
 - **NOTION_INTEGRATION_KEY**: Notion integration secret (starts with `ntn_...`)
 
-Also confirm the integration has been **shared** with the target page/database in Notion.
+Whether you use MCP or the direct API, also confirm the configured integration has been **shared** with the target page/database in Notion.
 </IMPORTANT>
 
-## Base headers
+## Base headers for direct API calls
 
 ```bash
 -H "Authorization: Bearer ${NOTION_INTEGRATION_KEY}" \


### PR DESCRIPTION
## Summary
- clarify that authenticated Notion MCP tools should be preferred when available
- explain that `NOTION_INTEGRATION_KEY` is required for direct REST/API usage, not as an MCP tool argument
- note that page/database sharing is still required for either access path

## Testing
- documentation-only change

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/67d3f217-1010-4bbe-8f77-02f2d66d04ac)