### PR TITLE
Add Apple Notes Snapshot control-room skill

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -277,6 +277,20 @@
             ]
         },
         {
+            "name": "notes-snapshot-control-room",
+            "source": "./notes-snapshot-control-room",
+            "description": "Keep Apple Notes Snapshot connected to local coding hosts without overstating product scope, attach proof, or official-listing status.",
+            "category": "development",
+            "keywords": [
+                "apple-notes",
+                "backup",
+                "mcp",
+                "codex",
+                "claude-code",
+                "openclaw"
+            ]
+        },
+        {
             "name": "npm",
             "source": "./npm",
             "description": "Handle npm package installation in non-interactive environments by piping confirmations. Use when installing Node.js packages that require user confirmation prompts.",

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -1,0 +1,25 @@
+# notes-snapshot-control-room
+
+Repo-scoped guidance for connecting Apple Notes Snapshot to local coding hosts
+without overstating product scope or proof level.
+
+## What this skill is for
+
+- keeping the Apple Notes backup control-room identity first
+- requiring local `notesctl` preflight before attach claims
+- separating repo-owned starter packs from official public directory listings
+- keeping named-host proof language honest when Codex, Claude Code, OpenClaw,
+  or another local host is involved
+
+## What it does not claim
+
+- no hosted AI platform
+- no automatic public marketplace listing
+- no universal attach proof for every machine
+
+## Good trigger examples
+
+- "Connect Apple Notes Snapshot to Codex"
+- "Wire Apple Notes Snapshot into Claude Code"
+- "Set up Apple Notes Snapshot for OpenClaw"
+- "Keep the builder wording honest for Apple Notes Snapshot"

--- a/skills/notes-snapshot-control-room/SKILL.md
+++ b/skills/notes-snapshot-control-room/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: notes-snapshot-control-room
+description: This skill should be used when the user asks to connect Apple Notes Snapshot to Codex, Claude Code, OpenClaw, or another local coding host, or when they need repo-scoped guidance that keeps the Apple Notes backup control-room identity and host-proof boundaries honest.
+---
+
+# Apple Notes Snapshot Control-Room
+
+Use this skill to connect Apple Notes Snapshot to local coding hosts without
+rewriting it into a hosted AI product.
+
+## Identity first
+
+- Apple Notes local-first backup control room for macOS
+- `notesctl` is the canonical human entrypoint
+- `AI Diagnose` is an advisory sidecar
+- `Local Web API` is token-gated and same-machine
+- `MCP` is stdio-first and read-only-first
+
+## Preflight before attach claims
+
+Do not treat host registration as proof by itself.
+
+Verify:
+
+1. `./notesctl run --no-status`
+2. `./notesctl verify`
+3. `./notesctl doctor --json`
+4. `./notesctl status --json`
+
+If those fail, classify the issue as local snapshot preflight, not an MCP
+transport bug.
+
+## Distribution boundary
+
+- Repo-owned starter packs and local marketplaces are wiring kits.
+- They are not the same thing as official public directory listings.
+- A fresh named-host attach proof on one machine does not become a universal
+  proof for every machine or every host build.
+
+## Best-fit use cases
+
+- Repo-scoped guidance for Codex, Claude Code, OpenClaw, or another local host
+- Public skill distribution through an OpenHands or ClawHub-style skill lane
+- Public-facing docs or README edits that must keep builder wording honest
+
+## Do not overclaim
+
+- Do not reposition Apple Notes Snapshot as a hosted agent platform.
+- Do not claim official marketplace or directory listing unless it truly landed.
+- Do not collapse repo-side proof, current-host proof, and public registry
+  publication into one sentence.


### PR DESCRIPTION
## Summary
- add a public `notes-snapshot-control-room` skill under `skills/`
- include a README for discoverability and human-facing usage notes
- register the skill in `marketplaces/default.json`

## Why
This adds a reusable public skill for keeping Apple Notes Snapshot host integrations truthful without overstating product scope, attach proof, or marketplace status.

## Validation
- `uv sync --group test`
- `uv run pytest -q tests/test_skills_have_readme.py tests/test_sdk_loading.py`
