### PR TITLE
feat(skills): add campus and sourceharbor triage skills

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -473,6 +473,19 @@
             ]
         },
         {
+            "name": "campus-copilot-current-view-triage",
+            "source": "./campus-copilot-current-view-triage",
+            "description": "Turn a Campus Copilot snapshot or current-view export into one plain-language what-to-do-first answer for a student.",
+            "category": "productivity",
+            "keywords": [
+                "campus-copilot",
+                "student",
+                "triage",
+                "snapshot",
+                "read-only"
+            ]
+        },
+        {
             "name": "magic-test",
             "source": "./plugins/magic-test",
             "description": "A simple test plugin for verifying plugin loading. Triggers on magic words (alakazam, abracadabra) and returns a specific phrase to confirm plugins are working.",
@@ -496,6 +509,19 @@
                 "scheduling",
                 "openhands",
                 "slash-command"
+            ]
+        },
+        {
+            "name": "sourceharbor-watchlist-briefing",
+            "source": "./sourceharbor-watchlist-briefing",
+            "description": "Use SourceHarbor watchlists and briefing payloads to answer one operator question with evidence and a concrete next action.",
+            "category": "productivity",
+            "keywords": [
+                "sourceharbor",
+                "watchlist",
+                "briefing",
+                "mcp",
+                "operator"
             ]
         }
     ]

--- a/skills/campus-copilot-current-view-triage/README.md
+++ b/skills/campus-copilot-current-view-triage/README.md
@@ -1,19 +1,39 @@
-# Campus Copilot Current View Triage
+# Current View Triage
 
