### PR TITLE
feat: add Prompt Switchboard and Provenote public skills

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -340,6 +340,32 @@
             ]
         },
         {
+            "name": "prompt-switchboard-compare-workflows",
+            "source": "./prompt-switchboard-compare-workflows",
+            "description": "Use Prompt Switchboard as a compare-first browser workspace with a local MCP sidecar, while preserving its no-hosted-relay and local-first boundaries.",
+            "category": "productivity",
+            "keywords": [
+                "browser",
+                "mcp",
+                "compare",
+                "local-first",
+                "ai-workspace"
+            ]
+        },
+        {
+            "name": "provenote-mcp-outcome-workflows",
+            "source": "./provenote-mcp-outcome-workflows",
+            "description": "Guide read-first Provenote MCP workflows for drafts, research threads, and auditable runs without overclaiming marketplace or hosted-product status.",
+            "category": "productivity",
+            "keywords": [
+                "provenote",
+                "mcp",
+                "research",
+                "auditable",
+                "knowledge-workflow"
+            ]
+        },
+        {
             "name": "readiness-report",
             "source": "./readiness-report",
             "description": "Assess repository readiness for autonomous AI development and generate prioritized recommendations.",

--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -342,7 +342,7 @@
         {
             "name": "prompt-switchboard-compare-workflows",
             "source": "./prompt-switchboard-compare-workflows",
-            "description": "Use Prompt Switchboard as a compare-first browser workspace with a local MCP sidecar, while preserving its no-hosted-relay and local-first boundaries.",
+            "description": "Install Prompt Switchboard's local MCP sidecar, connect it in a host, and run compare-first browser workflows with concrete demo prompts and config snippets.",
             "category": "productivity",
             "keywords": [
                 "browser",
@@ -355,7 +355,7 @@
         {
             "name": "provenote-mcp-outcome-workflows",
             "source": "./provenote-mcp-outcome-workflows",
-            "description": "Guide read-first Provenote MCP workflows for drafts, research threads, and auditable runs without overclaiming marketplace or hosted-product status.",
+            "description": "Install Provenote's first-party MCP server, connect it in a host, and run read-first draft, research-thread, and auditable-run workflows with self-contained references.",
             "category": "productivity",
             "keywords": [
                 "provenote",

--- a/skills/prompt-switchboard-compare-workflows/README.md
+++ b/skills/prompt-switchboard-compare-workflows/README.md
@@ -1,42 +1,65 @@
-# Prompt Switchboard Compare Workflows
+# Prompt Switchboard Compare Workflows Public Skill
 
-This skill teaches an OpenHands agent how to connect Prompt Switchboard's local
-MCP sidecar and use it for compare-first browser workflows.
+This folder is the public, self-contained skill packet for Prompt Switchboard.
+It is meant to travel into host skill registries without forcing the reviewer to
+read the whole source repository first.
 
-## What this package includes
+## Purpose
+
+Use it when you want one portable skill folder that teaches four things inside
+the skill package itself:
+
+- how to install the local MCP sidecar
+- how to wire that MCP server into OpenHands or OpenClaw
+- what MCP tools Prompt Switchboard exposes
+- what a good first compare workflow looks like in practice
+
+## What this packet includes
 
 - `SKILL.md`
   - the agent-facing workflow prompt
+- `manifest.yaml`
+  - listing metadata for registry-style distribution
 - `references/INSTALL.md`
   - install and host wiring guide
 - `references/CAPABILITIES.md`
-  - exposed MCP tools and the recommended first-use path
+  - exposed MCP tools and recommended first-use path
 - `references/DEMO.md`
-  - exact demo prompt and success criteria
+  - exact demo prompts and success criteria
 - `references/OPENHANDS_MCP_CONFIG.json`
-  - ready-to-edit `mcpServers` config
+  - host config snippet for `mcpServers`
 - `references/OPENCLAW_MCP_CONFIG.json`
-  - equivalent OpenClaw config
+  - host config snippet for `mcp.servers`
+- `references/TROUBLESHOOTING.md`
+  - first-failure checks for bridge, readiness, and compare execution
 
-## What this skill teaches
+## Best-fit hosts
 
-- how to install the local Prompt Switchboard MCP sidecar
-- how to connect it inside OpenHands or OpenClaw
-- how to start with bridge and readiness checks before bigger automation
-- how to turn one compare run into an inspectable artifact
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect a standalone folder with its own
+  install and demo references
 
-## Best fit
+## Current verified state
 
-- compare-first browser review workflows
-- local MCP sidecar usage
-- read-first verification before broader automation
+- the ClawHub skill listing is live
+- the Prompt Switchboard MCP server is live in the Official MCP Registry
+- the OpenHands/extensions lane is review-pending, not merged
 
-## Source repository
+## What this packet must not claim
 
-- Repo: https://github.com/xiaojiou176-open/multi-ai-sidepanel
-- MCP docs: https://github.com/xiaojiou176-open/multi-ai-sidepanel/blob/main/docs/mcp-coding-agents.html
+- no live OpenHands/extensions listing without fresh PR/read-back
+- no hosted Glama deployment, Docker catalog listing, or public relay claim
+- no `listed everywhere` claim that hides review-pending state
 
-## Boundaries
+## Source of truth
 
-- This skill does not imply a hosted Prompt Switchboard backend.
-- This skill should stay aligned with the source repo's MCP surface and demo flow.
+This folder is a public-facing derived packet. Keep it aligned with the source
+repo, but do not make reviewers rely on repo-root docs to understand the skill:
+
+- `README.md`
+- `docs/mcp-coding-agents.html`
+- `server.json`
+
+If the product boundary or MCP workflow changes, update this packet before
+submitting it again.

--- a/skills/prompt-switchboard-compare-workflows/README.md
+++ b/skills/prompt-switchboard-compare-workflows/README.md
@@ -1,0 +1,22 @@
+# Prompt Switchboard Compare Workflows
+
+This skill ports the public host-facing workflow packet from
+`xiaojiou176-open/multi-ai-sidepanel` into the OpenHands public extensions
+registry.
+
+## Best fit
+
+- compare-first browser review workflows
+- local MCP sidecar usage
+- read-first verification before broader automation
+
+## Source repository
+
+- Repo: https://github.com/xiaojiou176-open/multi-ai-sidepanel
+- MCP docs: https://github.com/xiaojiou176-open/multi-ai-sidepanel/blob/main/docs/mcp-coding-agents.html
+
+## Boundaries
+
+- This skill does not imply a hosted Prompt Switchboard backend.
+- This skill does not imply a public registry listing outside OpenHands.
+- This skill should stay aligned with the source repo's `server.json` and README.

--- a/skills/prompt-switchboard-compare-workflows/README.md
+++ b/skills/prompt-switchboard-compare-workflows/README.md
@@ -10,6 +10,12 @@ registry.
 - local MCP sidecar usage
 - read-first verification before broader automation
 
+## What this skill teaches
+
+- how to treat Prompt Switchboard as a browser workspace for AI comparisons
+- how to start with bridge and readiness checks before bigger automation
+- how to turn one compare run into an inspectable artifact
+
 ## Source repository
 
 - Repo: https://github.com/xiaojiou176-open/multi-ai-sidepanel
@@ -18,5 +24,4 @@ registry.
 ## Boundaries
 
 - This skill does not imply a hosted Prompt Switchboard backend.
-- This skill does not imply a public registry listing outside OpenHands.
 - This skill should stay aligned with the source repo's `server.json` and README.

--- a/skills/prompt-switchboard-compare-workflows/README.md
+++ b/skills/prompt-switchboard-compare-workflows/README.md
@@ -1,20 +1,35 @@
 # Prompt Switchboard Compare Workflows
 
-This skill ports the public host-facing workflow packet from
-`xiaojiou176-open/multi-ai-sidepanel` into the OpenHands public extensions
-registry.
+This skill teaches an OpenHands agent how to connect Prompt Switchboard's local
+MCP sidecar and use it for compare-first browser workflows.
+
+## What this package includes
+
+- `SKILL.md`
+  - the agent-facing workflow prompt
+- `references/INSTALL.md`
+  - install and host wiring guide
+- `references/CAPABILITIES.md`
+  - exposed MCP tools and the recommended first-use path
+- `references/DEMO.md`
+  - exact demo prompt and success criteria
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - ready-to-edit `mcpServers` config
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - equivalent OpenClaw config
+
+## What this skill teaches
+
+- how to install the local Prompt Switchboard MCP sidecar
+- how to connect it inside OpenHands or OpenClaw
+- how to start with bridge and readiness checks before bigger automation
+- how to turn one compare run into an inspectable artifact
 
 ## Best fit
 
 - compare-first browser review workflows
 - local MCP sidecar usage
 - read-first verification before broader automation
-
-## What this skill teaches
-
-- how to treat Prompt Switchboard as a browser workspace for AI comparisons
-- how to start with bridge and readiness checks before bigger automation
-- how to turn one compare run into an inspectable artifact
 
 ## Source repository
 
@@ -24,4 +39,4 @@ registry.
 ## Boundaries
 
 - This skill does not imply a hosted Prompt Switchboard backend.
-- This skill should stay aligned with the source repo's `server.json` and README.
+- This skill should stay aligned with the source repo's MCP surface and demo flow.

--- a/skills/prompt-switchboard-compare-workflows/SKILL.md
+++ b/skills/prompt-switchboard-compare-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prompt-switchboard-compare-workflows
 description: Teach an agent to install Prompt Switchboard's local MCP sidecar, connect it in a host, and run a compare-first browser workflow.
-version: 1.1.0
+version: 1.1.1
 triggers:
   - prompt switchboard
   - prompt-switchboard

--- a/skills/prompt-switchboard-compare-workflows/SKILL.md
+++ b/skills/prompt-switchboard-compare-workflows/SKILL.md
@@ -12,8 +12,8 @@ triggers:
 
 # Prompt Switchboard Compare Workflows
 
-Teach the agent how to install, connect, and use Prompt Switchboard as a local
-browser workspace for side-by-side AI comparison.
+Teach the agent how to install, connect, and use Prompt Switchboard as a
+compare-first browser workspace.
 
 ## Use this skill when
 
@@ -21,11 +21,12 @@ browser workspace for side-by-side AI comparison.
 - the host can run a local MCP server
 - the user wants one inspectable compare artifact before broader automation
 
-## What the agent should know
+## What this package teaches
 
-- Prompt Switchboard is a compare-first browser extension workspace
-- the MCP sidecar is local and supports readiness, compare, analysis, export, and workflow tools
-- the first success path is bridge -> readiness -> compare
+- how to wire the local Prompt Switchboard MCP sidecar into a host
+- which MCP tools are safe and useful first
+- how to move from readiness checks to a real compare turn
+- how to keep the workflow grounded in a browser-native compare product
 
 ## Start here
 
@@ -62,5 +63,6 @@ important wording differences.
 
 ## Boundaries
 
-- treat Prompt Switchboard as a local browser workflow, not a hosted platform
-- keep claims grounded in the MCP tool surface documented in this package
+- Prompt Switchboard stays a local browser workflow, not a hosted service
+- the MCP sidecar supports compare workflows; it does not replace the extension
+- keep claims grounded in the actual tool surface documented in this package

--- a/skills/prompt-switchboard-compare-workflows/SKILL.md
+++ b/skills/prompt-switchboard-compare-workflows/SKILL.md
@@ -6,37 +6,36 @@ version: 1.0.0
 
 # Prompt Switchboard Compare Workflows
 
-## Purpose
+Teach the agent how to use Prompt Switchboard as a local browser workspace for
+side-by-side AI comparison.
 
-Help an OpenHands user consume Prompt Switchboard as a compare-first browser
-workspace instead of misframing it as a hosted AI platform.
+## Use this skill when
 
-## Keep this identity first
+- the user wants to compare the same prompt across multiple already-open AI chat tabs
+- the user wants a browser-native compare workspace instead of a hosted API service
+- the user wants one read-first MCP check before larger browser automation
 
-- browser-native compare workspace first
-- local MCP sidecar for builder lanes second
-- no hosted relay
-- no public HTTP API
-- no "already listed everywhere" claim
+## What the agent should know
 
-## Preferred flow
+- Prompt Switchboard is a compare-first browser extension workspace
+- the MCP sidecar is local and supports readiness, compare, and workflow helper tools
+- the first success path is to run one real compare and inspect the result locally
 
-1. `prompt_switchboard.bridge_status`
-2. `prompt_switchboard.check_readiness`
-3. `prompt_switchboard.compare`
-4. `prompt_switchboard.analyze_compare`
-5. `prompt_switchboard.run_workflow`
+## Recommended workflow
 
-## Proof path
+1. Confirm the bridge is healthy with `prompt_switchboard.bridge_status`
+2. Check the current browser/session state with `prompt_switchboard.check_readiness`
+3. Run one comparison with `prompt_switchboard.compare`
+4. Summarize the differences with `prompt_switchboard.analyze_compare`
+5. Only then move to `prompt_switchboard.run_workflow` for broader orchestration
 
-1. Install the latest release zip
-2. Run one real compare from the side panel
-3. Verify the MCP sidecar can read readiness and compare state
-4. Keep the first success path local and inspectable
+## Good first tasks
 
-## Truth language
+- compare one prompt across two or more models
+- verify which model tabs are ready before asking for automation
+- collect one inspectable compare artifact before proposing larger workflow changes
 
-- Good: "repo-owned public skill packet"
-- Good: "compare-first local MCP workflow skill"
-- Forbidden: "officially listed skill" without fresh host-side read-back
-- Forbidden: "hosted Prompt Switchboard platform"
+## Boundaries
+
+- treat Prompt Switchboard as a local browser workflow, not a hosted platform
+- keep claims grounded in the repo-owned MCP and extension surfaces

--- a/skills/prompt-switchboard-compare-workflows/SKILL.md
+++ b/skills/prompt-switchboard-compare-workflows/SKILL.md
@@ -1,41 +1,66 @@
 ---
 name: prompt-switchboard-compare-workflows
-description: Use this skill when you want Prompt Switchboard's compare-first browser workflow through the local MCP sidecar without overclaiming a hosted relay or a live marketplace listing.
-version: 1.0.0
+description: Teach an agent to install Prompt Switchboard's local MCP sidecar, connect it in a host, and run a compare-first browser workflow.
+version: 1.1.0
+triggers:
+  - prompt switchboard
+  - prompt-switchboard
+  - prompt_switchboard
+  - compare-first
+  - multi-ai-sidepanel
 ---
 
 # Prompt Switchboard Compare Workflows
 
-Teach the agent how to use Prompt Switchboard as a local browser workspace for
-side-by-side AI comparison.
+Teach the agent how to install, connect, and use Prompt Switchboard as a local
+browser workspace for side-by-side AI comparison.
 
 ## Use this skill when
 
 - the user wants to compare the same prompt across multiple already-open AI chat tabs
-- the user wants a browser-native compare workspace instead of a hosted API service
-- the user wants one read-first MCP check before larger browser automation
+- the host can run a local MCP server
+- the user wants one inspectable compare artifact before broader automation
 
 ## What the agent should know
 
 - Prompt Switchboard is a compare-first browser extension workspace
-- the MCP sidecar is local and supports readiness, compare, and workflow helper tools
-- the first success path is to run one real compare and inspect the result locally
+- the MCP sidecar is local and supports readiness, compare, analysis, export, and workflow tools
+- the first success path is bridge -> readiness -> compare
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the demo from [references/DEMO.md](references/DEMO.md)
 
 ## Recommended workflow
 
-1. Confirm the bridge is healthy with `prompt_switchboard.bridge_status`
-2. Check the current browser/session state with `prompt_switchboard.check_readiness`
-3. Run one comparison with `prompt_switchboard.compare`
-4. Summarize the differences with `prompt_switchboard.analyze_compare`
-5. Only then move to `prompt_switchboard.run_workflow` for broader orchestration
+1. `prompt_switchboard.bridge_status`
+2. `prompt_switchboard.check_readiness`
+3. `prompt_switchboard.compare`
+4. `prompt_switchboard.analyze_compare`
+5. `prompt_switchboard.run_workflow`
 
-## Good first tasks
+## Suggested first prompt
 
-- compare one prompt across two or more models
-- verify which model tabs are ready before asking for automation
-- collect one inspectable compare artifact before proposing larger workflow changes
+Use Prompt Switchboard to compare the prompt below across the ready ChatGPT and
+Gemini tabs. Start with `prompt_switchboard.bridge_status` and
+`prompt_switchboard.check_readiness`. If fewer than two model tabs are ready,
+stop and tell me exactly which login or tab-prep step is missing. If two or
+more tabs are ready, run `prompt_switchboard.compare` and summarize the most
+important wording differences.
+
+## Success checks
+
+- the host can launch the MCP server from the provided config
+- `bridge_status` confirms the local bridge is reachable
+- `check_readiness` identifies which tabs are ready
+- `compare` produces a real session/turn artifact the agent can inspect
 
 ## Boundaries
 
 - treat Prompt Switchboard as a local browser workflow, not a hosted platform
-- keep claims grounded in the repo-owned MCP and extension surfaces
+- keep claims grounded in the MCP tool surface documented in this package

--- a/skills/prompt-switchboard-compare-workflows/SKILL.md
+++ b/skills/prompt-switchboard-compare-workflows/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: prompt-switchboard-compare-workflows
+description: Use this skill when you want Prompt Switchboard's compare-first browser workflow through the local MCP sidecar without overclaiming a hosted relay or a live marketplace listing.
+version: 1.0.0
+---
+
+# Prompt Switchboard Compare Workflows
+
+## Purpose
+
+Help an OpenHands user consume Prompt Switchboard as a compare-first browser
+workspace instead of misframing it as a hosted AI platform.
+
+## Keep this identity first
+
+- browser-native compare workspace first
+- local MCP sidecar for builder lanes second
+- no hosted relay
+- no public HTTP API
+- no "already listed everywhere" claim
+
+## Preferred flow
+
+1. `prompt_switchboard.bridge_status`
+2. `prompt_switchboard.check_readiness`
+3. `prompt_switchboard.compare`
+4. `prompt_switchboard.analyze_compare`
+5. `prompt_switchboard.run_workflow`
+
+## Proof path
+
+1. Install the latest release zip
+2. Run one real compare from the side panel
+3. Verify the MCP sidecar can read readiness and compare state
+4. Keep the first success path local and inspectable
+
+## Truth language
+
+- Good: "repo-owned public skill packet"
+- Good: "compare-first local MCP workflow skill"
+- Forbidden: "officially listed skill" without fresh host-side read-back
+- Forbidden: "hosted Prompt Switchboard platform"

--- a/skills/prompt-switchboard-compare-workflows/manifest.yaml
+++ b/skills/prompt-switchboard-compare-workflows/manifest.yaml
@@ -4,7 +4,7 @@ artifact: public-skill-listing-manifest
 skill:
   name: prompt-switchboard-compare-workflows
   display_name: Prompt Switchboard Compare Workflows
-  version: 1.1.0
+  version: 1.1.1
   entrypoint: SKILL.md
   package_shape: skill-folder
 
@@ -13,7 +13,7 @@ registry_targets:
     status: listed-live
     package_shape: skill-folder
     listing_url: https://www.clawhub.ai/skills/prompt-switchboard-compare-workflows
-    submit_via: clawhub publish . --slug prompt-switchboard-compare-workflows --name "Prompt Switchboard Compare Workflows" --version 1.1.0 --tags browser-extension,mcp,compare-first,productivity
+    submit_via: clawhub publish . --slug prompt-switchboard-compare-workflows --name "Prompt Switchboard Compare Workflows" --version 1.1.1 --tags browser-extension,mcp,compare-first,productivity
   openhands-extensions:
     status: review-pending
     package_shape: skill-folder

--- a/skills/prompt-switchboard-compare-workflows/manifest.yaml
+++ b/skills/prompt-switchboard-compare-workflows/manifest.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: prompt-switchboard-compare-workflows
+  display_name: Prompt Switchboard Compare Workflows
+  version: 1.1.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/prompt-switchboard-compare-workflows
+    submit_via: clawhub publish . --slug prompt-switchboard-compare-workflows --name "Prompt Switchboard Compare Workflows" --version 1.1.0 --tags browser-extension,mcp,compare-first,productivity
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/154
+    submit_via: submit this folder as skills/prompt-switchboard-compare-workflows/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Compare-first browser workspace with a local MCP sidecar for Prompt Switchboard.
+  canonical_repo_version: 0.2.2
+  official_listing_state: partially-live
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No hosted relay or public runtime is claimed
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/prompt-switchboard-compare-workflows/references/CAPABILITIES.md
+++ b/skills/prompt-switchboard-compare-workflows/references/CAPABILITIES.md
@@ -1,0 +1,37 @@
+# Prompt Switchboard MCP Capabilities
+
+These are the MCP tools this skill expects the host to expose.
+
+## Best first tools
+
+- `prompt_switchboard.bridge_status`
+  - confirm the local bridge is reachable
+- `prompt_switchboard.check_readiness`
+  - tell the agent which model tabs are ready before it spends the user's prompt
+- `prompt_switchboard.compare`
+  - send one prompt across the ready tabs and create an inspectable compare turn
+
+## Useful follow-through tools
+
+- `prompt_switchboard.analyze_compare`
+  - summarize the compare turn
+- `prompt_switchboard.export_compare`
+  - export the compare as Markdown or a compact local share artifact
+- `prompt_switchboard.retry_failed`
+  - rerun only the failed model tabs
+
+## Workflow tools
+
+- `prompt_switchboard.run_workflow`
+- `prompt_switchboard.list_workflow_runs`
+- `prompt_switchboard.get_workflow_run`
+- `prompt_switchboard.resume_workflow`
+
+These tools are best after one real compare turn already exists.
+
+## Session inspection tools
+
+- `prompt_switchboard.get_session`
+- `prompt_switchboard.list_sessions`
+
+Use these when the user wants to inspect or export prior compare history.

--- a/skills/prompt-switchboard-compare-workflows/references/DEMO.md
+++ b/skills/prompt-switchboard-compare-workflows/references/DEMO.md
@@ -29,6 +29,23 @@ differences and recommend which answer is better for a friendly product update.
 - the compare step creates a real turn/session artifact
 - the analysis step refers back to the compare output instead of inventing text
 
+## What the output should look like
+
+You do not need byte-for-byte identical JSON, but the shape should feel like
+this:
+
+- readiness output names which models are ready or blocked
+- compare output yields a session/turn pair the host can inspect later
+- analysis output cites the compare turn instead of free-writing from memory
+
+Example compare-oriented fields to expect:
+
+```text
+sessionId: session-1
+turnId: turn-1
+requestedModels: [ChatGPT, Gemini]
+```
+
 ## OpenClaw variant
 
 Use the same prompt after loading the MCP config from

--- a/skills/prompt-switchboard-compare-workflows/references/DEMO.md
+++ b/skills/prompt-switchboard-compare-workflows/references/DEMO.md
@@ -1,0 +1,36 @@
+# OpenHands / OpenClaw Demo Walkthrough
+
+This is the shortest concrete demo you can run to prove the skill is doing real
+work instead of just existing as prose.
+
+## Demo prompt
+
+Use Prompt Switchboard to compare this rewrite request across the ready ChatGPT
+and Gemini tabs:
+
+> Rewrite the following onboarding email so it sounds warmer and 30% shorter.
+
+Start with `prompt_switchboard.bridge_status` and
+`prompt_switchboard.check_readiness`. If both tabs are ready, run
+`prompt_switchboard.compare`. After the compare turn lands, use
+`prompt_switchboard.analyze_compare` to summarize the biggest wording
+differences and recommend which answer is better for a friendly product update.
+
+## Expected tool sequence
+
+1. `prompt_switchboard.bridge_status`
+2. `prompt_switchboard.check_readiness`
+3. `prompt_switchboard.compare`
+4. `prompt_switchboard.analyze_compare`
+
+## Visible success criteria
+
+- the agent names which tabs are ready instead of guessing
+- the compare step creates a real turn/session artifact
+- the analysis step refers back to the compare output instead of inventing text
+
+## OpenClaw variant
+
+Use the same prompt after loading the MCP config from
+[OPENCLAW_MCP_CONFIG.json](OPENCLAW_MCP_CONFIG.json). The success criteria stay
+the same: bridge, readiness, compare, then analysis.

--- a/skills/prompt-switchboard-compare-workflows/references/INSTALL.md
+++ b/skills/prompt-switchboard-compare-workflows/references/INSTALL.md
@@ -1,0 +1,49 @@
+# Install and Connect Prompt Switchboard MCP
+
+This guide avoids private paths and keeps the install loop portable.
+
+## What you need
+
+- a local clone of `https://github.com/xiaojiou176-open/multi-ai-sidepanel`
+- Node.js and npm
+- the Prompt Switchboard browser extension installed and able to reach its side panel
+- at least two supported AI chat tabs signed in and open
+
+## 1. Clone and install the repo
+
+```bash
+git clone https://github.com/xiaojiou176-open/multi-ai-sidepanel.git
+cd multi-ai-sidepanel
+npm install
+```
+
+## 2. Make the MCP server launchable
+
+Prompt Switchboard exposes its MCP server through the repo-owned script:
+
+```bash
+npm --prefix /absolute/path/to/multi-ai-sidepanel run mcp:server
+```
+
+You do not need to invent a new wrapper. Reuse that command in your host config.
+
+## 3. Connect it in an OpenHands-style host
+
+Copy and edit [OPENHANDS_MCP_CONFIG.json](OPENHANDS_MCP_CONFIG.json) so the
+absolute path points at your local clone.
+
+## 4. Connect it in OpenClaw
+
+Copy and edit [OPENCLAW_MCP_CONFIG.json](OPENCLAW_MCP_CONFIG.json), then load it
+into your OpenClaw MCP configuration.
+
+## 5. Verify the smallest useful loop
+
+Once the host can see the server, run this tool sequence:
+
+1. `prompt_switchboard.bridge_status`
+2. `prompt_switchboard.check_readiness`
+3. `prompt_switchboard.compare`
+
+If that loop works, the host wiring is good enough for a real compare-first
+workflow.

--- a/skills/prompt-switchboard-compare-workflows/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/prompt-switchboard-compare-workflows/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "servers": {
+      "prompt_switchboard": {
+        "command": "npm",
+        "args": [
+          "--prefix",
+          "/absolute/path/to/multi-ai-sidepanel",
+          "run",
+          "mcp:server"
+        ]
+      }
+    }
+  }
+}

--- a/skills/prompt-switchboard-compare-workflows/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/prompt-switchboard-compare-workflows/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "prompt_switchboard": {
+      "command": "npm",
+      "args": [
+        "--prefix",
+        "/absolute/path/to/multi-ai-sidepanel",
+        "run",
+        "mcp:server"
+      ]
+    }
+  }
+}

--- a/skills/prompt-switchboard-compare-workflows/references/README.md
+++ b/skills/prompt-switchboard-compare-workflows/references/README.md
@@ -1,0 +1,18 @@
+# Prompt Switchboard Skill References
+
+This directory keeps the practical material that a host reviewer or agent needs
+without depending on repo-root documents.
+
+## Included references
+
+- `INSTALL.md`
+  - install the browser extension, prepare the local MCP sidecar, and wire it
+    into a host
+- `CAPABILITIES.md`
+  - the exposed MCP tools and the recommended first-use sequence
+- `DEMO.md`
+  - exact demo prompts for OpenHands or OpenClaw
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet

--- a/skills/prompt-switchboard-compare-workflows/references/README.md
+++ b/skills/prompt-switchboard-compare-workflows/references/README.md
@@ -16,3 +16,5 @@ without depending on repo-root documents.
   - a ready-to-edit `mcpServers` snippet
 - `OPENCLAW_MCP_CONFIG.json`
   - a ready-to-edit `mcp.servers` snippet
+- `TROUBLESHOOTING.md`
+  - the first places to check when the bridge, readiness gate, or compare turn fails

--- a/skills/prompt-switchboard-compare-workflows/references/TROUBLESHOOTING.md
+++ b/skills/prompt-switchboard-compare-workflows/references/TROUBLESHOOTING.md
@@ -1,0 +1,51 @@
+# Prompt Switchboard Troubleshooting
+
+Use this page when the packet installs cleanly on paper but the first real
+compare turn does not succeed.
+
+## 1. `bridge_status` says the bridge is unreachable
+
+Check these first:
+
+- the Prompt Switchboard browser extension is installed and enabled
+- the local sidecar process can start from the command in `INSTALL.md`
+- the host config points at the right command, args, and working directory
+
+If the bridge is still unreachable, stop and report it as a local bridge setup
+problem instead of pretending the compare lane is ready.
+
+## 2. `check_readiness` says fewer than two model tabs are ready
+
+This usually means one of these is still missing:
+
+- the expected chat tabs are not open
+- the user is not logged in on one of the providers
+- the extension cannot see the tab because the page has not finished loading
+
+Do not run `compare` until `check_readiness` says two or more model tabs are
+ready.
+
+## 3. `compare` fails after readiness looked good
+
+Try this order:
+
+1. rerun `prompt_switchboard.bridge_status`
+2. rerun `prompt_switchboard.check_readiness`
+3. if the skill supports it, use `prompt_switchboard.retry_failed`
+4. if the same tab keeps failing, report the exact blocked model tab instead of
+   generalizing
+
+## 4. The reviewer asks what success should look like
+
+Point back to `DEMO.md` and confirm these three signals:
+
+- the agent names which model tabs are ready
+- the compare step creates a real session/turn artifact
+- the analysis step cites the compare output instead of free-writing from
+  memory
+
+## 5. Boundary reminder
+
+Prompt Switchboard is a local browser workflow with a local MCP sidecar. This
+packet does not claim a hosted relay, a live marketplace listing, or universal
+readiness on every machine.

--- a/skills/provenote-mcp-outcome-workflows/README.md
+++ b/skills/provenote-mcp-outcome-workflows/README.md
@@ -9,6 +9,12 @@ This skill ports the public host-facing workflow packet from
 - first-party MCP usage through `provenote-mcp`
 - read-first validation before write-oriented automation
 
+## What this skill teaches
+
+- how to inspect Provenote drafts, research threads, and auditable runs first
+- how to keep write actions narrow and outcome-linked
+- how to treat `provenote-mcp` as the main execution surface
+
 ## Source repository
 
 - Repo: https://github.com/xiaojiou176-open/provenote

--- a/skills/provenote-mcp-outcome-workflows/README.md
+++ b/skills/provenote-mcp-outcome-workflows/README.md
@@ -1,19 +1,35 @@
 # Provenote MCP Outcome Workflows
 
-This skill ports the public host-facing workflow packet from
-`xiaojiou176-open/provenote` into the OpenHands public extensions registry.
+This skill teaches an OpenHands agent how to connect Provenote's first-party
+MCP server and use it for read-first outcome workflows.
+
+## What this package includes
+
+- `SKILL.md`
+  - the agent-facing workflow prompt
+- `references/INSTALL.md`
+  - install and host wiring guide
+- `references/CAPABILITIES.md`
+  - exposed MCP tools and the recommended first-use path
+- `references/DEMO.md`
+  - exact demo prompt and success criteria
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - ready-to-edit `mcpServers` config
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - equivalent OpenClaw config
+
+## What this skill teaches
+
+- how to install and launch `provenote-mcp`
+- how to connect it inside OpenHands or OpenClaw
+- how to inspect Provenote drafts, research threads, and auditable runs first
+- how to keep write actions narrow and outcome-linked
 
 ## Best fit
 
 - long-context to structured research workflows
 - first-party MCP usage through `provenote-mcp`
 - read-first validation before write-oriented automation
-
-## What this skill teaches
-
-- how to inspect Provenote drafts, research threads, and auditable runs first
-- how to keep write actions narrow and outcome-linked
-- how to treat `provenote-mcp` as the main execution surface
 
 ## Source repository
 
@@ -24,4 +40,4 @@ This skill ports the public host-facing workflow packet from
 
 - This skill does not replace the first-party `provenote-mcp` server.
 - This skill does not imply a hosted Provenote SaaS surface.
-- This skill should stay aligned with the source repo's MCP docs and public skill packet.
+- This skill should stay aligned with the source repo's MCP docs and demo flow.

--- a/skills/provenote-mcp-outcome-workflows/README.md
+++ b/skills/provenote-mcp-outcome-workflows/README.md
@@ -1,43 +1,62 @@
-# Provenote MCP Outcome Workflows
+# Provenote MCP Outcome Workflows Public Skill
 
-This skill teaches an OpenHands agent how to connect Provenote's first-party
-MCP server and use it for read-first outcome workflows.
+This folder is the public, self-contained skill packet for Provenote.
+It is designed to carry install, config, capability, and demo material inside
+the skill folder instead of pushing that burden back to repo-root docs.
 
-## What this package includes
+## Purpose
+
+Use it when you want one portable skill folder that teaches four things clearly:
+
+- how to install and launch the first-party `provenote-mcp` server
+- how to wire it into OpenHands or OpenClaw
+- what MCP tool families Provenote exposes
+- what a read-first outcome workflow looks like in practice
+
+## What this packet includes
 
 - `SKILL.md`
   - the agent-facing workflow prompt
+- `manifest.yaml`
+  - listing metadata for registry-style distribution
 - `references/INSTALL.md`
   - install and host wiring guide
 - `references/CAPABILITIES.md`
-  - exposed MCP tools and the recommended first-use path
+  - exposed MCP tools and recommended first-use path
 - `references/DEMO.md`
-  - exact demo prompt and success criteria
+  - exact demo prompts and success criteria
 - `references/OPENHANDS_MCP_CONFIG.json`
-  - ready-to-edit `mcpServers` config
+  - host config snippet for `mcpServers`
 - `references/OPENCLAW_MCP_CONFIG.json`
-  - equivalent OpenClaw config
+  - host config snippet for `mcp.servers`
+- `references/TROUBLESHOOTING.md`
+  - first-failure checks for launch, empty workspaces, and narrow write steps
 
-## What this skill teaches
+## Best-fit hosts
 
-- how to install and launch `provenote-mcp`
-- how to connect it inside OpenHands or OpenClaw
-- how to inspect Provenote drafts, research threads, and auditable runs first
-- how to keep write actions narrow and outcome-linked
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect a standalone folder with its own
+  install and demo references
 
-## Best fit
+## Current verified state
 
-- long-context to structured research workflows
-- first-party MCP usage through `provenote-mcp`
-- read-first validation before write-oriented automation
+- the ClawHub skill listing is live
+- the Provenote MCP server is live in the Official MCP Registry
+- the OpenHands/extensions lane is review-pending, not merged
 
-## Source repository
+## What this packet must not claim
 
-- Repo: https://github.com/xiaojiou176-open/provenote
-- MCP docs: https://github.com/xiaojiou176-open/provenote/blob/main/docs/mcp.md
+- no live OpenHands/extensions listing without fresh PR/read-back
+- no official marketplace or directory listing by itself
+- no replacement of the first-party `provenote-mcp` server
 
-## Boundaries
+## Source of truth
 
-- This skill does not replace the first-party `provenote-mcp` server.
-- This skill does not imply a hosted Provenote SaaS surface.
-- This skill should stay aligned with the source repo's MCP docs and demo flow.
+Keep this packet aligned with the source repo, but do not make reviewers depend
+on repo-root docs before they can understand the skill:
+
+- `docs/distribution.md`
+- `docs/project-status.md`
+- `server.json`
+- `examples/hosts/openclaw/clawhub/provenote-mcp-outcome-workflows/SKILL.md`

--- a/skills/provenote-mcp-outcome-workflows/README.md
+++ b/skills/provenote-mcp-outcome-workflows/README.md
@@ -1,0 +1,21 @@
+# Provenote MCP Outcome Workflows
+
+This skill ports the public host-facing workflow packet from
+`xiaojiou176-open/provenote` into the OpenHands public extensions registry.
+
+## Best fit
+
+- long-context to structured research workflows
+- first-party MCP usage through `provenote-mcp`
+- read-first validation before write-oriented automation
+
+## Source repository
+
+- Repo: https://github.com/xiaojiou176-open/provenote
+- MCP docs: https://github.com/xiaojiou176-open/provenote/blob/main/docs/mcp.md
+
+## Boundaries
+
+- This skill does not replace the first-party `provenote-mcp` server.
+- This skill does not imply a hosted Provenote SaaS surface.
+- This skill should stay aligned with the source repo's MCP docs and public skill packet.

--- a/skills/provenote-mcp-outcome-workflows/SKILL.md
+++ b/skills/provenote-mcp-outcome-workflows/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: provenote-mcp-outcome-workflows
+description: Use this skill when you want Provenote's first-party MCP outcome workflows through a host-facing skill packet without overclaiming a live listing or marketplace status.
+version: 1.0.0
+---
+
+# Provenote MCP Outcome Workflows
+
+## Purpose
+
+Help an OpenHands user consume Provenote's first-party MCP surfaces without
+rewriting the repo into a hosted platform or a generic public skills catalog.
+
+## Read-first workflow
+
+1. list drafts
+2. list research threads
+3. list auditable runs
+4. only then move to one narrow write-oriented action
+
+## Safe first mutations
+
+- `research_thread.to_draft`
+- `draft.verify`
+- `draft.download`
+- `auditable_run.create`
+- `auditable_run.download`
+
+## Validation
+
+Before calling this skill working, prove all four:
+
+1. the host can execute `provenote-mcp`
+2. a read-first tool succeeds
+3. one narrow write-oriented workflow succeeds
+4. the result maps back to an inspectable repo-owned surface
+
+## Boundary
+
+- public-ready host-facing skill packet from this repository
+- not a live OpenHands/extensions listing yet
+- not a live ClawHub listing yet
+- not a public skills catalog or marketplace surface by itself

--- a/skills/provenote-mcp-outcome-workflows/SKILL.md
+++ b/skills/provenote-mcp-outcome-workflows/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: provenote-mcp-outcome-workflows
 description: Teach an agent to install Provenote's first-party MCP server, connect it in a host, and run read-first outcome workflows.
-version: 1.1.0
+version: 1.1.1
 triggers:
   - provenote
   - provenote-mcp

--- a/skills/provenote-mcp-outcome-workflows/SKILL.md
+++ b/skills/provenote-mcp-outcome-workflows/SKILL.md
@@ -1,19 +1,25 @@
 ---
 name: provenote-mcp-outcome-workflows
-description: Use this skill when you want Provenote's first-party MCP outcome workflows through a host-facing skill packet without overclaiming a live listing or marketplace status.
-version: 1.0.0
+description: Teach an agent to install Provenote's first-party MCP server, connect it in a host, and run read-first outcome workflows.
+version: 1.1.0
+triggers:
+  - provenote
+  - provenote-mcp
+  - research thread
+  - auditable run
+  - source-grounded notes
 ---
 
 # Provenote MCP Outcome Workflows
 
-Teach the agent how to use Provenote's first-party MCP server for structured,
-source-grounded note and research workflows.
+Teach the agent how to install, connect, and use Provenote's first-party MCP
+server for structured, source-grounded note and research workflows.
 
 ## Use this skill when
 
 - the user wants to turn messy long context into structured drafts or research threads
-- the user wants auditable outcomes instead of free-form note taking
-- the user wants a read-first MCP workflow before narrow write actions
+- the host can run a local MCP server
+- the user wants inspectable outcomes before broad write automation
 
 ## What the agent should know
 
@@ -21,18 +27,21 @@ source-grounded note and research workflows.
 - the most important read surfaces are drafts, research threads, and auditable runs
 - the safest first success path is to inspect existing outcomes before mutating anything
 
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the demo from [references/DEMO.md](references/DEMO.md)
+
 ## Recommended workflow
 
-1. List drafts
-2. List research threads
-3. List auditable runs
+1. `draft.list`
+2. `research_thread.list`
+3. `auditable_run.list`
 4. Pick one narrow write-oriented action only after the read surfaces make sense
-
-## Good first actions
-
-- summarize the current draft set
-- inspect how a research thread maps into a draft
-- create or download one auditable run tied to a real repo-owned result
 
 ## Safe first mutations
 
@@ -41,6 +50,14 @@ source-grounded note and research workflows.
 - `draft.download`
 - `auditable_run.create`
 - `auditable_run.download`
+
+## Suggested first prompt
+
+Use Provenote to inspect the current drafts, research threads, and auditable
+runs for this workspace. Start with `draft.list`, `research_thread.list`, and
+`auditable_run.list`. After you summarize what already exists, choose one
+narrow next step: either convert a research thread into a draft with
+`research_thread.to_draft` or verify an existing draft with `draft.verify`.
 
 ## Validation
 

--- a/skills/provenote-mcp-outcome-workflows/SKILL.md
+++ b/skills/provenote-mcp-outcome-workflows/SKILL.md
@@ -13,7 +13,7 @@ triggers:
 # Provenote MCP Outcome Workflows
 
 Teach the agent how to install, connect, and use Provenote's first-party MCP
-server for structured, source-grounded note and research workflows.
+server for read-first note and research workflows.
 
 ## Use this skill when
 
@@ -21,11 +21,12 @@ server for structured, source-grounded note and research workflows.
 - the host can run a local MCP server
 - the user wants inspectable outcomes before broad write automation
 
-## What the agent should know
+## What this package teaches
 
-- Provenote ships a first-party MCP entrypoint: `provenote-mcp`
-- the most important read surfaces are drafts, research threads, and auditable runs
-- the safest first success path is to inspect existing outcomes before mutating anything
+- how to launch `provenote-mcp` from a local clone
+- how to wire it into OpenHands or OpenClaw
+- which read-first MCP tools to use first
+- which write actions are narrow and safe to try next
 
 ## Start here
 
@@ -36,12 +37,12 @@ server for structured, source-grounded note and research workflows.
 3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
 4. Run the demo from [references/DEMO.md](references/DEMO.md)
 
-## Recommended workflow
+## Read-first workflow
 
 1. `draft.list`
 2. `research_thread.list`
 3. `auditable_run.list`
-4. Pick one narrow write-oriented action only after the read surfaces make sense
+4. only then move to one narrow write-oriented action
 
 ## Safe first mutations
 
@@ -59,16 +60,13 @@ runs for this workspace. Start with `draft.list`, `research_thread.list`, and
 narrow next step: either convert a research thread into a draft with
 `research_thread.to_draft` or verify an existing draft with `draft.verify`.
 
-## Validation
+## Success checks
 
-Before treating the workflow as working, prove all four:
-
-1. the host can execute `provenote-mcp`
-2. a read-first tool succeeds
-3. one narrow write-oriented workflow succeeds
-4. the result maps back to an inspectable repo-owned surface
+- the host can launch `provenote-mcp` from the provided config
+- the three read-first list calls succeed
+- one narrow mutation succeeds and maps back to an inspectable artifact
 
 ## Boundaries
 
-- keep Provenote centered on its first-party MCP server
+- Provenote stays centered on its first-party MCP server
 - keep outcome claims tied to inspectable repo-owned artifacts

--- a/skills/provenote-mcp-outcome-workflows/SKILL.md
+++ b/skills/provenote-mcp-outcome-workflows/SKILL.md
@@ -6,17 +6,33 @@ version: 1.0.0
 
 # Provenote MCP Outcome Workflows
 
-## Purpose
+Teach the agent how to use Provenote's first-party MCP server for structured,
+source-grounded note and research workflows.
 
-Help an OpenHands user consume Provenote's first-party MCP surfaces without
-rewriting the repo into a hosted platform or a generic public skills catalog.
+## Use this skill when
 
-## Read-first workflow
+- the user wants to turn messy long context into structured drafts or research threads
+- the user wants auditable outcomes instead of free-form note taking
+- the user wants a read-first MCP workflow before narrow write actions
 
-1. list drafts
-2. list research threads
-3. list auditable runs
-4. only then move to one narrow write-oriented action
+## What the agent should know
+
+- Provenote ships a first-party MCP entrypoint: `provenote-mcp`
+- the most important read surfaces are drafts, research threads, and auditable runs
+- the safest first success path is to inspect existing outcomes before mutating anything
+
+## Recommended workflow
+
+1. List drafts
+2. List research threads
+3. List auditable runs
+4. Pick one narrow write-oriented action only after the read surfaces make sense
+
+## Good first actions
+
+- summarize the current draft set
+- inspect how a research thread maps into a draft
+- create or download one auditable run tied to a real repo-owned result
 
 ## Safe first mutations
 
@@ -28,16 +44,14 @@ rewriting the repo into a hosted platform or a generic public skills catalog.
 
 ## Validation
 
-Before calling this skill working, prove all four:
+Before treating the workflow as working, prove all four:
 
 1. the host can execute `provenote-mcp`
 2. a read-first tool succeeds
 3. one narrow write-oriented workflow succeeds
 4. the result maps back to an inspectable repo-owned surface
 
-## Boundary
+## Boundaries
 
-- public-ready host-facing skill packet from this repository
-- not a live OpenHands/extensions listing yet
-- not a live ClawHub listing yet
-- not a public skills catalog or marketplace surface by itself
+- keep Provenote centered on its first-party MCP server
+- keep outcome claims tied to inspectable repo-owned artifacts

--- a/skills/provenote-mcp-outcome-workflows/manifest.yaml
+++ b/skills/provenote-mcp-outcome-workflows/manifest.yaml
@@ -4,7 +4,7 @@ artifact: public-skill-listing-manifest
 skill:
   name: provenote-mcp-outcome-workflows
   display_name: Provenote MCP Outcome Workflows
-  version: 1.1.0
+  version: 1.1.1
   entrypoint: SKILL.md
   package_shape: skill-folder
 
@@ -13,7 +13,7 @@ registry_targets:
     status: listed-live
     package_shape: skill-folder
     listing_url: https://www.clawhub.ai/skills/provenote-mcp-outcome-workflows
-    submit_via: clawhub publish . --slug provenote-mcp-outcome-workflows --name "Provenote MCP Outcome Workflows" --version 1.1.0 --tags mcp,notes,research,outcomes,provenote
+    submit_via: clawhub publish . --slug provenote-mcp-outcome-workflows --name "Provenote MCP Outcome Workflows" --version 1.1.1 --tags mcp,notes,research,outcomes,provenote
   openhands-extensions:
     status: review-pending
     package_shape: skill-folder

--- a/skills/provenote-mcp-outcome-workflows/manifest.yaml
+++ b/skills/provenote-mcp-outcome-workflows/manifest.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: provenote-mcp-outcome-workflows
+  display_name: Provenote MCP Outcome Workflows
+  version: 1.1.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/provenote-mcp-outcome-workflows
+    submit_via: clawhub publish . --slug provenote-mcp-outcome-workflows --name "Provenote MCP Outcome Workflows" --version 1.1.0 --tags mcp,notes,research,outcomes,provenote
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/154
+    submit_via: submit this folder as skills/provenote-mcp-outcome-workflows/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Source-grounded Provenote outcome workflows through the first-party MCP server.
+  canonical_repo_version: 1.8.5
+  official_listing_state: partially-live
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No hosted Glama deployment exists yet
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/provenote-mcp-outcome-workflows/references/CAPABILITIES.md
+++ b/skills/provenote-mcp-outcome-workflows/references/CAPABILITIES.md
@@ -1,0 +1,39 @@
+# Provenote MCP Capabilities
+
+These are the MCP tool families this skill expects the host to expose.
+
+## Read-first tool families
+
+- `draft.*`
+  - inspect, create, verify, and download notebook drafts
+- `research_thread.*`
+  - inspect or evolve research threads, then promote one into a draft
+- `auditable_run.*`
+  - inspect and create auditable output bundles
+
+## Recommended first-use sequence
+
+1. `draft.list`
+2. `research_thread.list`
+3. `auditable_run.list`
+
+That sequence tells the agent what already exists before it proposes any write
+action.
+
+## Good next actions
+
+- `research_thread.to_draft`
+- `draft.verify`
+- `draft.download`
+- `auditable_run.create`
+- `auditable_run.download`
+
+## Utility surfaces
+
+- `knowledge.search`
+- `chat.run`
+- `model.inspect`
+- `settings.mutate`
+
+Use these after the read-first workflow is already grounded in the user's
+actual drafts or research threads.

--- a/skills/provenote-mcp-outcome-workflows/references/DEMO.md
+++ b/skills/provenote-mcp-outcome-workflows/references/DEMO.md
@@ -1,0 +1,37 @@
+# OpenHands / OpenClaw Demo Walkthrough
+
+This is the shortest concrete demo you can run to prove the skill is teaching a
+real read-first Provenote workflow instead of only describing one.
+
+## Demo prompt
+
+Use Provenote to inspect the current notes workspace. Start with
+`draft.list`, `research_thread.list`, and `auditable_run.list`. Summarize what
+already exists. Then pick one narrow next step:
+
+- if there is a promising research thread, run `research_thread.to_draft`
+- if there is an unverified draft, run `draft.verify`
+
+Finally, explain which repo-owned artifact changed and how the user can inspect
+it.
+
+## Expected tool sequence
+
+1. `draft.list`
+2. `research_thread.list`
+3. `auditable_run.list`
+4. one of:
+   - `research_thread.to_draft`
+   - `draft.verify`
+
+## Visible success criteria
+
+- the agent reports what drafts, threads, or runs already exist
+- the write action is narrow and tied to something that was just read
+- the agent points back to an inspectable draft or auditable-run artifact
+
+## OpenClaw variant
+
+Use the same prompt after loading the MCP config from
+[OPENCLAW_MCP_CONFIG.json](OPENCLAW_MCP_CONFIG.json). The success criteria stay
+the same: read first, mutate once, then point back to the changed artifact.

--- a/skills/provenote-mcp-outcome-workflows/references/DEMO.md
+++ b/skills/provenote-mcp-outcome-workflows/references/DEMO.md
@@ -30,6 +30,30 @@ it.
 - the write action is narrow and tied to something that was just read
 - the agent points back to an inspectable draft or auditable-run artifact
 
+## What the output should look like
+
+You do not need byte-for-byte identical JSON, but the shape should feel like
+the tested MCP outputs:
+
+```json
+[
+  {
+    "id": "draft:1",
+    "notebook_id": "notebook:1",
+    "status": "completed"
+  }
+]
+```
+
+```json
+{
+  "status": "verified"
+}
+```
+
+That is the level of concreteness the demo should reach: list something real,
+then mutate one real thing, then point back to the changed artifact.
+
 ## OpenClaw variant
 
 Use the same prompt after loading the MCP config from

--- a/skills/provenote-mcp-outcome-workflows/references/INSTALL.md
+++ b/skills/provenote-mcp-outcome-workflows/references/INSTALL.md
@@ -1,0 +1,50 @@
+# Install and Connect Provenote MCP
+
+This guide avoids private paths and keeps the install loop portable.
+
+## What you need
+
+- a local clone of `https://github.com/xiaojiou176-open/provenote`
+- `uv`
+- a workspace where the host can launch shell commands
+
+## 1. Clone and install the repo
+
+```bash
+git clone https://github.com/xiaojiou176-open/provenote.git
+cd provenote
+uv sync
+```
+
+## 2. Make the MCP server launchable
+
+Provenote exposes its MCP server through the repo-owned entrypoint:
+
+```bash
+cd /absolute/path/to/provenote
+uv run provenote-mcp
+```
+
+You do not need to invent a wrapper package. Reuse that command in your host
+config.
+
+## 3. Connect it in an OpenHands-style host
+
+Copy and edit [OPENHANDS_MCP_CONFIG.json](OPENHANDS_MCP_CONFIG.json) so the
+absolute path points at your local clone.
+
+## 4. Connect it in OpenClaw
+
+Copy and edit [OPENCLAW_MCP_CONFIG.json](OPENCLAW_MCP_CONFIG.json), then load it
+into your OpenClaw MCP configuration.
+
+## 5. Verify the smallest useful loop
+
+Once the host can see the server, run this tool sequence:
+
+1. `draft.list`
+2. `research_thread.list`
+3. `auditable_run.list`
+
+If those three read calls work, the host wiring is good enough for a real
+read-first outcome workflow.

--- a/skills/provenote-mcp-outcome-workflows/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/provenote-mcp-outcome-workflows/references/OPENCLAW_MCP_CONFIG.json
@@ -2,8 +2,8 @@
   "mcp": {
     "servers": {
       "provenote": {
-        "command": [
-          "bash",
+        "command": "bash",
+        "args": [
           "-lc",
           "cd /absolute/path/to/provenote && uv run provenote-mcp"
         ]

--- a/skills/provenote-mcp-outcome-workflows/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/provenote-mcp-outcome-workflows/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,13 @@
+{
+  "mcp": {
+    "servers": {
+      "provenote": {
+        "command": [
+          "bash",
+          "-lc",
+          "cd /absolute/path/to/provenote && uv run provenote-mcp"
+        ]
+      }
+    }
+  }
+}

--- a/skills/provenote-mcp-outcome-workflows/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/provenote-mcp-outcome-workflows/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "provenote": {
+      "command": "bash",
+      "args": [
+        "-lc",
+        "cd /absolute/path/to/provenote && uv run provenote-mcp"
+      ]
+    }
+  }
+}

--- a/skills/provenote-mcp-outcome-workflows/references/README.md
+++ b/skills/provenote-mcp-outcome-workflows/references/README.md
@@ -15,3 +15,5 @@ without depending on repo-root documents.
   - a ready-to-edit `mcpServers` snippet
 - `OPENCLAW_MCP_CONFIG.json`
   - a ready-to-edit `mcp.servers` snippet
+- `TROUBLESHOOTING.md`
+  - the first places to check when launch, list calls, or the first narrow mutation fails

--- a/skills/provenote-mcp-outcome-workflows/references/README.md
+++ b/skills/provenote-mcp-outcome-workflows/references/README.md
@@ -1,0 +1,17 @@
+# Provenote Skill References
+
+This directory keeps the practical material that a host reviewer or agent needs
+without depending on repo-root documents.
+
+## Included references
+
+- `INSTALL.md`
+  - install Provenote locally, launch `provenote-mcp`, and wire it into a host
+- `CAPABILITIES.md`
+  - the exposed MCP tool families and the recommended first-use sequence
+- `DEMO.md`
+  - exact demo prompts for OpenHands or OpenClaw
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet

--- a/skills/provenote-mcp-outcome-workflows/references/TROUBLESHOOTING.md
+++ b/skills/provenote-mcp-outcome-workflows/references/TROUBLESHOOTING.md
@@ -1,0 +1,50 @@
+# Provenote Troubleshooting
+
+Use this page when the packet looks correct but the first real read-first
+workflow still does not succeed.
+
+## 1. The MCP server does not launch
+
+Check these first:
+
+- the local clone exists and the install steps from `INSTALL.md` finished
+- the host config points at the right command, args, and working directory
+- the environment has the expected dependencies available for `provenote-mcp`
+
+If launch still fails, report it as a local install or config problem instead
+of claiming the packet is attach-ready.
+
+## 2. `draft.list`, `research_thread.list`, or `auditable_run.list` returns nothing
+
+An empty result is not automatically a bug. Confirm:
+
+- whether the workspace is actually populated yet
+- whether the user expected a fresh workspace or an existing notebook
+- whether the host is pointing at the intended notebook or data root
+
+If the workspace is empty, say so clearly and stop after the read-first pass.
+
+## 3. The first narrow mutation fails
+
+Stay narrow and retry in this order:
+
+1. rerun the three read-first list calls
+2. pick exactly one target artifact
+3. retry only one mutation such as `research_thread.to_draft` or `draft.verify`
+4. if it still fails, report the exact artifact id and the failing step
+
+Do not widen into multiple writes just to make the demo look busier.
+
+## 4. The reviewer asks what success looks like
+
+Point back to `DEMO.md` and verify these signals:
+
+- the agent lists real drafts, research threads, or auditable runs
+- the write action is tied to something that was just read
+- the agent names which repo-owned artifact changed
+
+## 5. Boundary reminder
+
+This packet teaches a local, first-party Provenote MCP workflow. It does not
+claim a hosted SaaS, a live marketplace listing, or a universal always-ready
+workspace.


### PR DESCRIPTION
## What these skills teach
- `prompt-switchboard-compare-workflows`: how an agent wires the local Prompt Switchboard MCP sidecar into a host, checks bridge readiness, and runs a compare-first browser workflow.
- `provenote-mcp-outcome-workflows`: how an agent wires the first-party Provenote MCP server into a host, starts with read-first listing tools, and then performs one narrow mutation tied back to an inspectable artifact.

## Why this revision is stronger
- both skills now begin with **what the agent learns**
- setup and host configs are explicit in `references/INSTALL.md`, `references/OPENHANDS_MCP_CONFIG.json`, and `references/OPENCLAW_MCP_CONFIG.json`
- safe-first tool ordering is explicit in `references/CAPABILITIES.md`
- first-success paths are explicit in `references/DEMO.md`
- troubleshooting is explicit in `references/TROUBLESHOOTING.md`
- claims stay local-first and artifact-backed instead of sounding like generic product marketing

## Boundaries kept explicit
- no hosted relay/runtime claims
- no "listed everywhere" claim hiding review-pending state
- no broad write automation claim without inspectable outcomes

## Validation
- local packet consistency checks passed before this PR refresh
