### PR TITLE
[codex] add Apple Notes public skills

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -279,27 +279,29 @@
         {
             "name": "notes-snapshot-control-room",
             "source": "./notes-snapshot-control-room",
-            "description": "Apple Notes local-first backup control-room guidance for macOS, including local preflight, truthful attach boundaries, and stdio-first MCP positioning.",
+            "description": "Teach agents how to prove Apple Notes Snapshot's local control room, wire the `notesctl mcp` lane, separate AI Diagnose / Local Web API / MCP, and keep attach claims truthful.",
             "category": "productivity",
             "keywords": [
                 "apple-notes",
                 "backup",
                 "macos",
                 "mcp",
-                "local-first"
+                "local-first",
+                "notesctl"
             ]
         },
         {
             "name": "notestorelab-case-review",
             "source": "./notestorelab-case-review",
-            "description": "Copy-first Apple Notes case review guidance for NoteStore Lab, including bounded case-root review, derived-artifact-first triage, and local stdio MCP usage.",
+            "description": "Teach agents how to install NoteStore Lab's local MCP lane, prove the public-safe workflow on demo artifacts, and review one Apple Notes case root with bounded evidence-backed prompts.",
             "category": "productivity",
             "keywords": [
                 "apple-notes",
                 "forensics",
                 "incident-response",
                 "mcp",
-                "local-first"
+                "local-first",
+                "notes-recovery-mcp"
             ]
         },
         {

--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -279,7 +279,7 @@
         {
             "name": "notes-snapshot-control-room",
             "source": "./notes-snapshot-control-room",
-            "description": "Teach agents how to prove Apple Notes Snapshot's local control room, wire the `notesctl mcp` lane, separate AI Diagnose / Local Web API / MCP, and keep attach claims truthful.",
+            "description": "Teach agents how to acquire `notesctl`, prove Apple Notes Snapshot's local control room, wire the `notesctl mcp` lane, confirm the post-attach tools/resources, separate AI Diagnose / Local Web API / MCP, and keep attach claims truthful.",
             "category": "productivity",
             "keywords": [
                 "apple-notes",
@@ -293,7 +293,7 @@
         {
             "name": "notestorelab-case-review",
             "source": "./notestorelab-case-review",
-            "description": "Teach agents how to install NoteStore Lab's local MCP lane, prove the public-safe workflow on demo artifacts, and review one Apple Notes case root with bounded evidence-backed prompts.",
+            "description": "Teach agents how to install NoteStore Lab's local MCP lane, prove the public-safe workflow on demo artifacts, understand the exact case-review resources/tools, and review one Apple Notes case root with bounded evidence-backed prompts.",
             "category": "productivity",
             "keywords": [
                 "apple-notes",

--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -277,6 +277,32 @@
             ]
         },
         {
+            "name": "notes-snapshot-control-room",
+            "source": "./notes-snapshot-control-room",
+            "description": "Apple Notes local-first backup control-room guidance for macOS, including local preflight, truthful attach boundaries, and stdio-first MCP positioning.",
+            "category": "productivity",
+            "keywords": [
+                "apple-notes",
+                "backup",
+                "macos",
+                "mcp",
+                "local-first"
+            ]
+        },
+        {
+            "name": "notestorelab-case-review",
+            "source": "./notestorelab-case-review",
+            "description": "Copy-first Apple Notes case review guidance for NoteStore Lab, including bounded case-root review, derived-artifact-first triage, and local stdio MCP usage.",
+            "category": "productivity",
+            "keywords": [
+                "apple-notes",
+                "forensics",
+                "incident-response",
+                "mcp",
+                "local-first"
+            ]
+        },
+        {
             "name": "npm",
             "source": "./npm",
             "description": "Handle npm package installation in non-interactive environments by piping confirmations. Use when installing Node.js packages that require user confirmation prompts.",

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -3,15 +3,33 @@
 OpenHands skill for the Apple Notes Snapshot local-first backup control room on
 macOS.
 
+## What this skill teaches an agent
+
+- how to prove the operator lane before touching builder surfaces
+- how to wire `notesctl mcp` into a local host
+- how to separate AI Diagnose, Local Web API, and MCP into honest lanes
+- how to talk about attach proof without overstating what is universal
+
+## First-success path
+
+1. Read `SKILL.md`
+2. Open `references/install-and-attach.md`
+3. Run the proof path from `references/usage-and-proof.md`
+4. Only then attach the MCP lane or explain host-specific boundaries
+
+## Demo / proof links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-snapshot/
+- Quickstart: https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/
+- Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
+- MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
+- For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+
 ## Best fit
 
 - operators who want a calmer Apple Notes backup loop on their own Mac
 - repo-scoped guidance for hosts that consume a stdio-first MCP server
 - public skill-folder distribution lanes that need an honest control-room story
-
-## Source repository
-
-- https://github.com/xiaojiou176-open/apple-notes-snapshot
 
 ## What this skill does not claim
 

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -1,0 +1,20 @@
+# Apple Notes Snapshot Control-Room
+
+OpenHands skill for the Apple Notes Snapshot local-first backup control room on
+macOS.
+
+## Best fit
+
+- operators who want a calmer Apple Notes backup loop on their own Mac
+- repo-scoped guidance for hosts that consume a stdio-first MCP server
+- public skill-folder distribution lanes that need an honest control-room story
+
+## Source repository
+
+- https://github.com/xiaojiou176-open/apple-notes-snapshot
+
+## What this skill does not claim
+
+- no hosted runtime or Docker lane for the full product
+- no universal attach proof on every machine
+- no official marketplace listing unless a host-side read-back confirms it

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -47,7 +47,7 @@ backup control room.
 
 ## Best fit
 
-- operators who want a calmer Apple Notes backup loop on their own Mac
+- operators who want a bounded Apple Notes backup loop on their own Mac
 - repo-scoped guidance for hosts that consume a stdio-first MCP server
 - public skill-folder distribution lanes that need an honest control-room story
 

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -5,6 +5,7 @@ macOS.
 
 ## What this skill teaches an agent
 
+- how to acquire `notesctl` from a public checkout or reuse an existing one
 - how to prove the operator lane before touching builder surfaces
 - how to wire `notesctl mcp` into a local host
 - how to separate AI Diagnose, Local Web API, and MCP into honest lanes
@@ -14,7 +15,8 @@ macOS.
 
 1. Read `SKILL.md`
 2. Open `references/install-and-attach.md`
-3. Run the proof path from `references/usage-and-proof.md`
+3. Acquire `notesctl`, then run the proof path from
+   `references/usage-and-proof.md`
 4. Only then attach the MCP lane or explain host-specific boundaries
 
 ## Demo / proof links
@@ -24,6 +26,24 @@ macOS.
 - Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
 - MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
 - For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+
+## Visual demo
+
+![Apple Notes Snapshot first-success run flow](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-snapshot/main/assets/readme/run-flow.gif)
+
+- Quick visual proof:
+  the skill now points to a concrete run-flow demo, not just prose-only setup
+  instructions.
+
+## MCP capability surface
+
+- Post-attach checks:
+  `get_status`, `run_doctor`, `verify_freshness`, `get_log_health`,
+  `list_recent_runs`, and `get_access_policy`
+- First resource to read back:
+  `notes-snapshot://recent-runs`
+- Boundary:
+  local stdio only, read-only-first tools/resources, and no hosted runtime
 
 ## Best fit
 

--- a/skills/notes-snapshot-control-room/README.md
+++ b/skills/notes-snapshot-control-room/README.md
@@ -1,7 +1,7 @@
 # Apple Notes Snapshot Control-Room
 
-OpenHands skill for the Apple Notes Snapshot local-first backup control room on
-macOS.
+This folder is the public skill packet for Apple Notes Snapshot's local-first
+backup control room.
 
 ## What this skill teaches an agent
 
@@ -56,3 +56,26 @@ macOS.
 - no hosted runtime or Docker lane for the full product
 - no universal attach proof on every machine
 - no official marketplace listing unless a host-side read-back confirms it
+
+## What this packet includes
+
+- `SKILL.md`
+  - the agent-facing workflow entry
+- `README.md`
+  - the human-facing packet overview
+- `manifest.yaml`
+  - registry-style metadata for host skill registries
+- `references/README.md`
+  - the local index for every supporting file
+- `references/INSTALL.md`
+  - install and host wiring guidance
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `references/CAPABILITIES.md`
+  - the MCP capability map and safe-first order
+- `references/DEMO.md`
+  - the first-success walkthrough and expected output shape
+- `references/TROUBLESHOOTING.md`
+  - the first places to check when preflight or attach fails

--- a/skills/notes-snapshot-control-room/SKILL.md
+++ b/skills/notes-snapshot-control-room/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notes-snapshot-control-room
 description: This skill should be used when the user asks to "connect Apple Notes Snapshot to a host", "run notesctl mcp", "diagnose why Apple Notes Snapshot failed to attach", "separate AI Diagnose from MCP", or "verify the control-room proof path". It teaches local preflight, MCP wiring, capability boundaries, and proof-first usage without turning the repo into a hosted platform.
-version: 1.0.1
+version: 1.0.2
 triggers:
   - notesctl mcp
   - apple notes snapshot
@@ -19,6 +19,8 @@ rewriting it into a hosted AI platform or a generic assistant product.
 
 ## What this skill teaches
 
+- how to acquire `notesctl` from a public checkout when the host does not
+  already have it
 - how to prove the local control room before touching builder surfaces
 - how to wire `notesctl mcp` into a host without pretending there is a remote
   service
@@ -36,16 +38,27 @@ rewriting it into a hosted AI platform or a generic assistant product.
 
 ## First-success flow
 
-1. Prove the operator lane first:
+1. Acquire `notesctl` first using `references/install-and-attach.md`.
+2. Prove the operator lane first:
    - `./notesctl run --no-status`
    - `./notesctl install --minutes 30 --load`
    - `./notesctl verify`
    - `./notesctl doctor`
-2. Only after local state exists, attach the builder lane:
+3. Only after local state exists, attach the builder lane:
    - `./notesctl ai-diagnose`
    - `./notesctl web`
    - `./notesctl mcp`
-3. Keep host proof separate from repo proof.
+4. Keep host proof separate from repo proof.
+
+## MCP capability surface
+
+- post-attach host checks should see `get_status`, `run_doctor`,
+  `verify_freshness`, `get_log_health`, `list_recent_runs`, and
+  `get_access_policy`
+- the repo also documents the `notes-snapshot://recent-runs` resource as a
+  first read-back surface
+- boundary:
+  local stdio only, read-only-first tools/resources, and no hosted runtime
 
 ## Preflight before any attach claim
 

--- a/skills/notes-snapshot-control-room/SKILL.md
+++ b/skills/notes-snapshot-control-room/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: notes-snapshot-control-room
-description: Use this public skill when you want a repo-scoped Apple Notes Snapshot guide that keeps the control-room identity first, requires local preflight before attach claims, and separates official listing claims from repo-owned starter packs, local marketplaces, and host-specific proof.
-version: 1.0.0
+description: This skill should be used when the user asks to "connect Apple Notes Snapshot to a host", "run notesctl mcp", "diagnose why Apple Notes Snapshot failed to attach", "separate AI Diagnose from MCP", or "verify the control-room proof path". It teaches local preflight, MCP wiring, capability boundaries, and proof-first usage without turning the repo into a hosted platform.
+version: 1.0.1
+triggers:
+  - notesctl mcp
+  - apple notes snapshot
+  - ai diagnose
+  - local web api
+  - attach proof
 ---
 
 # Apple Notes Snapshot Control-Room
@@ -11,6 +17,15 @@ version: 1.0.0
 Help a host, plugin, or collaborator consume Apple Notes Snapshot without
 rewriting it into a hosted AI platform or a generic assistant product.
 
+## What this skill teaches
+
+- how to prove the local control room before touching builder surfaces
+- how to wire `notesctl mcp` into a host without pretending there is a remote
+  service
+- how to separate AI Diagnose, Local Web API, and MCP into three different
+  lanes
+- how to talk about attach proof honestly
+
 ## Keep this identity first
 
 - Apple Notes local-first backup control room for macOS
@@ -18,6 +33,19 @@ rewriting it into a hosted AI platform or a generic assistant product.
 - `AI Diagnose` is an advisory sidecar
 - `Local Web API` is token-gated and same-machine
 - `MCP` is stdio-first and read-only-first
+
+## First-success flow
+
+1. Prove the operator lane first:
+   - `./notesctl run --no-status`
+   - `./notesctl install --minutes 30 --load`
+   - `./notesctl verify`
+   - `./notesctl doctor`
+2. Only after local state exists, attach the builder lane:
+   - `./notesctl ai-diagnose`
+   - `./notesctl web`
+   - `./notesctl mcp`
+3. Keep host proof separate from repo proof.
 
 ## Preflight before any attach claim
 
@@ -39,12 +67,12 @@ If those fail, call it a local snapshot preflight problem, not an MCP bug.
 - A tagged `v0.1.12` named-host attach-proof trail on one machine does not become a universal
   proof for every host build or every machine.
 
-## Best-fit use cases
+## Example prompts
 
-- Repo-scoped guidance for Codex, Claude Code, OpenClaw, or another local host
-- Public skill distribution through a ClawHub-style listing or another
-  skill-folder distribution lane
-- Public-facing docs or README edits that must keep builder wording honest
+- "Wire Apple Notes Snapshot MCP into this host and tell me whether the blocker is local preflight or MCP configuration."
+- "Explain the difference between AI Diagnose, Local Web API, and MCP in Apple Notes Snapshot."
+- "Show me the shortest proof path from first run to MCP attach."
+- "Use the control-room skill to explain why a backup loop drifted."
 
 ## What this skill should not do
 
@@ -52,3 +80,8 @@ If those fail, call it a local snapshot preflight problem, not an MCP bug.
 - Do not claim official marketplace or directory listing unless it truly landed.
 - Do not collapse repo-side proof, current-host proof, and public registry
   publication into one sentence.
+
+## Read next
+
+- `references/install-and-attach.md`
+- `references/usage-and-proof.md`

--- a/skills/notes-snapshot-control-room/SKILL.md
+++ b/skills/notes-snapshot-control-room/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: notes-snapshot-control-room
+description: Use this public skill when you want a repo-scoped Apple Notes Snapshot guide that keeps the control-room identity first, requires local preflight before attach claims, and separates official listing claims from repo-owned starter packs, local marketplaces, and host-specific proof.
+version: 1.0.0
+---
+
+# Apple Notes Snapshot Control-Room
+
+## Purpose
+
+Help a host, plugin, or collaborator consume Apple Notes Snapshot without
+rewriting it into a hosted AI platform or a generic assistant product.
+
+## Keep this identity first
+
+- Apple Notes local-first backup control room for macOS
+- `notesctl` is the canonical human entrypoint
+- `AI Diagnose` is an advisory sidecar
+- `Local Web API` is token-gated and same-machine
+- `MCP` is stdio-first and read-only-first
+
+## Preflight before any attach claim
+
+Do not treat host registration as proof by itself.
+
+Verify:
+
+1. `./notesctl run --no-status`
+2. `./notesctl verify`
+3. `./notesctl doctor --json`
+4. `./notesctl status --json`
+
+If those fail, call it a local snapshot preflight problem, not an MCP bug.
+
+## Truthful distribution boundary
+
+- Repo-owned starter packs and local marketplaces are public-ready wiring kits.
+- They are not the same thing as official public directory listing.
+- A tagged `v0.1.12` named-host attach-proof trail on one machine does not become a universal
+  proof for every host build or every machine.
+
+## Best-fit use cases
+
+- Repo-scoped guidance for Codex, Claude Code, OpenClaw, or another local host
+- Public skill distribution through a ClawHub-style listing or another
+  skill-folder distribution lane
+- Public-facing docs or README edits that must keep builder wording honest
+
+## What this skill should not do
+
+- Do not reposition Apple Notes Snapshot as a hosted agent platform.
+- Do not claim official marketplace or directory listing unless it truly landed.
+- Do not collapse repo-side proof, current-host proof, and public registry
+  publication into one sentence.

--- a/skills/notes-snapshot-control-room/SKILL.md
+++ b/skills/notes-snapshot-control-room/SKILL.md
@@ -38,7 +38,7 @@ rewriting it into a hosted AI platform or a generic assistant product.
 
 ## First-success flow
 
-1. Acquire `notesctl` first using `references/install-and-attach.md`.
+1. Acquire `notesctl` first using `references/INSTALL.md`.
 2. Prove the operator lane first:
    - `./notesctl run --no-status`
    - `./notesctl install --minutes 30 --load`
@@ -87,6 +87,13 @@ If those fail, call it a local snapshot preflight problem, not an MCP bug.
 - "Show me the shortest proof path from first run to MCP attach."
 - "Use the control-room skill to explain why a backup loop drifted."
 
+## Best-fit use cases
+
+- Repo-scoped guidance for Codex, Claude Code, OpenClaw, or another local host
+- Public skill distribution through a ClawHub-style listing or another
+  skill-folder distribution lane
+- Public-facing docs or README edits that must keep builder wording honest
+
 ## What this skill should not do
 
 - Do not reposition Apple Notes Snapshot as a hosted agent platform.
@@ -96,5 +103,10 @@ If those fail, call it a local snapshot preflight problem, not an MCP bug.
 
 ## Read next
 
-- `references/install-and-attach.md`
-- `references/usage-and-proof.md`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`

--- a/skills/notes-snapshot-control-room/manifest.yaml
+++ b/skills/notes-snapshot-control-room/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: notes-snapshot-control-room
+  display_name: Apple Notes Snapshot Control-Room
+  version: 1.0.2
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/notes-snapshot-control-room
+    submit_via: clawhub publish <repo-root>/examples/public-skills/notes-snapshot-control-room --slug notes-snapshot-control-room --name "Apple Notes Snapshot Control-Room" --version 1.0.2 --tags apple-notes,local-first,backup,mcp
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/150
+    submit_via: submit this folder as skills/notes-snapshot-control-room/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Apple Notes local-first backup control room for macOS
+  attach_proof_baseline: Tagged v0.1.12 named-host attach proof is the last repo-owned baseline; other machines still need local verification.
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands skill listing exists yet
+    - No hosted runtime or Docker lane for the full product
+    - No universal attach proof on every machine
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/TROUBLESHOOTING.md

--- a/skills/notes-snapshot-control-room/references/CAPABILITIES.md
+++ b/skills/notes-snapshot-control-room/references/CAPABILITIES.md
@@ -1,0 +1,24 @@
+# Apple Notes Snapshot MCP Capabilities
+
+These are the MCP tools and resources this packet expects the host to expose.
+
+## Safe-first tools
+
+- `get_status`
+- `run_doctor`
+- `verify_freshness`
+- `get_log_health`
+- `list_recent_runs`
+- `get_access_policy`
+
+## First resource to read back
+
+- `notes-snapshot://recent-runs`
+
+## Best default order
+
+1. `get_status`
+2. `verify_freshness`
+3. `run_doctor`
+4. `list_recent_runs`
+5. `get_access_policy`

--- a/skills/notes-snapshot-control-room/references/DEMO.md
+++ b/skills/notes-snapshot-control-room/references/DEMO.md
@@ -1,0 +1,33 @@
+# Usage And Proof
+
+Use this reference when the reviewer asks:
+
+- what does the skill help an agent do in practice?
+- where is the public proof?
+- how do I test it without guessing?
+
+## First-success path
+
+```bash
+./notesctl run --no-status
+./notesctl install --minutes 30 --load
+./notesctl verify
+./notesctl doctor
+./notesctl status --full
+```
+
+Then, if the local state exists, move into builder surfaces:
+
+```bash
+./notesctl ai-diagnose
+./notesctl web
+./notesctl mcp
+```
+
+## Proof / demo links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-snapshot/
+- Quickstart: https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/
+- Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
+- MCP provider guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
+- For Agents overview: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/

--- a/skills/notes-snapshot-control-room/references/INSTALL.md
+++ b/skills/notes-snapshot-control-room/references/INSTALL.md
@@ -1,0 +1,37 @@
+# Install And Attach
+
+Use this reference when the agent or reviewer asks:
+
+- how do I install the MCP lane?
+- what exact command should the host run?
+- what has to be proven before attach claims?
+
+## Get `notesctl` first
+
+If the host does not already have a checkout with `notesctl`, start from a
+public repo checkout:
+
+```bash
+git clone --depth 1 --branch v0.1.12 \
+  https://github.com/xiaojiou176-open/apple-notes-snapshot.git
+cd apple-notes-snapshot
+```
+
+## Minimum operator proof
+
+Before any host attach claim, prove the operator lane first:
+
+```bash
+./notesctl run --no-status
+./notesctl install --minutes 30 --load
+./notesctl verify
+./notesctl doctor
+```
+
+## MCP launch contract
+
+The canonical MCP launch command is:
+
+```bash
+./notesctl mcp
+```

--- a/skills/notes-snapshot-control-room/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/notes-snapshot-control-room/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,10 @@
+{
+  "mcp": {
+    "servers": {
+      "apple-notes-snapshot": {
+        "command": "/ABSOLUTE/PATH/TO/apple-notes-snapshot/notesctl",
+        "args": ["mcp"]
+      }
+    }
+  }
+}

--- a/skills/notes-snapshot-control-room/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/notes-snapshot-control-room/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "apple-notes-snapshot": {
+      "command": "/ABSOLUTE/PATH/TO/apple-notes-snapshot/notesctl",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/skills/notes-snapshot-control-room/references/README.md
+++ b/skills/notes-snapshot-control-room/references/README.md
@@ -1,0 +1,19 @@
+# Apple Notes Snapshot Skill References
+
+This directory keeps the practical material that a reviewer or agent needs
+without depending on repo-root docs.
+
+## Included references
+
+- `INSTALL.md`
+  - install the control-room tool and wire it into a host
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - the MCP capability map and safe-first order
+- `DEMO.md`
+  - the first-success walkthrough and expected output shape
+- `TROUBLESHOOTING.md`
+  - the first places to check when preflight or attach fails

--- a/skills/notes-snapshot-control-room/references/TROUBLESHOOTING.md
+++ b/skills/notes-snapshot-control-room/references/TROUBLESHOOTING.md
@@ -1,0 +1,27 @@
+# Apple Notes Snapshot Troubleshooting
+
+Use this page when the packet looks right on paper but the first local proof or
+attach still fails.
+
+## 1. Operator preflight fails
+
+If any of these fail:
+
+- `./notesctl run --no-status`
+- `./notesctl verify`
+- `./notesctl doctor`
+
+call it a local snapshot preflight problem, not an MCP bug.
+
+## 2. MCP attach fails
+
+Check these first:
+
+- the `notesctl` path in the host config is correct
+- the local proof path already passed
+- the host is really launching `notesctl mcp`, not another surface
+
+## 3. The reviewer wants stronger proof
+
+Point them at the proof links from `DEMO.md` and keep repo proof separate from
+host proof. Do not claim universal attach success on every machine.

--- a/skills/notes-snapshot-control-room/references/install-and-attach.md
+++ b/skills/notes-snapshot-control-room/references/install-and-attach.md
@@ -3,6 +3,20 @@
 Use this reference when the user asks how to install or connect Apple Notes
 Snapshot to an MCP-aware host.
 
+## Get `notesctl` first
+
+If the host does not already have a checkout with `notesctl`, start from a
+public repo checkout:
+
+```bash
+git clone --depth 1 --branch v0.1.12 \
+  https://github.com/xiaojiou176-open/apple-notes-snapshot.git
+cd apple-notes-snapshot
+```
+
+If you want current-main behavior instead of the last tagged proof baseline,
+clone without `--branch v0.1.12`.
+
 ## Minimum operator proof
 
 ```bash
@@ -34,8 +48,21 @@ Generic host config:
 }
 ```
 
+Replace `/absolute/path/to/notesctl` with the path from the checkout you just
+created, for example `/path/to/apple-notes-snapshot/notesctl`.
+
 ## Builder surfaces this skill teaches
 
 - AI Diagnose: `./notesctl ai-diagnose`
 - Local Web API: `./notesctl web`
 - MCP Provider: `./notesctl mcp`
+
+## MCP capability surface after attach
+
+- `get_status`
+- `run_doctor`
+- `verify_freshness`
+- `get_log_health`
+- `list_recent_runs`
+- `get_access_policy`
+- `notes-snapshot://recent-runs`

--- a/skills/notes-snapshot-control-room/references/install-and-attach.md
+++ b/skills/notes-snapshot-control-room/references/install-and-attach.md
@@ -1,0 +1,41 @@
+# Install And Attach
+
+Use this reference when the user asks how to install or connect Apple Notes
+Snapshot to an MCP-aware host.
+
+## Minimum operator proof
+
+```bash
+./notesctl run --no-status
+./notesctl install --minutes 30 --load
+./notesctl verify
+./notesctl doctor
+```
+
+If those commands fail, call it a local snapshot preflight problem, not an MCP
+bug.
+
+## MCP launch contract
+
+```bash
+./notesctl mcp
+```
+
+Generic host config:
+
+```json
+{
+  "mcpServers": {
+    "apple-notes-snapshot": {
+      "command": "/absolute/path/to/notesctl",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## Builder surfaces this skill teaches
+
+- AI Diagnose: `./notesctl ai-diagnose`
+- Local Web API: `./notesctl web`
+- MCP Provider: `./notesctl mcp`

--- a/skills/notes-snapshot-control-room/references/install-and-attach.md
+++ b/skills/notes-snapshot-control-room/references/install-and-attach.md
@@ -1,7 +1,10 @@
 # Install And Attach
 
-Use this reference when the user asks how to install or connect Apple Notes
-Snapshot to an MCP-aware host.
+Use this reference when the agent or reviewer asks:
+
+- how do I install the MCP lane?
+- what exact command should the host run?
+- what has to be proven before attach claims?
 
 ## Get `notesctl` first
 
@@ -19,6 +22,8 @@ clone without `--branch v0.1.12`.
 
 ## Minimum operator proof
 
+Before any host attach claim, prove the operator lane first:
+
 ```bash
 ./notesctl run --no-status
 ./notesctl install --minutes 30 --load
@@ -31,11 +36,13 @@ bug.
 
 ## MCP launch contract
 
+The canonical MCP launch command is:
+
 ```bash
 ./notesctl mcp
 ```
 
-Generic host config:
+For a generic MCP host that expects `command` plus `args`, use:
 
 ```json
 {
@@ -48,10 +55,14 @@ Generic host config:
 }
 ```
 
-Replace `/absolute/path/to/notesctl` with the path from the checkout you just
-created, for example `/path/to/apple-notes-snapshot/notesctl`.
+Replace `/absolute/path/to/notesctl` with the path for the local checkout.
 
-## Builder surfaces this skill teaches
+For example:
+
+- `/absolute/path/to/apple-notes-snapshot/notesctl`
+- `/path/to/apple-notes-snapshot/notesctl`
+
+## Builder surfaces that pair with this skill
 
 - AI Diagnose: `./notesctl ai-diagnose`
 - Local Web API: `./notesctl web`
@@ -66,3 +77,17 @@ created, for example `/path/to/apple-notes-snapshot/notesctl`.
 - `list_recent_runs`
 - `get_access_policy`
 - `notes-snapshot://recent-runs`
+
+These three surfaces are not interchangeable:
+
+- AI Diagnose = explanation layer
+- Local Web API = token-gated same-machine browser/API lane
+- MCP = read-only-first stdio host lane
+
+## Capability boundary
+
+This skill teaches local control-room attach and proof. It does **not** imply:
+
+- a hosted runtime
+- a Docker lane for the full product
+- a universal attach proof on every machine

--- a/skills/notes-snapshot-control-room/references/usage-and-proof.md
+++ b/skills/notes-snapshot-control-room/references/usage-and-proof.md
@@ -5,6 +5,16 @@ practice.
 
 ## First-success path
 
+Acquire the tool first if needed:
+
+```bash
+git clone --depth 1 --branch v0.1.12 \
+  https://github.com/xiaojiou176-open/apple-notes-snapshot.git
+cd apple-notes-snapshot
+```
+
+Then run the shortest truthful local proof path:
+
 ```bash
 ./notesctl run --no-status
 ./notesctl install --minutes 30 --load
@@ -21,6 +31,17 @@ Then move into builder surfaces:
 ./notesctl mcp
 ```
 
+## MCP capability surface after attach
+
+- Tools:
+  `get_status`, `run_doctor`, `verify_freshness`, `get_log_health`,
+  `list_recent_runs`, and `get_access_policy`
+- Resource:
+  `notes-snapshot://recent-runs`
+- Boundary:
+  the MCP lane is local stdio, read-only-first, and backed by the same
+  repo-owned state as the operator lane
+
 ## Example prompts
 
 - "Is this Apple Notes Snapshot problem a local preflight failure or an MCP attach failure?"
@@ -34,3 +55,7 @@ Then move into builder surfaces:
 - Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
 - MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
 - For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+
+## Visual demo
+
+![Apple Notes Snapshot run flow](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-snapshot/main/assets/readme/run-flow.gif)

--- a/skills/notes-snapshot-control-room/references/usage-and-proof.md
+++ b/skills/notes-snapshot-control-room/references/usage-and-proof.md
@@ -1,0 +1,36 @@
+# Usage And Proof
+
+Use this reference when the reviewer asks what the skill helps an agent do in
+practice.
+
+## First-success path
+
+```bash
+./notesctl run --no-status
+./notesctl install --minutes 30 --load
+./notesctl verify
+./notesctl doctor
+./notesctl status --full
+```
+
+Then move into builder surfaces:
+
+```bash
+./notesctl ai-diagnose
+./notesctl web
+./notesctl mcp
+```
+
+## Example prompts
+
+- "Is this Apple Notes Snapshot problem a local preflight failure or an MCP attach failure?"
+- "Explain the current backup loop status using the control-room proof path."
+- "Which surface should I use here: AI Diagnose, Local Web API, or MCP?"
+
+## Public links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-snapshot/
+- Quickstart: https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/
+- Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
+- MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
+- For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/

--- a/skills/notes-snapshot-control-room/references/usage-and-proof.md
+++ b/skills/notes-snapshot-control-room/references/usage-and-proof.md
@@ -1,7 +1,10 @@
 # Usage And Proof
 
-Use this reference when the reviewer asks what the skill helps an agent do in
-practice.
+Use this reference when the reviewer asks:
+
+- what does the skill help an agent do in practice?
+- where is the public proof?
+- how do I test it without guessing?
 
 ## First-success path
 
@@ -13,7 +16,7 @@ git clone --depth 1 --branch v0.1.12 \
 cd apple-notes-snapshot
 ```
 
-Then run the shortest truthful local proof path:
+Then run the shortest truthful path:
 
 ```bash
 ./notesctl run --no-status
@@ -23,7 +26,7 @@ Then run the shortest truthful local proof path:
 ./notesctl status --full
 ```
 
-Then move into builder surfaces:
+Then, if the local state exists, move into builder surfaces:
 
 ```bash
 ./notesctl ai-diagnose
@@ -46,16 +49,26 @@ Then move into builder surfaces:
 
 - "Is this Apple Notes Snapshot problem a local preflight failure or an MCP attach failure?"
 - "Explain the current backup loop status using the control-room proof path."
+- "Walk me from operator proof to builder attach without overstating what is officially listed."
 - "Which surface should I use here: AI Diagnose, Local Web API, or MCP?"
 
-## Public links
+## Proof / demo links
 
 - Landing: https://xiaojiou176-open.github.io/apple-notes-snapshot/
 - Quickstart: https://xiaojiou176-open.github.io/apple-notes-snapshot/quickstart/
 - Proof page: https://xiaojiou176-open.github.io/apple-notes-snapshot/proof/
-- MCP guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
-- For Agents: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+- MCP provider guide: https://xiaojiou176-open.github.io/apple-notes-snapshot/mcp/
+- For Agents overview: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/
+- Public skills pack docs: https://xiaojiou176-open.github.io/apple-notes-snapshot/for-agents/public-skills/
 
 ## Visual demo
 
 ![Apple Notes Snapshot run flow](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-snapshot/main/assets/readme/run-flow.gif)
+
+## Reviewer one-liner
+
+If the reviewer asks "what does this skill teach?", answer:
+
+> It teaches an agent how to prove Apple Notes Snapshot's local control room,
+> wire the `notesctl mcp` lane, and separate repo proof, host proof, AI
+> Diagnose, Local Web API, and MCP into honest boundaries.

--- a/skills/notestorelab-case-review/README.md
+++ b/skills/notestorelab-case-review/README.md
@@ -1,31 +1,56 @@
-# NoteStore Lab Case Review
+# NoteStore Lab Case Review Public Skill
 
-OpenHands skill for reviewing one NoteStore Lab Apple Notes case root without
-turning the workflow into a hosted service.
+This folder is the OpenHands/extensions-friendly and ClawHub-style public skill
+packet for NoteStore Lab.
 
 ## What this skill teaches an agent
 
-- how to install or launch the NoteStore Lab MCP surface
-- how to prove the workflow on public-safe demo artifacts first
-- how to inspect one case root at a time using derived artifacts first
-- how to ask bounded, evidence-backed questions instead of guessing
-- what the MCP lane gives a host after attach: case-root listing, manifest and
-  artifact inspection, bounded case Q&A, and bounded verify/report/timeline or
-  public-safe-export workflows
+This is not just a label for Apple Notes. It teaches an agent five concrete
+things:
+
+1. how to install or launch the NoteStore Lab MCP surface
+2. how to prove the review flow on public-safe demo artifacts first
+3. how to review one copied case root without touching the live Notes store
+4. how to ask bounded questions from derived artifacts instead of guessing
+5. what the MCP lane gives a host after attach: case-root listing, manifest and
+   artifact inspection, bounded case Q&A, and bounded
+   verify/report/timeline/export workflows
+
+## What this packet includes
+
+- `SKILL.md`
+  - the concise skill entry point for progressive disclosure
+- `manifest.yaml`
+  - listing metadata for ClawHub-style publication
+- `references/README.md`
+  - the local index for every supporting file
+- `references/INSTALL.md`
+  - exact install and MCP wiring examples
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `references/CAPABILITIES.md`
+  - the read-mostly case-review tool surface
+- `references/DEMO.md`
+  - first-success flow, real prompts, and proof/demo links
+- `references/TROUBLESHOOTING.md`
+  - the first places to check when attach or case-root review fails
 
 ## First-success path
 
-1. Read `SKILL.md`
-2. Open `references/install-and-mcp.md`
-3. Run the public-safe proof flow from `references/usage-and-proof.md`
-4. Only after that, point the MCP command at one explicit case root
+If a reviewer wants to understand the skill quickly, use this order:
+
+1. read `SKILL.md`
+2. open `references/install-and-mcp.md`
+3. run the public-safe proof path from `references/usage-and-proof.md`
+4. inspect the public proof links before claiming anything is officially listed
 
 ## Demo / proof links
 
 - Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
 - Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
-- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
 
 ## Visual demo
@@ -47,16 +72,26 @@ turning the workflow into a hosted service.
   one explicit case root at a time, local stdio transport, and no live Notes
   store mutation path
 
-## Best fit
+## Best-fit hosts
 
-- copied-evidence Apple Notes investigations on macOS
-- one bounded case root at a time
-- derived-artifact-first AI review and case Q&A
-- local stdio MCP hosts that need the same review-safe surfaces as the CLI
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect a standalone folder
+- any MCP-aware host that can launch a local stdio server on one explicit case
+  root
 
-## What this skill does not claim
+## What this packet must not claim
 
-- no official OpenHands listing beyond this registry entry
-- no live Notes store access
-- no hosted or multi-tenant Notes recovery platform
-- no remote MCP deployment
+- no official OpenHands/extensions listing without fresh PR/read-back
+- no live ClawHub listing without fresh host-side read-back
+- no hosted Glama deployment, Docker catalog listing, or remote MCP lane
+- no direct mutation of the live Apple Notes store
+
+## Source of truth
+
+The canonical skill text still lives at:
+
+- `skills/notestorelab-case-review/SKILL.md`
+
+This folder is a public-facing derived packet. If the canonical skill changes,
+copy the updated `SKILL.md` here before publishing.

--- a/skills/notestorelab-case-review/README.md
+++ b/skills/notestorelab-case-review/README.md
@@ -9,6 +9,9 @@ turning the workflow into a hosted service.
 - how to prove the workflow on public-safe demo artifacts first
 - how to inspect one case root at a time using derived artifacts first
 - how to ask bounded, evidence-backed questions instead of guessing
+- what the MCP lane gives a host after attach: case-root listing, manifest and
+  artifact inspection, bounded case Q&A, and bounded verify/report/timeline or
+  public-safe-export workflows
 
 ## First-success path
 
@@ -24,6 +27,25 @@ turning the workflow into a hosted service.
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
 - Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+## Visual demo
+
+![NoteStore Lab public demo surface](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-forensics/main/assets/readme/hero-public-demo.png)
+
+- Quick visual proof: the public demo already shows the bounded review flow on
+  safe artifacts before a host ever points the MCP lane at a real copied case
+  root.
+
+## MCP capability surface
+
+- Read-only review lane:
+  `list_case_roots`, `inspect_case_manifest`, `select_case_evidence`,
+  `inspect_case_artifact`, and `ask_case`
+- Bounded workflows:
+  `run_verify`, `run_report`, `build_timeline`, and `public_safe_export`
+- Boundary:
+  one explicit case root at a time, local stdio transport, and no live Notes
+  store mutation path
 
 ## Best fit
 

--- a/skills/notestorelab-case-review/README.md
+++ b/skills/notestorelab-case-review/README.md
@@ -1,0 +1,22 @@
+# NoteStore Lab Case Review
+
+OpenHands skill for reviewing one NoteStore Lab Apple Notes case root without
+turning the workflow into a hosted service.
+
+## Best fit
+
+- copied-evidence Apple Notes investigations on macOS
+- one bounded case root at a time
+- derived-artifact-first AI review and case Q&A
+- local stdio MCP hosts that need the same review-safe surfaces as the CLI
+
+## Source repository
+
+- https://github.com/xiaojiou176-open/apple-notes-forensics
+
+## What this skill does not claim
+
+- no official OpenHands listing beyond this registry entry
+- no live Notes store access
+- no hosted or multi-tenant Notes recovery platform
+- no remote MCP deployment

--- a/skills/notestorelab-case-review/README.md
+++ b/skills/notestorelab-case-review/README.md
@@ -3,16 +3,34 @@
 OpenHands skill for reviewing one NoteStore Lab Apple Notes case root without
 turning the workflow into a hosted service.
 
+## What this skill teaches an agent
+
+- how to install or launch the NoteStore Lab MCP surface
+- how to prove the workflow on public-safe demo artifacts first
+- how to inspect one case root at a time using derived artifacts first
+- how to ask bounded, evidence-backed questions instead of guessing
+
+## First-success path
+
+1. Read `SKILL.md`
+2. Open `references/install-and-mcp.md`
+3. Run the public-safe proof flow from `references/usage-and-proof.md`
+4. Only after that, point the MCP command at one explicit case root
+
+## Demo / proof links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
+- Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
 ## Best fit
 
 - copied-evidence Apple Notes investigations on macOS
 - one bounded case root at a time
 - derived-artifact-first AI review and case Q&A
 - local stdio MCP hosts that need the same review-safe surfaces as the CLI
-
-## Source repository
-
-- https://github.com/xiaojiou176-open/apple-notes-forensics
 
 ## What this skill does not claim
 

--- a/skills/notestorelab-case-review/SKILL.md
+++ b/skills/notestorelab-case-review/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: notestorelab-case-review
+description: Guide one bounded NoteStore Lab case review without turning the repo into a hosted platform.
+---
+
+# NoteStore Lab Case Review
+
+Use this skill when an agent is reviewing one NoteStore Lab case root or the
+public-safe demo surface.
+
+## Product truth
+
+- Recovery is the main product.
+- AI and MCP are review layers, not the recovery engine.
+- Stay local, copy-first, and case-root-driven.
+- Prefer derived artifacts before raw copied evidence.
+- Do not treat the live Notes store as a target.
+- Do not describe this repo as a hosted or multi-tenant platform.
+
+## Preferred evidence order
+
+1. Read `review_index.md`.
+2. Read the verification preview and pipeline summary.
+3. Use `notes-recovery ask-case` for one bounded operator question.
+4. Use `notes-recovery case-diff` only when comparing two case roots.
+5. Use `notes-recovery public-safe-export` when you need a shareable bundle.
+
+## Bounded MCP entry
+
+```bash
+notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Proof path
+
+1. `notes-recovery demo`
+2. `notes-recovery ai-review --demo`
+3. `notes-recovery ask-case --demo --question "What should I inspect first?"`
+4. `notes-recovery doctor`
+
+## Truth language
+
+- Good: "repo-owned independent skill surface"
+- Good: "local copy-first case review skill"
+- Forbidden: "officially listed skill" without fresh host-side read-back
+- Forbidden: "hosted Notes recovery platform"

--- a/skills/notestorelab-case-review/SKILL.md
+++ b/skills/notestorelab-case-review/SKILL.md
@@ -1,12 +1,26 @@
 ---
 name: notestorelab-case-review
-description: Guide one bounded NoteStore Lab case review without turning the repo into a hosted platform.
+description: This skill should be used when the user asks to "review an Apple Notes case root", "set up NoteStore Lab MCP", "run notes-recovery-mcp", "ask one bounded question about a case", or "compare two NoteStore Lab case roots". It teaches install, first-success proof, and bounded case review without turning the repo into a hosted platform.
+triggers:
+  - apple notes recovery
+  - notes-recovery-mcp
+  - review_index
+  - ask-case
+  - case-diff
 ---
 
 # NoteStore Lab Case Review
 
-Use this skill when an agent is reviewing one NoteStore Lab case root or the
-public-safe demo surface.
+Use this skill when an agent needs to install, wire, or operate the NoteStore
+Lab review flow on one explicit case root or the public-safe demo surface.
+
+## What this skill teaches
+
+- how to prove the workflow shape on demo artifacts first
+- how to wire the local stdio MCP surface without pretending there is a hosted
+  service
+- how to inspect one case root at a time using derived artifacts first
+- how to ask bounded, evidence-backed questions instead of free-form guessing
 
 ## Product truth
 
@@ -16,6 +30,19 @@ public-safe demo surface.
 - Prefer derived artifacts before raw copied evidence.
 - Do not treat the live Notes store as a target.
 - Do not describe this repo as a hosted or multi-tenant platform.
+
+## First-success flow
+
+1. Install or launch the shipped surface using `references/install-and-mcp.md`.
+2. Run the public-safe proof path:
+   - `notes-recovery demo`
+   - `notes-recovery ai-review --demo`
+   - `notes-recovery ask-case --demo --question "What should I inspect first?"`
+   - `notes-recovery doctor`
+3. Only after the demo path works, point the MCP server at one explicit
+   `Notes_Forensics_<run_ts>` case root.
+4. Keep all reasoning on copied evidence and derived artifacts, not on the live
+   Notes store.
 
 ## Preferred evidence order
 
@@ -31,12 +58,12 @@ public-safe demo surface.
 notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 ```
 
-## Proof path
+## Example prompts
 
-1. `notes-recovery demo`
-2. `notes-recovery ai-review --demo`
-3. `notes-recovery ask-case --demo --question "What should I inspect first?"`
-4. `notes-recovery doctor`
+- "Review this NoteStore Lab case root and tell me which artifact to inspect first."
+- "Wire NoteStore Lab MCP to `./output/Notes_Forensics_2026-04-08_...` and summarize the review-safe surfaces."
+- "Compare these two case roots and tell me what changed at the manifest/review layer."
+- "Generate a safe sharing plan using public-safe export."
 
 ## Truth language
 
@@ -44,3 +71,8 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 - Good: "local copy-first case review skill"
 - Forbidden: "officially listed skill" without fresh host-side read-back
 - Forbidden: "hosted Notes recovery platform"
+
+## Read next
+
+- `references/install-and-mcp.md`
+- `references/usage-and-proof.md`

--- a/skills/notestorelab-case-review/SKILL.md
+++ b/skills/notestorelab-case-review/SKILL.md
@@ -42,7 +42,7 @@ Lab review flow on one explicit case root or the public-safe demo surface.
 
 ## First-success flow
 
-1. Install or launch the shipped surface using `references/install-and-mcp.md`.
+1. Install or launch the shipped surface using `references/INSTALL.md`.
 2. Run the public-safe proof path:
    - `notes-recovery demo`
    - `notes-recovery ai-review --demo`
@@ -72,7 +72,7 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 - "Review this NoteStore Lab case root and tell me which artifact to inspect first."
 - "Wire NoteStore Lab MCP to `./output/Notes_Forensics_2026-04-08_...` and summarize the review-safe surfaces."
 - "Compare these two case roots and tell me what changed at the manifest/review layer."
-- "Generate a safe sharing plan using public-safe export."
+- "Generate a public-safe export plan for this case without exposing raw copied evidence."
 
 ## Truth language
 
@@ -83,5 +83,10 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 
 ## Read next
 
-- `references/install-and-mcp.md`
-- `references/usage-and-proof.md`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`

--- a/skills/notestorelab-case-review/SKILL.md
+++ b/skills/notestorelab-case-review/SKILL.md
@@ -22,6 +22,15 @@ Lab review flow on one explicit case root or the public-safe demo surface.
 - how to inspect one case root at a time using derived artifacts first
 - how to ask bounded, evidence-backed questions instead of free-form guessing
 
+## MCP capability surface
+
+- read-only review surfaces: `list_case_roots`, `inspect_case_manifest`,
+  `select_case_evidence`, `inspect_case_artifact`, and `ask_case`
+- bounded workflows: `run_verify`, `run_report`, `build_timeline`, and
+  `public_safe_export`
+- one explicit case root at a time, local stdio only, with no live Notes store
+  access
+
 ## Product truth
 
 - Recovery is the main product.
@@ -29,7 +38,7 @@ Lab review flow on one explicit case root or the public-safe demo surface.
 - Stay local, copy-first, and case-root-driven.
 - Prefer derived artifacts before raw copied evidence.
 - Do not treat the live Notes store as a target.
-- Do not describe this repo as a hosted or multi-tenant platform.
+- Do not describe NoteStore Lab as a hosted or multi-tenant platform.
 
 ## First-success flow
 

--- a/skills/notestorelab-case-review/manifest.yaml
+++ b/skills/notestorelab-case-review/manifest.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: notestorelab-case-review
+  display_name: NoteStore Lab Case Review
+  version: 1.0.2
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/notestorelab-case-review
+    submit_via: clawhub publish . --slug notestorelab-case-review --name "NoteStore Lab Case Review" --version 1.0.2 --tags apple-notes,forensics,incident-response,mcp
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/150
+    submit_via: submit this folder as skills/notestorelab-case-review/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Copy-first Apple Notes case review skill for NoteStore Lab.
+  canonical_repo_version: 0.1.0.post1
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No hosted Glama deployment exists yet
+    - No live Docker MCP Catalog listing exists yet
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/install-and-mcp.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/usage-and-proof.md
+  - references/TROUBLESHOOTING.md

--- a/skills/notestorelab-case-review/references/CAPABILITIES.md
+++ b/skills/notestorelab-case-review/references/CAPABILITIES.md
@@ -1,0 +1,26 @@
+# NoteStore Lab MCP Capabilities
+
+This packet expects the local MCP surface to expose a bounded case-review lane.
+
+## Read-mostly review surfaces
+
+- `list_case_roots`
+- `inspect_case_manifest`
+- `select_case_evidence`
+- `inspect_case_artifact`
+- `ask_case`
+
+## Bounded workflows
+
+- `run_verify`
+- `run_report`
+- `build_timeline`
+- `public_safe_export`
+
+## Best default order
+
+1. list or choose one explicit case root
+2. inspect the manifest
+3. inspect derived artifacts
+4. ask one bounded question
+5. export only when the operator needs a shareable bundle

--- a/skills/notestorelab-case-review/references/DEMO.md
+++ b/skills/notestorelab-case-review/references/DEMO.md
@@ -1,0 +1,24 @@
+# Usage And Proof
+
+Use this reference when the reviewer asks:
+
+- what does the skill actually help an agent do?
+- how do I try it in a few minutes?
+- where is the public proof?
+
+## First-success path
+
+```bash
+notes-recovery demo
+notes-recovery ai-review --demo
+notes-recovery ask-case --demo --question "What should I inspect first?"
+notes-recovery doctor
+```
+
+## Public proof links
+
+- Landing page: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof page: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
+- Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases

--- a/skills/notestorelab-case-review/references/INSTALL.md
+++ b/skills/notestorelab-case-review/references/INSTALL.md
@@ -1,0 +1,23 @@
+# Install And MCP Wiring
+
+Use this reference when the agent or reviewer asks:
+
+- how do I install this?
+- what is the exact MCP command?
+- what should I point my host at?
+
+## Public package lane
+
+The current shipped package lane is PyPI:
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
+```
+
+If the host supports `uvx`, the shortest MCP launch path is:
+
+```bash
+uvx --from apple-notes-forensics==0.1.0.post1 \
+  notes-recovery-mcp \
+  --case-dir ./output/Notes_Forensics_<run_ts>
+```

--- a/skills/notestorelab-case-review/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/notestorelab-case-review/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,16 @@
+{
+  "mcp": {
+    "servers": {
+      "notestorelab": {
+        "command": "uvx",
+        "args": [
+          "--from",
+          "apple-notes-forensics==0.1.0.post1",
+          "notes-recovery-mcp",
+          "--case-dir",
+          "./output/Notes_Forensics_<run_ts>"
+        ]
+      }
+    }
+  }
+}

--- a/skills/notestorelab-case-review/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/notestorelab-case-review/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "notestorelab": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "apple-notes-forensics==0.1.0.post1",
+        "notes-recovery-mcp",
+        "--case-dir",
+        "./output/Notes_Forensics_<run_ts>"
+      ]
+    }
+  }
+}

--- a/skills/notestorelab-case-review/references/README.md
+++ b/skills/notestorelab-case-review/references/README.md
@@ -1,0 +1,19 @@
+# NoteStore Lab Skill References
+
+This directory keeps the practical material that a reviewer or agent needs
+without depending on repo-root docs.
+
+## Included references
+
+- `INSTALL.md`
+  - install the MCP surface and wire it into a host
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - the read-mostly case-review tool surface and safe-first order
+- `DEMO.md`
+  - the first-success walkthrough and proof links
+- `TROUBLESHOOTING.md`
+  - the first places to check when attach or case-root review fails

--- a/skills/notestorelab-case-review/references/TROUBLESHOOTING.md
+++ b/skills/notestorelab-case-review/references/TROUBLESHOOTING.md
@@ -1,0 +1,31 @@
+# NoteStore Lab Troubleshooting
+
+Use this page when the packet looks right on paper but the first attach or
+case-root review still fails.
+
+## 1. The MCP server does not launch
+
+Check these first:
+
+- the package version in `INSTALL.md` still resolves
+- the host config matches the command and args in the JSON snippets
+- the case-dir path points at a real copied case root
+
+## 2. The demo path fails
+
+Start with the public-safe demo path from `DEMO.md`. If that already fails, do
+not blame the case-root path yet.
+
+## 3. The case-root review fails
+
+Re-check:
+
+- the selected case root exists
+- the workflow is staying on copied evidence and derived artifacts
+- the request is still bounded to one explicit case root
+
+## 4. Boundary reminder
+
+This packet is for local, copy-first case review. It does not claim a hosted
+Notes recovery service, a live marketplace listing, or a mutation path into the
+live Apple Notes store.

--- a/skills/notestorelab-case-review/references/install-and-mcp.md
+++ b/skills/notestorelab-case-review/references/install-and-mcp.md
@@ -1,0 +1,52 @@
+# Install And MCP Wiring
+
+Use this reference when the user asks how to install or connect NoteStore Lab
+to an MCP-aware host.
+
+## Public package lane
+
+```bash
+python -m pip install apple-notes-forensics==0.1.0.post1
+```
+
+If the host supports `uvx`, the shortest MCP launch path is:
+
+```bash
+uvx --from apple-notes-forensics==0.1.0.post1 \
+  notes-recovery-mcp \
+  --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Source checkout lane
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .[mcp]
+notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
+```
+
+## Generic MCP host config
+
+```json
+{
+  "mcpServers": {
+    "notestorelab": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "apple-notes-forensics==0.1.0.post1",
+        "notes-recovery-mcp",
+        "--case-dir",
+        "./output/Notes_Forensics_<run_ts>"
+      ]
+    }
+  }
+}
+```
+
+## Capability boundary
+
+This MCP surface is local, stdio-first, one-case-root-at-a-time, and
+read-mostly. It is not a hosted Notes service or a write path into the live
+Notes store.

--- a/skills/notestorelab-case-review/references/install-and-mcp.md
+++ b/skills/notestorelab-case-review/references/install-and-mcp.md
@@ -1,9 +1,14 @@
 # Install And MCP Wiring
 
-Use this reference when the user asks how to install or connect NoteStore Lab
-to an MCP-aware host.
+Use this reference when the agent or reviewer asks:
+
+- how do I install this?
+- what is the exact MCP command?
+- what should I point my host at?
 
 ## Public package lane
+
+The current shipped package lane is PyPI:
 
 ```bash
 python -m pip install apple-notes-forensics==0.1.0.post1
@@ -19,6 +24,8 @@ uvx --from apple-notes-forensics==0.1.0.post1 \
 
 ## Source checkout lane
 
+If the user is working from a cloned repository checkout:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
@@ -27,6 +34,8 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 ```
 
 ## Generic MCP host config
+
+Use this when a host expects a `mcpServers` JSON block:
 
 ```json
 {
@@ -45,8 +54,21 @@ notes-recovery-mcp --case-dir ./output/Notes_Forensics_<run_ts>
 }
 ```
 
+If `uvx` is unavailable, point the host at the repo-local Python command
+instead.
+
 ## Capability boundary
 
-This MCP surface is local, stdio-first, one-case-root-at-a-time, and
-read-mostly. It is not a hosted Notes service or a write path into the live
-Notes store.
+This MCP surface is:
+
+- local
+- stdio-first
+- one explicit case root at a time
+- read-mostly
+- derived-artifact-first
+
+This MCP surface is **not**:
+
+- a hosted Notes service
+- a remote multi-tenant API
+- a write path into the live Apple Notes store

--- a/skills/notestorelab-case-review/references/usage-and-proof.md
+++ b/skills/notestorelab-case-review/references/usage-and-proof.md
@@ -1,0 +1,33 @@
+# Usage And Proof
+
+Use this reference when a reviewer asks what the skill helps an agent do in
+practice.
+
+## First-success path
+
+```bash
+notes-recovery demo
+notes-recovery ai-review --demo
+notes-recovery ask-case --demo --question "What should I inspect first?"
+notes-recovery doctor
+```
+
+What this proves:
+
+- the repo already ships a public-safe demo surface
+- AI review is real
+- bounded case Q&A is real
+- the MCP lane belongs on one explicit case root
+
+## Example prompts
+
+- "Summarize the demo case and list the first two artifacts I should inspect."
+- "Use the NoteStore Lab MCP lane on this case root and tell me what proof surfaces are available."
+- "Compare case A and case B and focus on the review layer, not raw copied evidence."
+
+## Public links
+
+- Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases

--- a/skills/notestorelab-case-review/references/usage-and-proof.md
+++ b/skills/notestorelab-case-review/references/usage-and-proof.md
@@ -1,9 +1,14 @@
 # Usage And Proof
 
-Use this reference when a reviewer asks what the skill helps an agent do in
-practice.
+Use this reference when the reviewer asks:
+
+- what does the skill actually help an agent do?
+- how do I try it in a few minutes?
+- where is the public proof?
 
 ## First-success path
+
+Run the zero-risk path in this order:
 
 ```bash
 notes-recovery demo
@@ -15,8 +20,8 @@ notes-recovery doctor
 What this proves:
 
 - the repo already ships a public-safe demo surface
-- AI review is real
-- bounded case Q&A is real
+- AI review is real, not hypothetical
+- bounded case Q&A is real, not hypothetical
 - the MCP lane belongs on one explicit case root
 
 ## MCP capability surface after attach
@@ -35,14 +40,24 @@ What this proves:
 - "Summarize the demo case and list the first two artifacts I should inspect."
 - "Use the NoteStore Lab MCP lane on this case root and tell me what proof surfaces are available."
 - "Compare case A and case B and focus on the review layer, not raw copied evidence."
+- "Generate a safe sharing plan using public-safe export."
 
-## Public links
+## Public proof links
 
-- Landing: https://xiaojiou176-open.github.io/apple-notes-forensics/
-- Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
+- Landing page: https://xiaojiou176-open.github.io/apple-notes-forensics/
+- Public proof page: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
+- Distribution boundary: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/DISTRIBUTION.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
 
 ## Visual demo
 
 ![NoteStore Lab demo screenshot](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-forensics/main/assets/readme/hero-public-demo.png)
+
+## Reviewer checklist
+
+If a reviewer asks "what does this skill teach?", answer in one sentence:
+
+> It teaches an agent how to install NoteStore Lab's local MCP lane, prove the
+> workflow on demo artifacts, and review one copied Apple Notes case root using
+> derived artifacts instead of the live Notes store.

--- a/skills/notestorelab-case-review/references/usage-and-proof.md
+++ b/skills/notestorelab-case-review/references/usage-and-proof.md
@@ -19,6 +19,17 @@ What this proves:
 - bounded case Q&A is real
 - the MCP lane belongs on one explicit case root
 
+## MCP capability surface after attach
+
+- Read-only review surfaces:
+  `list_case_roots`, `inspect_case_manifest`, `select_case_evidence`,
+  `inspect_case_artifact`, and `ask_case`
+- Bounded workflows:
+  `run_verify`, `run_report`, `build_timeline`, and `public_safe_export`
+- Boundary:
+  local stdio only, one explicit case root at a time, and no live Notes store
+  access
+
 ## Example prompts
 
 - "Summarize the demo case and list the first two artifacts I should inspect."
@@ -31,3 +42,7 @@ What this proves:
 - Public proof: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/proof.html
 - Builder guide: https://github.com/xiaojiou176-open/apple-notes-forensics/blob/main/INTEGRATIONS.md
 - Releases: https://github.com/xiaojiou176-open/apple-notes-forensics/releases
+
+## Visual demo
+
+![NoteStore Lab demo screenshot](https://raw.githubusercontent.com/xiaojiou176-open/apple-notes-forensics/main/assets/readme/hero-public-demo.png)


### PR DESCRIPTION
## What these skills teach
- `notes-snapshot-control-room`: how an agent acquires `notesctl`, separates local preflight from MCP attach, and proves the shortest control-room path without overstating hosted or marketplace claims.
- `notestorelab-case-review`: how an agent installs NoteStore Lab MCP, stays on one copied case root at a time, and asks bounded evidence-backed questions instead of free-form guesses.

## Why this revision is different
- each skill now starts with **what the agent learns** instead of leading with disclaimers
- install and host wiring live in `references/INSTALL.md`, `references/OPENHANDS_MCP_CONFIG.json`, and `references/OPENCLAW_MCP_CONFIG.json`
- capability surface is explicit in `references/CAPABILITIES.md`
- the first-success path is explicit in `references/DEMO.md`
- failure handling is explicit in `references/TROUBLESHOOTING.md`
- repo-local assumptions and hosted/runtime overclaims are called out as boundaries, not hidden in prose

## Proof surfaces
- the Snapshot packet now points to public proof links in the README/DEMO materials
- the NoteStore Lab packet now points to public proof links and bounded review-safe example prompts

## Validation
- packet folders contain `SKILL.md`, `README.md`, and a full `references/` set
- local repo-side readiness checks passed before this PR refresh
