### PR TITLE
Add PR template from OpenHands/OpenHands repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!-- Keep this PR as draft until it is ready for review. -->
+
+<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->
+
+- [ ] A human has tested these changes.
+
+---
+
+## Why
+
+<!-- Describe problem, motivation, etc.-->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed. -->
+-
+
+## Issue Number
+<!-- Required if there is a relevant issue to this PR. -->
+
+## How to Test
+
+<!--
+Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.
+
+If you could not test this, say why.
+-->
+
+## Video/Screenshots
+
+<!--
+Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.
+
+-->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Breaking change
+- [ ] Docs / chore
+
+## Notes
+
+<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,14 +33,6 @@ Provide a video or screenshots of testing your PR. e.g. you added a new feature 
 
 -->
 
-## Type
-
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor
-- [ ] Breaking change
-- [ ] Docs / chore
-
 ## Notes
 
 <!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


### PR DESCRIPTION
## Why

This PR adds a pull request template to the repository to standardize PR submissions and ensure all necessary information is provided.

## Summary

- Copied PR template from OpenHands/OpenHands repository
- Added `.github/pull_request_template.md` to the repository

## Issue Number

Fixes #142

## How to Test

This is a documentation/configuration change. To verify:
1. Check that `.github/pull_request_template.md` exists in the repository
2. Create a new PR and verify the template is automatically loaded

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This template matches the one used in the main OpenHands repository to maintain consistency across the organization.