-This skill packages the strongest "what should I do first right now?" workflow from [Campus Copilot](https://github.com/xiaojiou176-open/campus-copilot).
+This skill is the compact read-only triage card for Campus Copilot.
 
-It is designed as a **read-only skill plus MCP setup companion**:
+It is designed to work like a lightweight plugin bundle:
 
-- summarize what is open right now
-- inspect the top Focus Queue items
-- answer one student question in plain language
-- call out trust gaps instead of inventing facts
+- one skill prompt that tells the agent what job to do
+- one install/config pack that tells the operator how to connect the runtime
+- one capability map that explains which Campus Copilot tools are exposed
+- one demo path that shows the shortest first-success flow
+- one troubleshooting page that explains where the first failures usually live
+- one manifest so the folder can travel into review-driven skill registries
 
-Use this when you want a lightweight OpenHands skill that feels like a decision card, not a live campus-browser automation flow.
+Use it when you want the shortest truthful answer to:
 
-Included companion references:
+- what should the student do first right now
 
-- `references/mcp-setup.md`
-- `references/input-shape.md`
-- `references/capability-map.md`
-- `references/example-output.md`
+## What this packet includes
+
+- `SKILL.md`
+  - the agent-facing triage workflow
+- `README.md`
+  - the human-facing packet overview
+- `manifest.yaml`
+  - registry-style metadata for host skill registries
+- `references/README.md`
+  - the local index for every supporting file
+- `references/INSTALL.md`
+  - install and host wiring guidance
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `references/CAPABILITIES.md`
+  - the read-only Campus Copilot tool surface
+- `references/DEMO.md`
+  - the first-success walkthrough and expected output shape
+- `references/TROUBLESHOOTING.md`
+  - the first places to check when setup or triage fails

--- a/skills/campus-copilot-current-view-triage/README.md
+++ b/skills/campus-copilot-current-view-triage/README.md
@@ -14,5 +14,6 @@ Use this when you want a lightweight OpenHands skill that feels like a decision 
 Included companion references:
 
 - `references/mcp-setup.md`
+- `references/input-shape.md`
 - `references/capability-map.md`
 - `references/example-output.md`

--- a/skills/campus-copilot-current-view-triage/README.md
+++ b/skills/campus-copilot-current-view-triage/README.md
@@ -2,7 +2,7 @@
 
 This skill packages the strongest "what should I do first right now?" workflow from [Campus Copilot](https://github.com/xiaojiou176-open/campus-copilot).
 
-It is designed for snapshot-first, read-only study triage:
+It is designed as a **read-only skill plus MCP setup companion**:
 
 - summarize what is open right now
 - inspect the top Focus Queue items
@@ -10,3 +10,9 @@ It is designed for snapshot-first, read-only study triage:
 - call out trust gaps instead of inventing facts
 
 Use this when you want a lightweight OpenHands skill that feels like a decision card, not a live campus-browser automation flow.
+
+Included companion references:
+
+- `references/mcp-setup.md`
+- `references/capability-map.md`
+- `references/example-output.md`

--- a/skills/campus-copilot-current-view-triage/README.md
+++ b/skills/campus-copilot-current-view-triage/README.md
@@ -1,0 +1,12 @@
+# Campus Copilot Current View Triage
+
+This skill packages the strongest "what should I do first right now?" workflow from [Campus Copilot](https://github.com/xiaojiou176-open/campus-copilot).
+
+It is designed for snapshot-first, read-only study triage:
+
+- summarize what is open right now
+- inspect the top Focus Queue items
+- answer one student question in plain language
+- call out trust gaps instead of inventing facts
+
+Use this when you want a lightweight OpenHands skill that feels like a decision card, not a live campus-browser automation flow.

--- a/skills/campus-copilot-current-view-triage/SKILL.md
+++ b/skills/campus-copilot-current-view-triage/SKILL.md
@@ -1,100 +1,76 @@
 ---
-name: campus-copilot-current-view-triage
+name: current-view-triage
 description: Turn one Campus Copilot snapshot or MCP-backed current view into a plain-language what-to-do-first answer for a student.
-triggers:
-  - campus copilot
-  - focus queue
-  - current view
-  - study triage
 ---
 
-# Campus Copilot Current View Triage
+# Current View Triage
 
-Use this skill when you need one short answer to the question:
+Use this skill when you want one plain-language answer to the question:
 
 - what should the student do first right now
 
-Think of it as a **student triage card** on top of Campus Copilot's read-only surfaces:
+Treat it like a **read-only triage plugin card** over one imported workspace snapshot or one local BFF-backed current view, not a live-browser playbook.
 
-- imported snapshot / current-view JSON
-- or one connected Campus Copilot MCP server
-- optionally one student question
+## What this skill teaches
 
-This skill is for **read-only context and prioritization**. It is not a live-browser or write-action playbook.
-
-## What this skill teaches the agent
-
-- how to tell whether Campus Copilot MCP is available or whether only a snapshot/current-view export is available
-- how to use the smallest helpful Campus Copilot surface first instead of expanding into browser automation
-- how to turn Focus Queue and recent changes into one clear next step
-- how to answer with evidence and trust gaps rather than filling in missing facts
+- how to prefer read-only Campus Copilot MCP or snapshot surfaces first
+- how to turn Focus Queue and recent changes into one concrete next action
+- how to answer with evidence and trust gaps instead of inventing missing facts
 
 ## Runtime you need
 
-- one imported Campus Copilot snapshot or current-view export
-- or a connected Campus Copilot MCP server
-- if MCP is not connected yet, hand the operator the setup recipe in `references/mcp-setup.md`
+- one imported snapshot path or one current-view export
+- or one connected Campus Copilot MCP server
+- use `references/INSTALL.md` if the MCP server still needs to be connected
+- use `references/DEMO.md` for the first-success walkthrough
+- use `references/TROUBLESHOOTING.md` if setup or input truth is still unclear
 
-## MCP capability map
+## Exposed MCP abilities
 
-Campus Copilot exposes a small read-only MCP surface. The tools that matter most for this skill are:
+- `campus_health`
+- `providers_status`
+- `ask_campus_copilot`
+- the four `*_snapshot_view` tools
+- `export_snapshot_artifact`
 
-- `campus_health` to confirm the local BFF is alive
-- `providers_status` to see whether the cited-answer path is ready
-- `ask_campus_copilot` to answer one question over the Campus semantic contract
-- `canvas_snapshot_view`, `gradescope_snapshot_view`, `edstem_snapshot_view`, `myuw_snapshot_view` to inspect site slices
-- `export_snapshot_artifact` to produce a portable proof artifact
+Use `references/CAPABILITIES.md` when you need the quick map.
 
-Use the quick mapping in `references/capability-map.md` when you need the full list.
-
-## Inputs to fill in
+## Inputs
 
 - `SNAPSHOT_PATH` or one current-view export path
-- `QUESTION` if the student wants more than "what now"
-- `MCP_STATUS` = connected or not connected
+- optional `QUESTION`
+- optional `MCP_STATUS`
 
 ## Steps
 
-1. Decide the strongest available input:
-   - MCP-backed current view if Campus Copilot MCP is already connected
-   - otherwise the imported snapshot/current-view export
-2. Build a short workspace summary:
-   - top Focus Queue items
-   - what changed recently
-   - which site is carrying the most urgency
-3. If `QUESTION` exists, answer it through `ask_campus_copilot` or the current-view payload.
-4. Return one plain-language recommendation that includes:
-   - the first action
-   - why it is first
-   - evidence used
-   - trust gaps
-   - the next setup step if MCP was missing
+1. Decide whether MCP-backed current view is available; otherwise stay on the imported snapshot/current-view export.
+2. Build a short workspace summary from the strongest available read-only surface.
+3. Inspect the top Focus Queue items and recent updates.
+4. If a question is provided, use the cited-answer path instead of guessing.
+5. Return:
+   - `top_action`
+   - `why_now`
+   - `evidence_used`
+   - `trust_gaps`
 
 ## Good fit
 
-- OpenHands first-pass triage over a Campus Copilot snapshot
-- local student-facing "what now" briefs
-- repo-local verification that the decision layer is understandable before reopening live browser work
-
-## Output contract
-
-Return these four fields in plain language:
-
-- `top_action`
-- `why_now`
-- `evidence_used`
-- `trust_gaps`
-
-See `references/example-output.md` for a compact example.
+- Codex or Claude-style first-pass triage over a snapshot
+- OpenClaw-style local consumers that need one short "what now" brief
+- any read-only triage workflow that needs one trustworthy next action without reopening browser automation
 
 ## Hard boundary
 
 - stay on imported snapshots or the thin local BFF
-- do not claim live browser or session truth from snapshot-only evidence
+- do not claim live browser/session truth from snapshot-only evidence
 - do not mutate site state
 
-## Local references
+## Companion references
 
-- `references/mcp-setup.md`
-- `references/capability-map.md`
-- `references/example-output.md`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`

--- a/skills/campus-copilot-current-view-triage/SKILL.md
+++ b/skills/campus-copilot-current-view-triage/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: campus-copilot-current-view-triage
+description: Give one plain-language what-to-do-first answer from a Campus Copilot snapshot or current-view export.
+---
+
+# Campus Copilot Current View Triage
+
+Use this skill when you want one plain-language answer to the question:
+
+- what should the student do first right now
+
+Treat it like a quick triage card over one imported Campus Copilot workspace snapshot or one local BFF-backed current view, not a live-browser playbook.
+
+## Inputs
+
+- one snapshot path, or one current-view export derived from the shared Campus Copilot contract
+- optional question for the local Campus consumer seam
+
+## Steps
+
+1. Build a workspace summary from the imported snapshot.
+2. Inspect the top Focus Queue items and recent updates.
+3. If a question is provided, ask the local Campus consumer seam for a cited answer.
+4. Return the answer with trust gaps instead of inventing missing facts.
+
+## Good fit
+
+- OpenHands first-pass triage over a Campus Copilot snapshot
+- local student-facing "what now" briefs
+- repo-local verification that the decision layer is understandable before reopening live browser work
+
+## Hard boundary
+
+- stay on imported snapshots or the thin local BFF
+- do not claim live browser or session truth from snapshot-only evidence
+- do not mutate site state
+
+## Companion references
+
+- `examples/workspace-snapshot.sample.json`
+- `examples/cli-usage.md`
+- `examples/openclaw-readonly.md`

--- a/skills/campus-copilot-current-view-triage/SKILL.md
+++ b/skills/campus-copilot-current-view-triage/SKILL.md
@@ -1,27 +1,74 @@
 ---
 name: campus-copilot-current-view-triage
-description: Give one plain-language what-to-do-first answer from a Campus Copilot snapshot or current-view export.
+description: Turn one Campus Copilot snapshot or MCP-backed current view into a plain-language what-to-do-first answer for a student.
+triggers:
+  - campus copilot
+  - focus queue
+  - current view
+  - study triage
 ---
 
 # Campus Copilot Current View Triage
 
-Use this skill when you want one plain-language answer to the question:
+Use this skill when you need one short answer to the question:
 
 - what should the student do first right now
 
-Treat it like a quick triage card over one imported Campus Copilot workspace snapshot or one local BFF-backed current view, not a live-browser playbook.
+Think of it as a **student triage card** on top of Campus Copilot's read-only surfaces:
 
-## Inputs
+- imported snapshot / current-view JSON
+- or one connected Campus Copilot MCP server
+- optionally one student question
 
-- one snapshot path, or one current-view export derived from the shared Campus Copilot contract
-- optional question for the local Campus consumer seam
+This skill is for **read-only context and prioritization**. It is not a live-browser or write-action playbook.
+
+## What this skill teaches the agent
+
+- how to tell whether Campus Copilot MCP is available or whether only a snapshot/current-view export is available
+- how to use the smallest helpful Campus Copilot surface first instead of expanding into browser automation
+- how to turn Focus Queue and recent changes into one clear next step
+- how to answer with evidence and trust gaps rather than filling in missing facts
+
+## Runtime you need
+
+- one imported Campus Copilot snapshot or current-view export
+- or a connected Campus Copilot MCP server
+- if MCP is not connected yet, hand the operator the setup recipe in `references/mcp-setup.md`
+
+## MCP capability map
+
+Campus Copilot exposes a small read-only MCP surface. The tools that matter most for this skill are:
+
+- `campus_health` to confirm the local BFF is alive
+- `providers_status` to see whether the cited-answer path is ready
+- `ask_campus_copilot` to answer one question over the Campus semantic contract
+- `canvas_snapshot_view`, `gradescope_snapshot_view`, `edstem_snapshot_view`, `myuw_snapshot_view` to inspect site slices
+- `export_snapshot_artifact` to produce a portable proof artifact
+
+Use the quick mapping in `references/capability-map.md` when you need the full list.
+
+## Inputs to fill in
+
+- `SNAPSHOT_PATH` or one current-view export path
+- `QUESTION` if the student wants more than "what now"
+- `MCP_STATUS` = connected or not connected
 
 ## Steps
 
-1. Build a workspace summary from the imported snapshot.
-2. Inspect the top Focus Queue items and recent updates.
-3. If a question is provided, ask the local Campus consumer seam for a cited answer.
-4. Return the answer with trust gaps instead of inventing missing facts.
+1. Decide the strongest available input:
+   - MCP-backed current view if Campus Copilot MCP is already connected
+   - otherwise the imported snapshot/current-view export
+2. Build a short workspace summary:
+   - top Focus Queue items
+   - what changed recently
+   - which site is carrying the most urgency
+3. If `QUESTION` exists, answer it through `ask_campus_copilot` or the current-view payload.
+4. Return one plain-language recommendation that includes:
+   - the first action
+   - why it is first
+   - evidence used
+   - trust gaps
+   - the next setup step if MCP was missing
 
 ## Good fit
 
@@ -29,14 +76,25 @@ Treat it like a quick triage card over one imported Campus Copilot workspace sna
 - local student-facing "what now" briefs
 - repo-local verification that the decision layer is understandable before reopening live browser work
 
+## Output contract
+
+Return these four fields in plain language:
+
+- `top_action`
+- `why_now`
+- `evidence_used`
+- `trust_gaps`
+
+See `references/example-output.md` for a compact example.
+
 ## Hard boundary
 
 - stay on imported snapshots or the thin local BFF
 - do not claim live browser or session truth from snapshot-only evidence
 - do not mutate site state
 
-## Companion references
+## Local references
 
-- `examples/workspace-snapshot.sample.json`
-- `examples/cli-usage.md`
-- `examples/openclaw-readonly.md`
+- `references/mcp-setup.md`
+- `references/capability-map.md`
+- `references/example-output.md`

--- a/skills/campus-copilot-current-view-triage/manifest.yaml
+++ b/skills/campus-copilot-current-view-triage/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: current-view-triage
+  display_name: Current View Triage
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/current-view-triage
+    submit_via: clawhub publish . --slug current-view-triage --name "Current View Triage" --version 1.0.0 --tags campus,student,triage,mcp,read-only
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/155
+    submit_via: submit this folder as skills/current-view-triage/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Read-only student triage over Campus Copilot snapshots or current-view MCP output.
+  canonical_repo_version: 0.1.0
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No live browser-session truth is claimed from snapshot-only evidence
+    - No hosted Campus Copilot service is claimed
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/TROUBLESHOOTING.md

--- a/skills/campus-copilot-current-view-triage/references/CAPABILITIES.md
+++ b/skills/campus-copilot-current-view-triage/references/CAPABILITIES.md
@@ -1,0 +1,21 @@
+# Campus Copilot Capability Map
+
+This skill intentionally stays on the read-only Campus Copilot surfaces.
+
+## Core MCP tools
+
+- `campus_health`
+- `providers_status`
+- `ask_campus_copilot`
+- `canvas_snapshot_view`
+- `gradescope_snapshot_view`
+- `edstem_snapshot_view`
+- `myuw_snapshot_view`
+- `export_snapshot_artifact`
+
+## Best default order
+
+1. `campus_health`
+2. one or more `*_snapshot_view` tools
+3. `ask_campus_copilot` if a question exists
+4. `export_snapshot_artifact` only if the operator needs a saved proof artifact

--- a/skills/campus-copilot-current-view-triage/references/DEMO.md
+++ b/skills/campus-copilot-current-view-triage/references/DEMO.md
@@ -1,0 +1,23 @@
+# OpenHands / OpenClaw Demo Walkthrough
+
+This is the shortest concrete demo you can run to prove the skill is doing real
+triage work instead of only existing as prose.
+
+## Demo prompt
+
+Use Campus Copilot to tell the student what to do first right now. Start with
+`campus_health`. Then inspect the strongest available snapshot/current-view
+surface. If a student question exists, answer it through `ask_campus_copilot`.
+Return `top_action`, `why_now`, `evidence_used`, and `trust_gaps`.
+
+## Expected tool sequence
+
+1. `campus_health`
+2. one or more `*_snapshot_view` tools
+3. optionally `ask_campus_copilot`
+
+## Visible success criteria
+
+- the agent names one concrete first action
+- the answer cites the Focus Queue or snapshot surface instead of guessing
+- the boundary stays read-only and snapshot-aware

--- a/skills/campus-copilot-current-view-triage/references/INSTALL.md
+++ b/skills/campus-copilot-current-view-triage/references/INSTALL.md
@@ -1,0 +1,36 @@
+# Campus Copilot MCP Setup
+
+Use this when the host runtime does not already have Campus Copilot MCP
+connected.
+
+## Quickest local setup
+
+1. Clone the public repo:
+
+```bash
+git clone https://github.com/xiaojiou176-open/campus-copilot.git
+cd campus-copilot
+pnpm install
+```
+
+2. Build the read-only MCP server:
+
+```bash
+pnpm --filter @campus-copilot/mcp-server build
+```
+
+3. Start the MCP server directly:
+
+```bash
+pnpm --filter @campus-copilot/mcp-server start
+```
+
+4. Before loading the host config snippets in this folder, replace
+   `/ABSOLUTE/PATH/TO/campus-copilot` with the real path to your local clone.
+
+## If your host supports MCP Bundles
+
+Campus Copilot also ships a release-hosted MCP bundle:
+
+- registry name: `io.github.xiaojiou176-open/campus-copilot-mcp`
+- release asset: `https://github.com/xiaojiou176-open/campus-copilot/releases/download/v0.1.0/campus-copilot-mcp-0.1.0.mcpb`

--- a/skills/campus-copilot-current-view-triage/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/campus-copilot-current-view-triage/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,11 @@
+{
+  "mcp": {
+    "servers": {
+      "campus-copilot": {
+        "command": "pnpm",
+        "args": ["--filter", "@campus-copilot/mcp-server", "start"],
+        "cwd": "/ABSOLUTE/PATH/TO/campus-copilot"
+      }
+    }
+  }
+}

--- a/skills/campus-copilot-current-view-triage/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/campus-copilot-current-view-triage/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "campus-copilot": {
+      "command": "pnpm",
+      "args": ["--filter", "@campus-copilot/mcp-server", "start"],
+      "cwd": "/ABSOLUTE/PATH/TO/campus-copilot"
+    }
+  }
+}

--- a/skills/campus-copilot-current-view-triage/references/README.md
+++ b/skills/campus-copilot-current-view-triage/references/README.md
@@ -1,0 +1,19 @@
+# Campus Copilot Skill References
+
+This directory keeps the practical material that a reviewer or agent needs
+without depending on repo-root docs.
+
+## Included references
+
+- `INSTALL.md`
+  - install the Campus Copilot MCP server and wire it into a host
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - the read-only Campus Copilot tool surface and first-use order
+- `DEMO.md`
+  - the shortest first-success walkthrough and expected output shape
+- `TROUBLESHOOTING.md`
+  - the first places to check when setup or triage fails

--- a/skills/campus-copilot-current-view-triage/references/TROUBLESHOOTING.md
+++ b/skills/campus-copilot-current-view-triage/references/TROUBLESHOOTING.md
@@ -1,0 +1,26 @@
+# Campus Copilot Troubleshooting
+
+Use this page when the packet looks right on paper but the first triage answer
+still fails.
+
+## 1. The MCP server does not launch
+
+Check these first:
+
+- `pnpm install` finished in the repo root
+- the host config points at the right `cwd`
+- the MCP server was built before you tried to start it
+
+If launch still fails, report it as a local MCP setup problem instead of
+pretending the triage lane is ready.
+
+## 2. Only snapshot/current-view files are available
+
+That is allowed. Stay on the snapshot path and make the trust gap explicit.
+Do not claim live browser or session truth.
+
+## 3. The question is broader than one read-only next action
+
+Stop after the triage answer and tell the user what extra surface is missing.
+This packet is for “what should I do first right now,” not for broad workflow
+automation.

--- a/skills/campus-copilot-current-view-triage/references/capability-map.md
+++ b/skills/campus-copilot-current-view-triage/references/capability-map.md
@@ -1,0 +1,21 @@
+# Campus Copilot Capability Map
+
+This skill is intentionally narrow. It does not need every tool every time.
+
+## Core MCP tools
+
+- `campus_health`: verify that the local Campus Copilot BFF is alive
+- `providers_status`: check whether cited-answer providers are ready
+- `ask_campus_copilot`: answer one student question over the Campus semantic contract
+- `canvas_snapshot_view`: inspect Canvas snapshot records
+- `gradescope_snapshot_view`: inspect Gradescope snapshot records
+- `edstem_snapshot_view`: inspect EdStem snapshot records
+- `myuw_snapshot_view`: inspect MyUW snapshot records
+- `export_snapshot_artifact`: export a portable snapshot artifact
+
+## Best default order
+
+1. `campus_health`
+2. one or more `*_snapshot_view` tools
+3. `ask_campus_copilot` if a question exists
+4. `export_snapshot_artifact` only if the operator needs a saved proof artifact

--- a/skills/campus-copilot-current-view-triage/references/capability-map.md
+++ b/skills/campus-copilot-current-view-triage/references/capability-map.md
@@ -1,21 +1,21 @@
-# Campus Copilot Capability Map
+# Current View Triage Capability Map
 
-This skill is intentionally narrow. It does not need every tool every time.
+This skill only needs the read-only Campus Copilot surfaces.
 
-## Core MCP tools
+## Core tools
 
-- `campus_health`: verify that the local Campus Copilot BFF is alive
-- `providers_status`: check whether cited-answer providers are ready
-- `ask_campus_copilot`: answer one student question over the Campus semantic contract
-- `canvas_snapshot_view`: inspect Canvas snapshot records
-- `gradescope_snapshot_view`: inspect Gradescope snapshot records
-- `edstem_snapshot_view`: inspect EdStem snapshot records
-- `myuw_snapshot_view`: inspect MyUW snapshot records
-- `export_snapshot_artifact`: export a portable snapshot artifact
+- `campus_health`
+- `providers_status`
+- `ask_campus_copilot`
+- `canvas_snapshot_view`
+- `gradescope_snapshot_view`
+- `edstem_snapshot_view`
+- `myuw_snapshot_view`
+- `export_snapshot_artifact`
 
 ## Best default order
 
-1. `campus_health`
-2. one or more `*_snapshot_view` tools
-3. `ask_campus_copilot` if a question exists
-4. `export_snapshot_artifact` only if the operator needs a saved proof artifact
+1. health
+2. one or more snapshot-view tools
+3. ask, if there is an explicit question
+4. export only if the operator needs a saved proof artifact

--- a/skills/campus-copilot-current-view-triage/references/example-output.md
+++ b/skills/campus-copilot-current-view-triage/references/example-output.md
@@ -1,0 +1,8 @@
+# Example Output Shape
+
+```text
+Top action: Finish the Canvas item due tomorrow before touching the lower-priority backlog.
+Why now: It is the nearest due item and it also blocks the rest of this week's workload plan.
+Evidence used: Focus Queue rank 1, recent current-view change summary, and the Canvas snapshot slice.
+Trust gaps: No live browser truth was checked, so this answer assumes the imported snapshot is current.
+```

--- a/skills/campus-copilot-current-view-triage/references/example-output.md
+++ b/skills/campus-copilot-current-view-triage/references/example-output.md
@@ -1,8 +1,8 @@
-# Example Output Shape
+# Example Output
 
 ```text
-Top action: Finish the Canvas item due tomorrow before touching the lower-priority backlog.
-Why now: It is the nearest due item and it also blocks the rest of this week's workload plan.
-Evidence used: Focus Queue rank 1, recent current-view change summary, and the Canvas snapshot slice.
-Trust gaps: No live browser truth was checked, so this answer assumes the imported snapshot is current.
+Top action: Finish the Canvas item due tomorrow before the lower-priority backlog.
+Why now: It is the nearest due item and it blocks the rest of the week's plan.
+Evidence used: Focus Queue rank 1, recent current-view changes, and the Canvas snapshot slice.
+Trust gaps: This answer is snapshot-scoped and does not claim live browser truth.
 ```

--- a/skills/campus-copilot-current-view-triage/references/input-shape.md
+++ b/skills/campus-copilot-current-view-triage/references/input-shape.md
@@ -1,0 +1,43 @@
+# Campus Copilot Input Shape
+
+Use this when Campus Copilot MCP is not connected and the agent only has a snapshot or current-view export.
+
+## What the triage skill needs
+
+At minimum, the input should expose:
+
+- top Focus Queue items
+- recent changes or recent updates
+- enough site context to decide which area is most urgent
+
+## Minimal mental model
+
+The exact JSON can vary, but the triage workflow expects something equivalent to:
+
+```json
+{
+  "generatedAt": "2026-04-08T00:00:00Z",
+  "focusQueue": [
+    {
+      "title": "Homework 1",
+      "site": "canvas",
+      "priority": "high"
+    }
+  ],
+  "recentChanges": [
+    {
+      "site": "canvas",
+      "summary": "New assignment detected"
+    }
+  ]
+}
+```
+
+## If you only have a raw workspace snapshot
+
+Use the smallest helpful transformation first:
+
+- inspect one or more `*_snapshot_view` MCP tools, or
+- ask the operator for a current-view export that already summarizes Focus Queue and recent changes
+
+Do not invent overdue items, grades, or browser/session truth that are not present in the provided input.

--- a/skills/campus-copilot-current-view-triage/references/input-shape.md
+++ b/skills/campus-copilot-current-view-triage/references/input-shape.md
@@ -1,4 +1,4 @@
-# Campus Copilot Input Shape
+# Current View Input Shape
 
 Use this when Campus Copilot MCP is not connected and the agent only has a snapshot or current-view export.
 
@@ -37,7 +37,7 @@ The exact JSON can vary, but the triage workflow expects something equivalent to
 
 Use the smallest helpful transformation first:
 
-- inspect one or more `*_snapshot_view` MCP tools, or
-- ask the operator for a current-view export that already summarizes Focus Queue and recent changes
+- inspect the `*_snapshot_view` MCP tools, or
+- ask for a current-view export that already summarizes Focus Queue and recent changes
 
 Do not invent overdue items, grades, or browser/session truth that are not present in the provided input.

--- a/skills/campus-copilot-current-view-triage/references/mcp-setup.md
+++ b/skills/campus-copilot-current-view-triage/references/mcp-setup.md
@@ -1,38 +1,22 @@
-# Campus Copilot MCP Setup
+# Current View Triage MCP Setup
 
-Use this when the host runtime does not already have Campus Copilot MCP connected.
+## Fastest local setup
 
-## Quickest local setup
-
-1. Clone the public repo:
+From the Campus Copilot repo root:
 
 ```bash
-git clone https://github.com/xiaojiou176-open/campus-copilot.git
-cd campus-copilot
 pnpm install
-```
-
-2. Build the read-only MCP server:
-
-```bash
 pnpm --filter @campus-copilot/mcp-server build
-```
-
-3. Start the MCP server directly:
-
-```bash
 pnpm --filter @campus-copilot/mcp-server start
 ```
 
-## If your host supports MCP Bundles
-
-Campus Copilot also ships a release-hosted MCP Bundle:
+## If the host supports MCP Bundles
 
 - registry name: `io.github.xiaojiou176-open/campus-copilot-mcp`
 - release asset: `https://github.com/xiaojiou176-open/campus-copilot/releases/download/v0.1.0/campus-copilot-mcp-0.1.0.mcpb`
 
-## What the operator should hand back to the agent
+## Minimum handoff to the agent
 
-- whether Campus Copilot MCP is connected
-- whether only a snapshot/current-view export is available
-- the path to the snapshot or current-view file if MCP is not connected
+- one imported snapshot or current-view export path
+- whether Campus Copilot MCP is already connected
+- optional student question

--- a/skills/campus-copilot-current-view-triage/references/mcp-setup.md
+++ b/skills/campus-copilot-current-view-triage/references/mcp-setup.md
@@ -1,0 +1,38 @@
+# Campus Copilot MCP Setup
+
+Use this when the host runtime does not already have Campus Copilot MCP connected.
+
+## Quickest local setup
+
+1. Clone the public repo:
+
+```bash
+git clone https://github.com/xiaojiou176-open/campus-copilot.git
+cd campus-copilot
+pnpm install
+```
+
+2. Build the read-only MCP server:
+
+```bash
+pnpm --filter @campus-copilot/mcp-server build
+```
+
+3. Start the MCP server directly:
+
+```bash
+pnpm --filter @campus-copilot/mcp-server start
+```
+
+## If your host supports MCP Bundles
+
+Campus Copilot also ships a release-hosted MCP Bundle:
+
+- registry name: `io.github.xiaojiou176-open/campus-copilot-mcp`
+- release asset: `https://github.com/xiaojiou176-open/campus-copilot/releases/download/v0.1.0/campus-copilot-mcp-0.1.0.mcpb`
+
+## What the operator should hand back to the agent
+
+- whether Campus Copilot MCP is connected
+- whether only a snapshot/current-view export is available
+- the path to the snapshot or current-view file if MCP is not connected

--- a/skills/sourceharbor-watchlist-briefing/README.md
+++ b/skills/sourceharbor-watchlist-briefing/README.md
@@ -2,7 +2,7 @@
 
 This skill packages the watchlist-briefing workflow from [SourceHarbor](https://github.com/xiaojiou176-open/sourceharbor) for OpenHands.
 
-It is meant to feel like a **plugin-grade operator recipe**:
+It is meant to feel like a **self-contained operator skill package**:
 
 - start from one watchlist
 - load the current briefing/story payload
@@ -14,5 +14,6 @@ Use it when you want a source-first briefing workflow that can reuse SourceHarbo
 Included companion references:
 
 - `references/mcp-and-http-setup.md`
+- `references/http-fallback.md`
 - `references/capability-map.md`
 - `references/example-output.md`

--- a/skills/sourceharbor-watchlist-briefing/README.md
+++ b/skills/sourceharbor-watchlist-briefing/README.md
@@ -1,0 +1,12 @@
+# SourceHarbor Watchlist Briefing
+
+This skill packages the watchlist-briefing workflow from [SourceHarbor](https://github.com/xiaojiou176-open/sourceharbor) for OpenHands.
+
+It helps an agent:
+
+- start from one watchlist
+- load the current briefing/story payload
+- answer one operator question with evidence
+- finish with one concrete next action
+
+Use it when you want a source-first briefing workflow that can reuse SourceHarbor MCP or HTTP surfaces without pretending the product is already a hosted SaaS.

--- a/skills/sourceharbor-watchlist-briefing/README.md
+++ b/skills/sourceharbor-watchlist-briefing/README.md
@@ -1,19 +1,37 @@
 # SourceHarbor Watchlist Briefing
 
-This skill packages the watchlist-briefing workflow from [SourceHarbor](https://github.com/xiaojiou176-open/sourceharbor) for OpenHands.
+This skill is the OpenClaw-facing watchlist briefing card for SourceHarbor.
 
-It is meant to feel like a **self-contained operator skill package**:
+It is designed to behave like a self-contained operator skill package:
 
-- start from one watchlist
-- load the current briefing/story payload
-- answer one operator question with evidence
-- finish with one concrete next action
+- one skill prompt that teaches the agent the workflow
+- one install/config pack for MCP and HTTP fallback
+- one capability map over the SourceHarbor operator surfaces
+- one first-success demo path
+- one troubleshooting page that explains where the first failures live
+- one manifest so the folder can travel into review-driven skill registries
 
-Use it when you want a source-first briefing workflow that can reuse SourceHarbor MCP or HTTP surfaces without pretending the product is already a hosted SaaS.
+Use it when the agent should start from one watchlist, reuse the current story/briefing context, and answer one operator question with evidence.
 
-Included companion references:
+## What this packet includes
 
-- `references/mcp-and-http-setup.md`
-- `references/http-fallback.md`
-- `references/capability-map.md`
-- `references/example-output.md`
+- `SKILL.md`
+  - the agent-facing watchlist briefing workflow
+- `README.md`
+  - the human-facing packet overview
+- `manifest.yaml`
+  - registry-style metadata for host skill registries
+- `references/README.md`
+  - the local index for every supporting file
+- `references/INSTALL.md`
+  - MCP and HTTP setup guidance
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `references/CAPABILITIES.md`
+  - the operator-facing MCP capability map
+- `references/DEMO.md`
+  - the first-success walkthrough and expected output shape
+- `references/TROUBLESHOOTING.md`
+  - the first places to check when MCP or HTTP access fails

--- a/skills/sourceharbor-watchlist-briefing/README.md
+++ b/skills/sourceharbor-watchlist-briefing/README.md
@@ -2,7 +2,7 @@
 
 This skill packages the watchlist-briefing workflow from [SourceHarbor](https://github.com/xiaojiou176-open/sourceharbor) for OpenHands.
 
-It helps an agent:
+It is meant to feel like a **plugin-grade operator recipe**:
 
 - start from one watchlist
 - load the current briefing/story payload
@@ -10,3 +10,9 @@ It helps an agent:
 - finish with one concrete next action
 
 Use it when you want a source-first briefing workflow that can reuse SourceHarbor MCP or HTTP surfaces without pretending the product is already a hosted SaaS.
+
+Included companion references:
+
+- `references/mcp-and-http-setup.md`
+- `references/capability-map.md`
+- `references/example-output.md`

--- a/skills/sourceharbor-watchlist-briefing/SKILL.md
+++ b/skills/sourceharbor-watchlist-briefing/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sourceharbor-watchlist-briefing
+description: Use SourceHarbor watchlists, briefings, Ask, MCP, and HTTP API to answer one question with current story context and evidence.
+---
+
+Use this skill when you want OpenHands to inspect one SourceHarbor watchlist and answer a question with the current story and evidence context.
+
+## Goal
+
+- start from one watchlist
+- reuse the current briefing or story payload
+- answer one operator question
+- cite the evidence used
+- return one concrete next action
+
+## Inputs To Fill In
+
+- `WATCHLIST_ID`: the watchlist you want to inspect
+- `QUESTION`: the question you want answered
+- `SOURCE_HARBOR_API_BASE_URL`: the SourceHarbor API base URL when MCP is not wired
+- `SOURCE_HARBOR_MCP_STATUS`: whether SourceHarbor MCP is already connected
+
+## Workflow
+
+Use the strongest available path in this order:
+
+1. SourceHarbor MCP, if it is already connected
+2. SourceHarbor HTTP API at `SOURCE_HARBOR_API_BASE_URL`
+3. SourceHarbor web routes only as visible proof surfaces
+
+Required steps:
+
+1. Load the watchlist object.
+2. Load the current watchlist briefing or briefing page payload.
+3. Identify the selected story and the recent changes.
+4. Answer `QUESTION` using that story context.
+5. Return:
+   - Current story
+   - What changed
+   - Evidence used
+   - Suggested next operator action
+
+## Guardrails
+
+- Do not pretend SourceHarbor is a hosted SaaS.
+- Do not turn sample or demo surfaces into live-proof claims.
+- Do not answer without evidence.
+- If MCP or HTTP access is partial, say so clearly instead of filling gaps.
+
+## Related Public Surfaces
+
+- `docs/compat/openclaw.md`
+- `docs/builders.md`
+- `docs/mcp-quickstart.md`
+- `starter-packs/openclaw/README.md`

--- a/skills/sourceharbor-watchlist-briefing/SKILL.md
+++ b/skills/sourceharbor-watchlist-briefing/SKILL.md
@@ -12,7 +12,7 @@ triggers:
 
 Use this skill when you want OpenHands to inspect one SourceHarbor watchlist and answer a question with the current story and evidence context.
 
-Think of it as an **operator briefing plugin without executable code**:
+Think of it as an **operator briefing skill card**:
 
 - it teaches the agent how to use SourceHarbor's MCP or HTTP API
 - it starts from one watchlist
@@ -39,6 +39,7 @@ Think of it as an **operator briefing plugin without executable code**:
 - a connected SourceHarbor MCP server, or
 - a running local SourceHarbor HTTP API
 - if neither is ready yet, use `references/mcp-and-http-setup.md`
+- if HTTP is the only path, use `references/http-fallback.md`
 
 ## Capability map
 
@@ -47,7 +48,7 @@ SourceHarbor exposes a shared operator truth across MCP and HTTP API. The capabi
 - watchlist and briefing retrieval
 - Ask/search over the current story context
 - jobs, artifacts, and reports as evidence follow-ups
-- health and workflow tools when the runtime itself needs checking
+- health checks when the runtime itself needs checking
 
 Use `references/capability-map.md` for a concrete tool-group map.
 
@@ -91,5 +92,6 @@ Return a compact answer with:
 ## Local references
 
 - `references/mcp-and-http-setup.md`
+- `references/http-fallback.md`
 - `references/capability-map.md`
 - `references/example-output.md`

--- a/skills/sourceharbor-watchlist-briefing/SKILL.md
+++ b/skills/sourceharbor-watchlist-briefing/SKILL.md
@@ -1,17 +1,31 @@
 ---
 name: sourceharbor-watchlist-briefing
 description: Use SourceHarbor watchlists, briefings, Ask, MCP, and HTTP API to answer one question with current story context and evidence.
+triggers:
+  - sourceharbor
+  - watchlist
+  - briefing
+  - operator question
 ---
+
+# SourceHarbor Watchlist Briefing
 
 Use this skill when you want OpenHands to inspect one SourceHarbor watchlist and answer a question with the current story and evidence context.
 
-## Goal
+Think of it as an **operator briefing plugin without executable code**:
 
-- start from one watchlist
-- reuse the current briefing or story payload
-- answer one operator question
-- cite the evidence used
-- return one concrete next action
+- it teaches the agent how to use SourceHarbor's MCP or HTTP API
+- it starts from one watchlist
+- it reuses the current briefing/story payload
+- it answers one operator question with evidence
+- it finishes with one concrete next action
+
+## What this skill teaches the agent
+
+- how to prefer SourceHarbor MCP when it is already connected
+- how to fall back to the HTTP API without pretending the product is hosted SaaS
+- how to answer from the current story and change set rather than from vague search alone
+- how to return a briefing-style answer with explicit evidence and next action
 
 ## Inputs To Fill In
 
@@ -19,6 +33,23 @@ Use this skill when you want OpenHands to inspect one SourceHarbor watchlist and
 - `QUESTION`: the question you want answered
 - `SOURCE_HARBOR_API_BASE_URL`: the SourceHarbor API base URL when MCP is not wired
 - `SOURCE_HARBOR_MCP_STATUS`: whether SourceHarbor MCP is already connected
+
+## Runtime you need
+
+- a connected SourceHarbor MCP server, or
+- a running local SourceHarbor HTTP API
+- if neither is ready yet, use `references/mcp-and-http-setup.md`
+
+## Capability map
+
+SourceHarbor exposes a shared operator truth across MCP and HTTP API. The capability groups that matter most for this skill are:
+
+- watchlist and briefing retrieval
+- Ask/search over the current story context
+- jobs, artifacts, and reports as evidence follow-ups
+- health and workflow tools when the runtime itself needs checking
+
+Use `references/capability-map.md` for a concrete tool-group map.
 
 ## Workflow
 
@@ -40,6 +71,16 @@ Required steps:
    - Evidence used
    - Suggested next operator action
 
+## Output contract
+
+Return a compact answer with:
+
+- `current_story`
+- `what_changed`
+- `evidence_used`
+- `suggested_next_action`
+- `runtime_gap` if MCP or HTTP access was partial
+
 ## Guardrails
 
 - Do not pretend SourceHarbor is a hosted SaaS.
@@ -47,9 +88,8 @@ Required steps:
 - Do not answer without evidence.
 - If MCP or HTTP access is partial, say so clearly instead of filling gaps.
 
-## Related Public Surfaces
+## Local references
 
-- `docs/compat/openclaw.md`
-- `docs/builders.md`
-- `docs/mcp-quickstart.md`
-- `starter-packs/openclaw/README.md`
+- `references/mcp-and-http-setup.md`
+- `references/capability-map.md`
+- `references/example-output.md`

--- a/skills/sourceharbor-watchlist-briefing/SKILL.md
+++ b/skills/sourceharbor-watchlist-briefing/SKILL.md
@@ -10,22 +10,41 @@ triggers:
 
 # SourceHarbor Watchlist Briefing
 
-Use this skill when you want OpenHands to inspect one SourceHarbor watchlist and answer a question with the current story and evidence context.
+Use this skill when you want OpenClaw to inspect one SourceHarbor watchlist and
+answer a question with the current story and evidence context.
 
 Think of it as an **operator briefing skill card**:
 
-- it teaches the agent how to use SourceHarbor's MCP or HTTP API
-- it starts from one watchlist
-- it reuses the current briefing/story payload
-- it answers one operator question with evidence
-- it finishes with one concrete next action
+- it teaches the agent the workflow
+- it names the MCP/HTTP setup needed
+- it shows which SourceHarbor capabilities matter
+- it keeps the answer evidence-backed and operational
 
-## What this skill teaches the agent
+## Goal
 
-- how to prefer SourceHarbor MCP when it is already connected
-- how to fall back to the HTTP API without pretending the product is hosted SaaS
-- how to answer from the current story and change set rather than from vague search alone
-- how to return a briefing-style answer with explicit evidence and next action
+- start from one watchlist
+- reuse the current briefing or story payload
+- answer one operator question
+- cite the evidence used
+- return one concrete next action
+
+## Runtime you need
+
+- one connected SourceHarbor MCP server, or
+- one running SourceHarbor HTTP API at `SOURCE_HARBOR_API_BASE_URL`
+- if either still needs wiring, use `references/INSTALL.md`
+
+## Exposed MCP abilities
+
+This skill is built around these SourceHarbor capability groups:
+
+- health
+- retrieval / Ask-style evidence lookup
+- jobs and compare views
+- artifacts and reports
+- workflows, subscriptions, and notifications when the question is really about operator state
+
+Use `references/CAPABILITIES.md` for the concrete tool map.
 
 ## Inputs To Fill In
 
@@ -33,24 +52,6 @@ Think of it as an **operator briefing skill card**:
 - `QUESTION`: the question you want answered
 - `SOURCE_HARBOR_API_BASE_URL`: the SourceHarbor API base URL when MCP is not wired
 - `SOURCE_HARBOR_MCP_STATUS`: whether SourceHarbor MCP is already connected
-
-## Runtime you need
-
-- a connected SourceHarbor MCP server, or
-- a running local SourceHarbor HTTP API
-- if neither is ready yet, use `references/mcp-and-http-setup.md`
-- if HTTP is the only path, use `references/http-fallback.md`
-
-## Capability map
-
-SourceHarbor exposes a shared operator truth across MCP and HTTP API. The capability groups that matter most for this skill are:
-
-- watchlist and briefing retrieval
-- Ask/search over the current story context
-- jobs, artifacts, and reports as evidence follow-ups
-- health checks when the runtime itself needs checking
-
-Use `references/capability-map.md` for a concrete tool-group map.
 
 ## Workflow
 
@@ -74,7 +75,7 @@ Required steps:
 
 ## Output contract
 
-Return a compact answer with:
+Return:
 
 - `current_story`
 - `what_changed`
@@ -85,13 +86,17 @@ Return a compact answer with:
 ## Guardrails
 
 - Do not pretend SourceHarbor is a hosted SaaS.
-- Do not turn sample or demo surfaces into live-proof claims.
+- Do not turn sample/demo surfaces into live-proof claims.
 - Do not answer without evidence.
 - If MCP or HTTP access is partial, say so clearly instead of filling gaps.
 
-## Local references
+## Companion references
 
-- `references/mcp-and-http-setup.md`
-- `references/http-fallback.md`
-- `references/capability-map.md`
-- `references/example-output.md`
+- `README.md`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`

--- a/skills/sourceharbor-watchlist-briefing/manifest.yaml
+++ b/skills/sourceharbor-watchlist-briefing/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: sourceharbor-watchlist-briefing
+  display_name: SourceHarbor Watchlist Briefing
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/sourceharbor-watchlist-briefing
+    submit_via: clawhub publish . --slug sourceharbor-watchlist-briefing --name "SourceHarbor Watchlist Briefing" --version 1.0.0 --tags sourceharbor,watchlist,briefing,mcp,operator
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/155
+    submit_via: submit this folder as skills/sourceharbor-watchlist-briefing/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Watchlist-first operator briefing skill over SourceHarbor MCP or local HTTP API.
+  canonical_repo_version: 0.1.14
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No hosted SourceHarbor SaaS is claimed
+    - No answer should be given without evidence
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/TROUBLESHOOTING.md

--- a/skills/sourceharbor-watchlist-briefing/references/CAPABILITIES.md
+++ b/skills/sourceharbor-watchlist-briefing/references/CAPABILITIES.md
@@ -1,6 +1,7 @@
 # SourceHarbor Capability Map
 
-This skill focuses on the SourceHarbor surfaces that help answer one operator question from one watchlist.
+This skill focuses on the SourceHarbor surfaces that help answer one operator
+question from one watchlist.
 
 ## Relevant MCP capability groups
 
@@ -16,6 +17,6 @@ This skill focuses on the SourceHarbor surfaces that help answer one operator qu
 
 1. health
 2. watchlist + briefing payload
-3. retrieval / ask-style evidence lookup
+3. retrieval or ask-style evidence lookup
 4. jobs or artifacts only when the answer needs proof of what changed
 5. do not drift into subscription or notification changes unless the operator changes the task

--- a/skills/sourceharbor-watchlist-briefing/references/DEMO.md
+++ b/skills/sourceharbor-watchlist-briefing/references/DEMO.md
@@ -1,0 +1,24 @@
+# OpenHands / OpenClaw Demo Walkthrough
+
+This is the shortest concrete demo you can run to prove the skill is doing real
+operator-briefing work instead of only existing as prose.
+
+## Demo prompt
+
+Inspect one SourceHarbor watchlist and answer one operator question with
+evidence. Start with the watchlist object and current briefing payload. Then
+name the current story, what changed, the evidence used, and the suggested next
+operator action.
+
+## Expected sequence
+
+1. health
+2. watchlist or briefing payload
+3. retrieval / search if the briefing is incomplete
+4. jobs or artifacts only if the answer needs proof of what changed
+
+## Visible success criteria
+
+- the answer starts from one explicit watchlist
+- the answer names the current story and what changed
+- the answer cites evidence and ends with one concrete next action

--- a/skills/sourceharbor-watchlist-briefing/references/INSTALL.md
+++ b/skills/sourceharbor-watchlist-briefing/references/INSTALL.md
@@ -1,0 +1,27 @@
+# SourceHarbor MCP And HTTP Setup
+
+Use this when the host runtime does not already have SourceHarbor connected.
+
+## Local repo setup
+
+1. Clone the public repo:
+
+```bash
+git clone https://github.com/xiaojiou176-open/sourceharbor.git
+cd sourceharbor
+```
+
+2. Start the local MCP surface:
+
+```bash
+./bin/dev-mcp
+```
+
+3. Before loading the host config snippets in this folder, replace
+   `/ABSOLUTE/PATH/TO/sourceharbor` with the real path to your local clone.
+
+4. If you need the HTTP API fallback, make sure the local API is running and set:
+
+```bash
+export SOURCE_HARBOR_API_BASE_URL=http://127.0.0.1:9000
+```

--- a/skills/sourceharbor-watchlist-briefing/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/sourceharbor-watchlist-briefing/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,10 @@
+{
+  "mcp": {
+    "servers": {
+      "sourceharbor": {
+        "command": "./bin/dev-mcp",
+        "cwd": "/ABSOLUTE/PATH/TO/sourceharbor"
+      }
+    }
+  }
+}

--- a/skills/sourceharbor-watchlist-briefing/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/sourceharbor-watchlist-briefing/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sourceharbor": {
+      "command": "./bin/dev-mcp",
+      "cwd": "/ABSOLUTE/PATH/TO/sourceharbor"
+    }
+  }
+}

--- a/skills/sourceharbor-watchlist-briefing/references/README.md
+++ b/skills/sourceharbor-watchlist-briefing/references/README.md
@@ -1,0 +1,19 @@
+# SourceHarbor Skill References
+
+This directory keeps the practical material that a reviewer or agent needs
+without depending on repo-root docs.
+
+## Included references
+
+- `INSTALL.md`
+  - MCP and HTTP setup guidance for the local operator path
+- `OPENHANDS_MCP_CONFIG.json`
+  - a ready-to-edit `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - a ready-to-edit `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - the operator-facing MCP capability map and safe-first order
+- `DEMO.md`
+  - the first-success walkthrough and expected output shape
+- `TROUBLESHOOTING.md`
+  - the first places to check when MCP or HTTP access fails

--- a/skills/sourceharbor-watchlist-briefing/references/TROUBLESHOOTING.md
+++ b/skills/sourceharbor-watchlist-briefing/references/TROUBLESHOOTING.md
@@ -1,0 +1,30 @@
+# SourceHarbor Troubleshooting
+
+Use this page when the packet looks right on paper but the first watchlist
+briefing still fails.
+
+## 1. MCP is unavailable
+
+Use the HTTP fallback path from `INSTALL.md` and make the runtime gap explicit.
+Do not pretend MCP was connected.
+
+## 2. The HTTP API fallback is unavailable
+
+Check these first:
+
+- the local API is running
+- `SOURCE_HARBOR_API_BASE_URL` points at the right base URL
+- the watchlist id is valid
+
+If the briefing payload still does not load, report the exact missing endpoint
+instead of inventing a story summary.
+
+## 3. The operator question needs more than the current briefing
+
+Escalate narrowly:
+
+1. retrieval / ask-style evidence lookup
+2. jobs or compare view only if needed
+3. artifacts only if needed
+
+Do not widen into unrelated subscription or notification changes.

--- a/skills/sourceharbor-watchlist-briefing/references/capability-map.md
+++ b/skills/sourceharbor-watchlist-briefing/references/capability-map.md
@@ -9,8 +9,7 @@ This skill focuses on the SourceHarbor surfaces that help answer one operator qu
 - `sourceharbor.jobs.get` and `sourceharbor.jobs.compare`: inspect recent processing results
 - `sourceharbor.artifacts.get`: fetch saved artifacts that back a claim
 - `sourceharbor.reports.daily_send`: summarize the latest report-style output
-- `sourceharbor.workflows.run`: only when the operator explicitly wants a governed workflow rerun
-- `sourceharbor.subscriptions.manage` and `sourceharbor.notifications.manage`: useful only when the question is about source/watchlist configuration rather than story content
+- `sourceharbor.workflows.run`: only when the operator explicitly wants a governed workflow rerun after the briefing
 
 ## Best default order
 
@@ -18,3 +17,4 @@ This skill focuses on the SourceHarbor surfaces that help answer one operator qu
 2. watchlist / briefing payload
 3. retrieval or ask-style evidence lookup
 4. jobs or artifacts only if the answer needs proof of what changed
+5. do not drift into subscription or notification changes unless the operator changes the task

--- a/skills/sourceharbor-watchlist-briefing/references/capability-map.md
+++ b/skills/sourceharbor-watchlist-briefing/references/capability-map.md
@@ -1,0 +1,20 @@
+# SourceHarbor Capability Map
+
+This skill focuses on the SourceHarbor surfaces that help answer one operator question from one watchlist.
+
+## Most relevant MCP capability groups
+
+- `sourceharbor.health.get`: check runtime health before trusting the rest
+- `sourceharbor.retrieval.search`: retrieve grounded evidence when the briefing is incomplete
+- `sourceharbor.jobs.get` and `sourceharbor.jobs.compare`: inspect recent processing results
+- `sourceharbor.artifacts.get`: fetch saved artifacts that back a claim
+- `sourceharbor.reports.daily_send`: summarize the latest report-style output
+- `sourceharbor.workflows.run`: only when the operator explicitly wants a governed workflow rerun
+- `sourceharbor.subscriptions.manage` and `sourceharbor.notifications.manage`: useful only when the question is about source/watchlist configuration rather than story content
+
+## Best default order
+
+1. health
+2. watchlist / briefing payload
+3. retrieval or ask-style evidence lookup
+4. jobs or artifacts only if the answer needs proof of what changed

--- a/skills/sourceharbor-watchlist-briefing/references/example-output.md
+++ b/skills/sourceharbor-watchlist-briefing/references/example-output.md
@@ -1,9 +1,9 @@
-# Example Output Shape
+# Example Output
 
 ```text
-Current story: The selected watchlist story is still centered on the same claim, but two new evidence runs changed the confidence mix.
-What changed: One new artifact was added and one previous source fell out of the latest compare window.
+Current story: The selected watchlist still centers on the same claim, but the latest compare window added one new evidence run.
+What changed: One source was added, one previous item fell out of the compare window, and the selected story summary shifted.
 Evidence used: current briefing payload, latest compare summary, and one artifact lookup.
-Suggested next action: Re-run the retrieval/search leg for the selected watchlist before sending the next operator briefing.
-Runtime gap: MCP was unavailable, so this answer used the local HTTP API only.
+Suggested next action: Re-run retrieval/search for the selected watchlist before sending the next operator briefing.
+Runtime gap: MCP was unavailable, so this answer used the local HTTP fallback.
 ```

--- a/skills/sourceharbor-watchlist-briefing/references/example-output.md
+++ b/skills/sourceharbor-watchlist-briefing/references/example-output.md
@@ -1,0 +1,9 @@
+# Example Output Shape
+
+```text
+Current story: The selected watchlist story is still centered on the same claim, but two new evidence runs changed the confidence mix.
+What changed: One new artifact was added and one previous source fell out of the latest compare window.
+Evidence used: current briefing payload, latest compare summary, and one artifact lookup.
+Suggested next action: Re-run the retrieval/search leg for the selected watchlist before sending the next operator briefing.
+Runtime gap: MCP was unavailable, so this answer used the local HTTP API only.
+```

--- a/skills/sourceharbor-watchlist-briefing/references/http-fallback.md
+++ b/skills/sourceharbor-watchlist-briefing/references/http-fallback.md
@@ -1,0 +1,38 @@
+# SourceHarbor HTTP Fallback
+
+Use this path only when SourceHarbor MCP is unavailable and the local HTTP API is already running.
+
+## Required base URL
+
+```bash
+export SOURCE_HARBOR_API_BASE_URL=http://127.0.0.1:9000
+```
+
+## Most relevant endpoints
+
+1. Get the watchlist object:
+
+```bash
+curl -s "$SOURCE_HARBOR_API_BASE_URL/api/v1/watchlists/$WATCHLIST_ID"
+```
+
+2. Get the unified briefing payload:
+
+```bash
+curl -s "$SOURCE_HARBOR_API_BASE_URL/api/v1/watchlists/$WATCHLIST_ID/briefing"
+```
+
+3. If you need the selected-story page payload:
+
+```bash
+curl -s "$SOURCE_HARBOR_API_BASE_URL/api/v1/watchlists/$WATCHLIST_ID/briefing/page?story_id=$STORY_ID"
+```
+
+## What to extract
+
+- the current story summary
+- what changed across the compare window
+- cited evidence cards or artifact references
+- the next action implied by the current story
+
+If the briefing payload is not enough to answer the question, say so instead of inventing a conclusion.

--- a/skills/sourceharbor-watchlist-briefing/references/mcp-and-http-setup.md
+++ b/skills/sourceharbor-watchlist-briefing/references/mcp-and-http-setup.md
@@ -1,0 +1,31 @@
+# SourceHarbor MCP And HTTP Setup
+
+Use this when the host runtime does not already have SourceHarbor connected.
+
+## Local repo setup
+
+1. Clone the public repo:
+
+```bash
+git clone https://github.com/xiaojiou176-open/sourceharbor.git
+cd sourceharbor
+```
+
+2. Start the local MCP surface:
+
+```bash
+./bin/dev-mcp
+```
+
+3. If you need the HTTP API fallback, make sure the local API is running and set:
+
+```bash
+export SOURCE_HARBOR_API_BASE_URL=http://127.0.0.1:9000
+```
+
+## What the operator should hand back
+
+- whether SourceHarbor MCP is already connected
+- the watchlist id to inspect
+- the operator question
+- the current `SOURCE_HARBOR_API_BASE_URL` if MCP is not available

--- a/skills/sourceharbor-watchlist-briefing/references/mcp-and-http-setup.md
+++ b/skills/sourceharbor-watchlist-briefing/references/mcp-and-http-setup.md
@@ -1,31 +1,28 @@
-# SourceHarbor MCP And HTTP Setup
+# SourceHarbor OpenClaw Setup
 
-Use this when the host runtime does not already have SourceHarbor connected.
+## Fastest local setup
 
-## Local repo setup
-
-1. Clone the public repo:
-
-```bash
-git clone https://github.com/xiaojiou176-open/sourceharbor.git
-cd sourceharbor
-```
-
-2. Start the local MCP surface:
+From the SourceHarbor repo root:
 
 ```bash
 ./bin/dev-mcp
 ```
 
-3. If you need the HTTP API fallback, make sure the local API is running and set:
+If the MCP client is not wired yet, keep the HTTP fallback ready:
 
 ```bash
 export SOURCE_HARBOR_API_BASE_URL=http://127.0.0.1:9000
 ```
 
-## What the operator should hand back
+## OpenClaw starter-pack files
 
-- whether SourceHarbor MCP is already connected
-- the watchlist id to inspect
-- the operator question
-- the current `SOURCE_HARBOR_API_BASE_URL` if MCP is not available
+- `../../openclaw.plugin.json`
+- `../../sourceharbor-mcp-template.json`
+- `../../README.md`
+
+## Minimum handoff to the agent
+
+- one `WATCHLIST_ID`
+- one `QUESTION`
+- whether MCP is connected
+- the live `SOURCE_HARBOR_API_BASE_URL` if HTTP fallback is needed


### PR DESCRIPTION
## What these skills teach
- `campus-copilot-current-view-triage`: how an agent turns one Campus Copilot snapshot or MCP-backed current view into a single evidence-backed next action for a student.
- `sourceharbor-watchlist-briefing`: how an agent inspects one SourceHarbor watchlist, reuses the current briefing/story payload, and answers one operator question with evidence and one concrete next action.

## Why this revision is stronger
- both skills now start with **what the agent learns**
- MCP/host setup is explicit in `references/INSTALL.md`, `references/OPENHANDS_MCP_CONFIG.json`, and `references/OPENCLAW_MCP_CONFIG.json`
- safe-first capability guidance is explicit in `references/CAPABILITIES.md`
- first-success walkthroughs are explicit in `references/DEMO.md`
- troubleshooting is explicit in `references/TROUBLESHOOTING.md`
- the skill language is now centered on agent capability and truthful evidence use, not repo promo copy

## Boundaries kept explicit
- Campus stays snapshot/current-view/read-only first
- SourceHarbor stays evidence-backed and does not pretend to be hosted SaaS
- neither skill claims a live OpenHands listing while this PR is still under review

## Validation
- local packet folders were refreshed from the source repos and rechecked before this PR refresh
