### PR TITLE
security: disable uv cache in PR review workflow

### DIFF
--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -277,6 +277,7 @@ If you see rate limit errors:
 ## Security
 
 - Uses `pull_request_target` when you need secrets for fork PR reviews; apply strict maintainer-controlled triggers and checkout safeguards
+- Keeps GitHub Actions caching disabled in privileged review workflows to avoid cache-poisoning pivots from prompt injection
 - For lower-trust or comment-only smoke-test setups, prefer `pull_request` to reduce privilege by default
 - Only triggers for trusted contributors or when maintainers add labels/reviewers
 - PR code is checked out explicitly; secrets are not exposed to PR code

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -71,10 +71,13 @@ runs:
           with:
               python-version: '3.12'
 
+        # Security: keep GitHub Actions caching disabled in this workflow.
+        # Prompt injection can coerce the reviewer into running commands, and
+        # shared caches can become a pivot into more privileged workflows.
         - name: Install uv
           uses: astral-sh/setup-uv@v6
           with:
-              enable-cache: true
+              enable-cache: false
 
         - name: Install GitHub CLI
           shell: bash


### PR DESCRIPTION
## Summary
- disable `setup-uv` caching in the privileged PR review workflow
- document the cache-poisoning rationale in the PR review plugin README

## Why
The cache hardening is worth landing independently so it can be reviewed and merged separately from the broader PR review trigger/checkout changes.

## Testing
- `uv run --with pytest pytest tests/test_workflow_sync.py`
- `git diff --check`

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/06e8f6de-ffef-468e-981d-90016c95b407)