### PR TITLE
feat: add second-wave public skills

### DIFF
--- a/skills/movi-review-first-bundle/README.md
+++ b/skills/movi-review-first-bundle/README.md
@@ -1,0 +1,69 @@
+# Movi Review-First Bundle Public Skill
+
+Status: `clawhub-listed-live`
+
+This folder is the public, self-contained skill packet for Movi.
+It is meant to travel into OpenHands- or ClawHub-style review flows without
+forcing the reviewer to reopen the whole repo first.
+
+## Purpose
+
+Use it when you want one portable skill folder that teaches five things inside
+the packet itself:
+
+- what Movi helps an agent do
+- how to install and attach the local Movi MCP server
+- which tools are safe first for review-first batch work
+- what one good first-success path looks like
+- what the packet must not claim
+
+## What this packet includes
+
+- `SKILL.md`
+  - the agent-facing workflow brief
+- `manifest.yaml`
+  - packet metadata and truthful listing boundary
+- `references/README.md`
+  - quick map of the local reference files
+- `references/INSTALL.md`
+  - install and attach walkthrough
+- `references/OPENHANDS_MCP_CONFIG.json`
+  - host config snippet for OpenHands-style `mcpServers`
+- `references/OPENCLAW_MCP_CONFIG.json`
+  - host config snippet for OpenClaw-style `mcp.servers`
+- `references/CAPABILITIES.md`
+  - exact Movi tool surface and safe-first order
+- `references/DEMO.md`
+  - first-success prompt plus expected tool sequence
+- `references/TROUBLESHOOTING.md`
+  - attach, proof, and runtime failure checks
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect one standalone folder with its own
+  install, capability, and demo notes
+
+## Current verified state
+
+- the ClawHub skill listing is live
+- the OpenHands/extensions lane is still folder-ready, not merged
+
+## What this packet must not claim
+
+- no live OpenHands listing without fresh PR/read-back
+- no browser-extension marketplace listing
+- no hosted Movi SaaS or hidden execute shortcut
+
+## Existing repo-owned helper files
+
+This packet still ships the repo-owned helper files below because they are
+useful during review:
+
+- `codex.mcp.json`
+- `claude-code.mcp.json`
+- `openclaw.mcp.json`
+- `install-and-proof.md`
+
+They are helper artifacts, not evidence that a live listing already exists.

--- a/skills/movi-review-first-bundle/SKILL.md
+++ b/skills/movi-review-first-bundle/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: movi-review-first-bundle
+description: Teach an agent to install Movi's local MCP server, stay review-first, and use the safest manifest and batch-analysis tools before deeper mutation.
+version: 1.0.0
+triggers:
+  - movi
+  - movi organizer
+  - review-first batch
+  - manifest review
+  - openclaw movi
+---
+
+# Movi Review-First Bundle
+
+Teach the agent how to install, connect, and use Movi as a local-first
+review-first MCP workflow.
+
+## Use this skill when
+
+- the user wants to inspect one batch or review queue before executing anything
+- the host can run a local MCP server from a repo checkout
+- the operator wants a truthful packet that explains install, attach, proof, and
+  safe-first usage without claiming a live listing
+
+## What this package teaches
+
+- how to wire Movi MCP into Codex, Claude Code, OpenHands, or OpenClaw
+- which Movi tools are safe first when the work must stay review-first
+- how to inspect jobs, manifests, and review rules before calling heavier
+  mutation tools
+- how to keep listing claims honest while still proving the packet is real
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the first-success path in [references/DEMO.md](references/DEMO.md)
+
+## Safe-first workflow
+
+1. `jobs.list`
+2. `review_queue.get`
+3. `manifest.get`
+4. `analyze.create`
+5. only then consider preview or patch-style actions such as:
+   - `manifest.patch_row`
+   - `manifest.batch_patch`
+   - `review_rule.preview`
+
+## Suggested first prompt
+
+Use Movi to inspect the current review-first workload. Start with `jobs.list`,
+`review_queue.get`, and `manifest.get`. Summarize which batch needs attention
+first. If the manifest looks stable, use `analyze.create` to produce one
+analysis artifact. Do not call `manifest.patch_row`, `manifest.batch_patch`, or
+`review_rule.apply` unless I explicitly ask for a patch or rule change.
+
+## Success checks
+
+- the host can launch the local Movi MCP server from the provided config
+- the packet proves one real job/review queue exists instead of describing an
+  imaginary batch
+- the first analysis artifact is tied to a real manifest or job record
+
+## Boundaries
+
+- Movi stays a local-first review-first MCP workflow, not a hosted SaaS
+- this packet does not claim a live OpenHands or ClawHub listing
+- this packet does not bypass `review-first -> dry-run -> execute`
+
+## Local references
+
+- [references/INSTALL.md](references/INSTALL.md)
+- [references/CAPABILITIES.md](references/CAPABILITIES.md)
+- [references/DEMO.md](references/DEMO.md)
+- [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)

--- a/skills/movi-review-first-bundle/claude-code.mcp.json
+++ b/skills/movi-review-first-bundle/claude-code.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "movi": {
+      "command": "bash",
+      "args": [
+        "/absolute/path/to/movi-organizer/tooling/runtime/run_mcp_stdio.sh"
+      ]
+    }
+  }
+}

--- a/skills/movi-review-first-bundle/codex.mcp.json
+++ b/skills/movi-review-first-bundle/codex.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "movi": {
+      "command": "bash",
+      "args": [
+        "/absolute/path/to/movi-organizer/tooling/runtime/run_mcp_stdio.sh"
+      ]
+    }
+  }
+}

--- a/skills/movi-review-first-bundle/install-and-proof.md
+++ b/skills/movi-review-first-bundle/install-and-proof.md
@@ -1,0 +1,20 @@
+# Movi Agent Bundle Install And Proof
+
+Status: `submission-ready-unlisted`
+
+## Install
+
+- Codex: use `examples/skills/codex.mcp.json`
+- Claude Code: use `examples/skills/claude-code.mcp.json`
+- OpenClaw-style hosts: use `examples/skills/openclaw.mcp.json`
+
+## Proof Loop
+
+1. `bash tooling/runtime/bootstrap_env.sh`
+2. `npm run mcp:tools`
+3. `npm run public:readiness`
+4. `bash tooling/gates/verify_repo_final.sh`
+
+## Boundary
+
+This proves the repo-owned bundle exists. It does not prove a live listing.

--- a/skills/movi-review-first-bundle/manifest.yaml
+++ b/skills/movi-review-first-bundle/manifest.yaml
@@ -1,0 +1,37 @@
+version: 1
+id: movi-agent-bundle
+display_name: Movi Review-First Bundle
+status: clawhub-listed-live
+canonical_repo: xiaojiou176-open/movi-organizer
+entrypoint: SKILL.md
+package_shape: skill-folder
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/movi-review-first-bundle
+    submit_via: clawhub publish . --slug movi-review-first-bundle --name "Movi Review-First Bundle" --version 1.0.0 --tags mcp,review-first,batch,media,movi
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/movi-review-first-bundle/ in OpenHands/extensions
+bundle_surfaces:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/TROUBLESHOOTING.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - codex.mcp.json
+  - claude-code.mcp.json
+  - openclaw.mcp.json
+  - install-and-proof.md
+claims_not_made:
+  - no live OpenHands listing is claimed
+  - no live OpenClaw listing is claimed
+  - no browser-extension marketplace listing is claimed
+  - no hosted Movi SaaS claim is made

--- a/skills/movi-review-first-bundle/openclaw.mcp.json
+++ b/skills/movi-review-first-bundle/openclaw.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "movi": {
+      "command": "bash",
+      "args": [
+        "/absolute/path/to/movi-organizer/tooling/runtime/run_mcp_stdio.sh"
+      ]
+    }
+  }
+}

--- a/skills/movi-review-first-bundle/references/CAPABILITIES.md
+++ b/skills/movi-review-first-bundle/references/CAPABILITIES.md
@@ -1,0 +1,36 @@
+# Movi MCP Capabilities
+
+These are the current repo-owned Movi MCP tools exposed by `npm run mcp:tools`.
+
+## Best first tools
+
+1. `jobs.list`
+   - inspect the current batch queue before choosing a target
+2. `review_queue.get`
+   - see what is waiting for review-first attention
+3. `manifest.get`
+   - inspect the current manifest state before proposing any patch
+4. `analyze.create`
+   - create one analysis artifact without mutating the batch
+
+## Useful follow-through tools
+
+- `jobs.get`
+- `report.get`
+- `strategy_packs.list`
+- `watch_sources.list`
+- `inbox.scan`
+- `inbox.analyze`
+
+Use these after the first-safe picture is already clear.
+
+## Heavier mutation tools
+
+- `manifest.patch_row`
+- `manifest.batch_patch`
+- `review_rule.preview`
+- `review_rule.apply`
+- `apply.preview`
+
+Treat these as gated actions. Do not run them in the first pass unless the user
+explicitly asks for a patch or rule change.

--- a/skills/movi-review-first-bundle/references/DEMO.md
+++ b/skills/movi-review-first-bundle/references/DEMO.md
@@ -1,0 +1,33 @@
+# First-Success Path
+
+This is the shortest demo that proves the skill does real work instead of only
+describing a workflow.
+
+## Demo prompt
+
+Use Movi to inspect the current review-first batch queue. Start with
+`jobs.list`, `review_queue.get`, and `manifest.get`. Summarize which batch needs
+attention first. If the manifest is present and stable, run `analyze.create` to
+produce one analysis artifact. Stop before `manifest.patch_row`,
+`manifest.batch_patch`, or `review_rule.apply` unless I explicitly ask for a
+change.
+
+## Expected tool sequence
+
+1. `jobs.list`
+2. `review_queue.get`
+3. `manifest.get`
+4. `analyze.create`
+
+## Visible success criteria
+
+- the host attaches the local Movi MCP server
+- the agent names at least one real job or review queue item
+- the analysis step points back to a real manifest or batch artifact
+- the agent keeps the workflow review-first instead of jumping into mutation
+
+## What to check if it fails
+
+1. the host config path still points at the real repo checkout
+2. `bash tooling/runtime/bootstrap_env.sh` was run
+3. `npm run mcp:tools` returns the tool inventory without errors

--- a/skills/movi-review-first-bundle/references/INSTALL.md
+++ b/skills/movi-review-first-bundle/references/INSTALL.md
@@ -1,0 +1,42 @@
+# Install And Attach Movi MCP
+
+Use this when the host runtime does not already have Movi connected.
+
+## Local repo setup
+
+1. Clone the public repo:
+
+```bash
+git clone https://github.com/xiaojiou176-open/movi-organizer.git
+cd movi-organizer
+npm install
+```
+
+2. Bootstrap the local runtime:
+
+```bash
+bash tooling/runtime/bootstrap_env.sh
+```
+
+3. Load the host config that matches your shell:
+
+- `../codex.mcp.json`
+- `../claude-code.mcp.json`
+- `../openclaw.mcp.json`
+
+4. Replace the placeholder repo path before attaching the host.
+
+## Proof loop
+
+Run these from the repo root after the host attaches:
+
+```bash
+npm run mcp:tools
+npm run mcp:resources
+bash tooling/gates/verify_repo_final.sh
+```
+
+## Truth boundary
+
+This proves the repo-owned packet and local MCP surface exist.
+It does not prove a live OpenHands or ClawHub listing.

--- a/skills/movi-review-first-bundle/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/movi-review-first-bundle/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,12 @@
+{
+  "mcp": {
+    "servers": {
+      "movi": {
+        "command": "bash",
+        "args": [
+          "/absolute/path/to/movi-organizer/tooling/runtime/run_mcp_stdio.sh"
+        ]
+      }
+    }
+  }
+}

--- a/skills/movi-review-first-bundle/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/movi-review-first-bundle/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "movi": {
+      "command": "bash",
+      "args": [
+        "/absolute/path/to/movi-organizer/tooling/runtime/run_mcp_stdio.sh"
+      ]
+    }
+  }
+}

--- a/skills/movi-review-first-bundle/references/README.md
+++ b/skills/movi-review-first-bundle/references/README.md
@@ -1,0 +1,18 @@
+# Movi Review-First Bundle References
+
+Use this folder as the self-contained support shelf for the public skill packet.
+
+## File map
+
+- `INSTALL.md`
+  - clone, attach, and proof loop
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-style `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-style `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - exact Movi tools plus safe-first order
+- `DEMO.md`
+  - first-success prompt and expected tool sequence
+- `TROUBLESHOOTING.md`
+  - what to check first when attach, proof, or batch inspection fails

--- a/skills/movi-review-first-bundle/references/TROUBLESHOOTING.md
+++ b/skills/movi-review-first-bundle/references/TROUBLESHOOTING.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+## The host cannot attach the MCP server
+
+- confirm the repo path in the host config is real
+- run `bash tooling/runtime/bootstrap_env.sh`
+- rerun `npm run mcp:tools` from the repo root
+
+## The tool list is empty or incomplete
+
+- confirm the runtime bootstrap finished
+- verify the command still points at `tooling/runtime/run_mcp_stdio.sh`
+- check whether the current shell has the expected Node environment
+
+## The review-first demo drifts into mutation
+
+- restart from `jobs.list` and `review_queue.get`
+- treat `manifest.patch_row`, `manifest.batch_patch`, and `review_rule.apply`
+  as operator-approved actions only
+- keep `analyze.create` as the last allowed first-pass step

--- a/skills/openui-workspace-delivery/.claude-plugin/plugin.json
+++ b/skills/openui-workspace-delivery/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "openui-workspace-delivery",
+  "version": "0.1.0",
+  "description": "Claude Code and OpenClaw-compatible bundle for installing OpenUI MCP Studio from a local repo checkout and proving the workflow honestly.",
+  "commands": "./commands/",
+  "skills": "./skills/"
+}

--- a/skills/openui-workspace-delivery/.mcp.json
+++ b/skills/openui-workspace-delivery/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "openui": {
+      "command": "node",
+      "args": [
+        "/ABS/PATH/openui-mcp-studio/.runtime-cache/build/mcp-server/services/mcp-server/src/main.js"
+      ],
+      "env": {
+        "GEMINI_API_KEY": "your_key"
+      }
+    }
+  }
+}

--- a/skills/openui-workspace-delivery/README.md
+++ b/skills/openui-workspace-delivery/README.md
@@ -1,0 +1,33 @@
+# OpenUI Workspace Delivery
+
+This folder is the public, self-contained skill packet for OpenUI MCP Studio.
+
+It is meant to teach an agent four things without sending the reviewer back to
+repo-root docs first:
+
+- how to install the local MCP server
+- how to attach it to OpenHands or OpenClaw
+- which UI-generation tools are safe to use first
+- what the shortest proof loop looks like
+
+## Included files
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Truth boundary
+
+- this packet has a live ClawHub listing
+- it is still not a live vendor marketplace listing
+- it does not claim a hosted runtime
+- it does not claim vendor approval or official ClawHub placement
+
+Use the host configs and proof loop in `references/` first. Treat the older
+`commands/` and `samples/` files as supporting material, not as the primary
+reviewer packet.

--- a/skills/openui-workspace-delivery/SKILL.md
+++ b/skills/openui-workspace-delivery/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: openui-workspace-delivery
+description: Teach an agent how to install OpenUI MCP Studio, connect it to a host, and use the core UI generation and review workflow without overclaiming a live marketplace listing.
+version: 1.0.0
+triggers:
+  - openui
+  - openui-mcp-studio
+  - openui workspace delivery
+  - shadcn generation
+  - UI shipping
+---
+
+# OpenUI Workspace Delivery
+
+Teach the agent how to install, connect, and use OpenUI MCP Studio as a local
+MCP-first UI generation and review workspace.
+
+## Use this skill when
+
+- the user wants to generate or review shadcn-style UI from a local MCP server
+- the host can run a local `stdio` MCP server
+- the user wants one inspectable proof loop before any public claim
+
+## What this packet teaches
+
+- how to wire the local OpenUI MCP server into OpenHands or OpenClaw
+- which OpenUI MCP tools are safe and useful first
+- how to move from installation to a first proof loop
+- how to keep claims grounded in local MCP and repo-owned proof instead of
+  marketplace hype
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the proof loop in [references/DEMO.md](references/DEMO.md)
+5. If attach or proof fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)
+
+## Recommended workflow
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Suggested first prompt
+
+Use OpenUI MCP Studio to inspect this workspace and prepare one safe-first UI
+delivery step. Start with `openui_scan_workspace_profile` and
+`openui_plan_change`. If the workspace looks healthy, run `openui_generate_ui`
+for one small component or page change, then run `openui_quality_gate` and
+summarize what a reviewer should inspect next.
+
+## Success checks
+
+- the host can launch the OpenUI MCP server from the provided config
+- the workspace scan returns a real profile instead of placeholder text
+- the plan/generate flow yields a concrete UI output or change plan
+- the proof loop stays inside local MCP and repo-owned evidence
+
+## Boundaries
+
+- OpenUI MCP Studio stays a local MCP and repo-owned proof workflow
+- this packet does not claim a live ClawHub listing or a vendor marketplace
+  listing
+- this packet does not claim a hosted runtime or hosted API publication

--- a/skills/openui-workspace-delivery/commands/openui-install.md
+++ b/skills/openui-workspace-delivery/commands/openui-install.md
@@ -1,0 +1,16 @@
+# OpenUI install
+
+Use this bundle when you want the shortest honest path to add OpenUI MCP Studio
+to a local Claude Code or OpenClaw workflow.
+
+1. Build the repo if the runtime path is missing.
+   - `npm install`
+   - `npm run build`
+2. Open the repo-owned starter bundles.
+   - `packages/skills-kit/starter-bundles/claude-code.mcp.json`
+   - `packages/skills-kit/starter-bundles/openclaw.mcp.json`
+3. Copy the starter JSON into your local host config and replace
+   `/ABS/PATH/openui-mcp-studio` with the real checkout path.
+4. Keep the truth boundary visible.
+   - This bundle helps with install and proof.
+   - It does not prove an official marketplace listing or hosted runtime.

--- a/skills/openui-workspace-delivery/commands/openui-proof.md
+++ b/skills/openui-workspace-delivery/commands/openui-proof.md
@@ -1,0 +1,11 @@
+# OpenUI first proof
+
+Run the repo-owned proof loop after you wire the local MCP config:
+
+1. `openui-mcp-studio surface-guide --json`
+2. `openui-mcp-studio ecosystem-guide --json`
+3. `npm run repo:doctor`
+4. Open `/proof` or `docs/proof-and-faq.md`
+
+Use `packages/skills-kit/starter-troubleshooting.md` if the host config looks
+correct but attach or proof still fails.

--- a/skills/openui-workspace-delivery/manifest.yaml
+++ b/skills/openui-workspace-delivery/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: openui-workspace-delivery
+  display_name: OpenUI Workspace Delivery
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/openui-workspace-delivery
+    submit_via: clawhub publish . --slug openui-workspace-delivery --name "OpenUI Workspace Delivery" --version 1.0.0 --tags openui,mcp,ui,workspace,delivery
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/openui-workspace-delivery/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Local MCP-first UI generation and review workspace for OpenUI MCP Studio.
+  canonical_repo_version: 0.1.0
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No live official marketplace listing exists yet
+    - No hosted runtime or managed API publication is claimed
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/openui-workspace-delivery/references/CAPABILITIES.md
+++ b/skills/openui-workspace-delivery/references/CAPABILITIES.md
@@ -1,0 +1,42 @@
+# OpenUI MCP Studio Capabilities
+
+OpenUI MCP Studio exposes a local UI generation and review workflow.
+
+## Core workflow tools
+
+- `openui_scan_workspace_profile`
+- `openui_plan_change`
+- `openui_generate_ui`
+- `openui_convert_react_shadcn`
+- `openui_make_react_page`
+- `openui_apply_files`
+- `openui_quality_gate`
+- `openui_next_smoke`
+- `openui_ship_react_page`
+
+## Delivery-intelligence tools
+
+- `openui_build_acceptance_pack`
+- `openui_build_review_bundle`
+- `openui_ship_feature_flow`
+
+## Supporting tools
+
+- `openui_refine_ui`
+- `openui_review_uiux`
+- `openui_list_models`
+- `openui_embed_content`
+
+## Recommended first-use order
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Boundary
+
+- good fit: local MCP-first UI generation, review, and proof
+- not a fit: claiming hosted runtime, official marketplace listing, or a vendor
+  managed install surface

--- a/skills/openui-workspace-delivery/references/DEMO.md
+++ b/skills/openui-workspace-delivery/references/DEMO.md
@@ -1,0 +1,26 @@
+# OpenUI MCP Studio First-Success Demo
+
+This is the shortest proof loop that shows the packet is real.
+
+## Demo prompt
+
+Use OpenUI MCP Studio to inspect this workspace and prepare one safe-first UI
+delivery step. Start with `openui_scan_workspace_profile` and
+`openui_plan_change`. If the workspace looks healthy, run `openui_generate_ui`
+for one small component or page change, then run `openui_quality_gate` and
+summarize what a reviewer should inspect next.
+
+## Expected tool sequence
+
+1. `openui_scan_workspace_profile`
+2. `openui_plan_change`
+3. `openui_generate_ui`
+4. `openui_quality_gate`
+5. `openui_build_review_bundle`
+
+## Visible success criteria
+
+- the MCP server launches from the provided config
+- the workspace profile is real and repo-specific
+- the generation step produces a concrete UI payload or change plan
+- the quality gate reports repo-owned findings instead of placeholder prose

--- a/skills/openui-workspace-delivery/references/INSTALL.md
+++ b/skills/openui-workspace-delivery/references/INSTALL.md
@@ -1,0 +1,38 @@
+# Install And Attach OpenUI MCP Studio
+
+Use the current repo-native MCP path first.
+
+## Quickest local setup
+
+1. Clone the public repository:
+
+```bash
+git clone https://github.com/xiaojiou176-open/openui-mcp-studio.git
+cd openui-mcp-studio
+npm install
+npm run build
+```
+
+2. Confirm the compiled MCP entry exists:
+
+- `.runtime-cache/build/mcp-server/services/mcp-server/src/main.js`
+
+3. Replace the placeholder server path in the host config snippets with the real
+   local checkout path, and replace `GEMINI_API_KEY` with a real local secret
+   before attach.
+
+4. Attach the host with one of the config snippets in this folder.
+
+## Current truthful install mode
+
+- protocol: `stdio`
+- transport: `stdio`
+- runtime: local repo checkout
+- public marketplace listing: not claimed
+
+## What to hand back to the agent
+
+- whether the build output exists
+- whether `GEMINI_API_KEY` is available
+- which host you are attaching
+- whether the proof loop commands complete

--- a/skills/openui-workspace-delivery/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/openui-workspace-delivery/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "servers": {
+      "openui": {
+        "command": "node",
+        "args": [
+          "/ABSOLUTE/PATH/TO/OPENUI-MCP-STUDIO/.runtime-cache/build/mcp-server/services/mcp-server/src/main.js"
+        ],
+        "env": {
+          "GEMINI_API_KEY": "your_key"
+        }
+      }
+    }
+  }
+}

--- a/skills/openui-workspace-delivery/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/openui-workspace-delivery/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "openui": {
+      "command": "node",
+      "args": [
+        "/ABSOLUTE/PATH/TO/OPENUI-MCP-STUDIO/.runtime-cache/build/mcp-server/services/mcp-server/src/main.js"
+      ],
+      "env": {
+        "GEMINI_API_KEY": "your_key"
+      }
+    }
+  }
+}

--- a/skills/openui-workspace-delivery/references/README.md
+++ b/skills/openui-workspace-delivery/references/README.md
@@ -1,0 +1,18 @@
+# OpenUI Workspace Delivery Packet References
+
+This folder keeps the public packet self-contained.
+
+## Files
+
+- `INSTALL.md`
+  - local install and attach guide
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-ready config snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-ready config snippet
+- `CAPABILITIES.md`
+  - safe-first tool map and capability boundaries
+- `DEMO.md`
+  - first-success generation and review loop
+- `TROUBLESHOOTING.md`
+  - shortest checks before escalation

--- a/skills/openui-workspace-delivery/references/TROUBLESHOOTING.md
+++ b/skills/openui-workspace-delivery/references/TROUBLESHOOTING.md
@@ -1,0 +1,32 @@
+# OpenUI MCP Studio Troubleshooting
+
+Use these checks before escalating.
+
+## 1. Build output path is missing
+
+- run `npm install`
+- run `npm run build`
+- confirm `.runtime-cache/build/mcp-server/services/mcp-server/src/main.js`
+  exists
+
+## 2. Gemini key is missing
+
+- provide `GEMINI_API_KEY` in the host config
+- rerun any local env check you rely on before attaching again
+
+## 3. You only need the shortest proof loop
+
+- run `openui-mcp-studio surface-guide --json`
+- run `openui-mcp-studio ecosystem-guide --json`
+- run `npm run repo:doctor`
+
+## 4. The claim sounds bigger than reality
+
+Stop and re-check:
+
+- `DISTRIBUTION.md`
+- `INTEGRATIONS.md`
+- `manifest.yaml`
+
+Do not claim ClawHub, official marketplace, or hosted runtime status unless
+fresh read-back exists.

--- a/skills/openui-workspace-delivery/samples/claude-code.mcp.json
+++ b/skills/openui-workspace-delivery/samples/claude-code.mcp.json
@@ -1,0 +1,13 @@
+{
+  "host": "Claude Code",
+  "starterBundle": "packages/skills-kit/starter-bundles/claude-code.mcp.json",
+  "proofLoop": [
+    "openui-mcp-studio surface-guide --json",
+    "openui-mcp-studio ecosystem-guide --json",
+    "npm run repo:doctor"
+  ],
+  "notFor": [
+    "claiming an Anthropic marketplace listing",
+    "claiming a managed runtime or hosted API publication"
+  ]
+}

--- a/skills/openui-workspace-delivery/skills/openui-local-install/SKILL.md
+++ b/skills/openui-workspace-delivery/skills/openui-local-install/SKILL.md
@@ -1,0 +1,32 @@
+# OpenUI local install
+
+You are using the repo-owned OpenUI install helper bundle.
+
+## Goal
+
+Help the operator wire OpenUI MCP Studio into a local Claude Code or OpenClaw
+flow without overclaiming a hosted runtime or official listing.
+
+## Read first
+
+- `packages/skills-kit/starter-bundles/claude-code.mcp.json`
+- `packages/skills-kit/starter-bundles/openclaw.mcp.json`
+- `packages/skills-kit/starter-troubleshooting.md`
+- `docs/proof-and-faq.md`
+
+## Default route
+
+1. Confirm the repo build output exists.
+2. Copy the starter bundle JSON and replace the absolute repo path.
+3. Run the proof loop:
+   - `openui-mcp-studio surface-guide --json`
+   - `openui-mcp-studio ecosystem-guide --json`
+   - `npm run repo:doctor`
+4. Escalate only if the runtime path or host attach still fails after the
+   troubleshooting note has been followed.
+
+## Boundaries
+
+- Treat this as repo-owned install/proof help.
+- Do not claim Anthropic marketplace publication or ClawHub publication.
+- Do not claim a managed runtime or a hosted API deployment.

--- a/skills/prooflane-mcp/README.md
+++ b/skills/prooflane-mcp/README.md
@@ -1,0 +1,41 @@
+# Prooflane MCP Public Skill
+
+This folder is the public, self-contained skill packet for Prooflane's
+repo-native MCP surface.
+
+## Purpose
+
+Use it when you want one portable skill folder that teaches:
+
+- what Prooflane helps an agent do today
+- how to attach the repo-native stdio MCP server
+- which tool families are safe first
+- what a concrete first-success path looks like
+- which package, marketplace, and hosted claims remain out of bounds
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect one standalone folder with install,
+  capability, and demo notes
+
+## What this packet must not claim
+
+- no live OpenHands listing without fresh PR/read-back
+- no live ClawHub listing without fresh host-side read-back
+- no published npm package or public Docker image unless the repo has fresh
+  proof
+- no hosted Prooflane SaaS claim

--- a/skills/prooflane-mcp/SKILL.md
+++ b/skills/prooflane-mcp/SKILL.md
@@ -1,0 +1,172 @@
+# Prooflane MCP Skill
+
+Use this skill when an agent needs to **clone, install, configure, verify, and
+use Prooflane's current MCP and local product surfaces** without overclaiming
+package-registry or hosted distribution that does not exist yet.
+
+## Use When
+
+- You want to evaluate Prooflane from the canonical public repository.
+- You want to connect Codex, Claude Code, OpenClaw, or another MCP-capable
+  client to Prooflane's repo-native MCP server.
+- You need a truthful walkthrough for local UI first-look, MCP setup, and
+  governed run verification.
+
+## Truthful Boundaries
+
+- Prooflane is public and distribution-ready on GitHub today.
+- The MCP server is real and repo-native today.
+- The package shape `@uiq/mcp-server` / `prooflane-mcp` is publish-ready, but
+  it is **not published to npm yet**.
+- MCP today means **stdio only**.
+- Local stdio startup does **not** use OAuth; protected HTTP/API and
+  automation surfaces keep the existing token/header contract.
+- Prooflane is **not** currently a hosted SaaS service.
+- This skill is a generic in-repo scaffold. It is **not** a published skill
+  marketplace artifact yet.
+
+## Prerequisites
+
+- Git
+- Node.js 20+
+- pnpm
+- Python 3.12+
+- A local shell session in the repository root
+
+## Canonical Repo
+
+```bash
+git clone https://github.com/xiaojiou176-open/ui-automation-control-plane.git
+cd ui-automation-control-plane
+```
+
+## Install
+
+```bash
+./scripts/setup.sh
+```
+
+If you already trust the workspace toolchain and only need JS dependencies:
+
+```bash
+pnpm install
+```
+
+## First Local Product Win
+
+Launch the local stress-lab shell:
+
+```bash
+./scripts/dev-up.sh
+```
+
+What success looks like:
+
+- Command Center on `http://127.0.0.1:17373`
+- API health on `http://127.0.0.1:17380/health/`
+- A visible Stress Lab surface with Runs & Blocks, Flow Studio, and Advanced Review
+
+## Repo-Native MCP Start (Today)
+
+Start the current MCP server from the repository:
+
+```bash
+pnpm mcp:start
+```
+
+This is the truthful installation path today.
+
+## Publish-Ready Package Shape (Not Published Yet)
+
+Once the MCP package is actually published, the intended command shape is:
+
+```bash
+npx -y @uiq/mcp-server
+```
+
+or:
+
+```bash
+pnpm dlx @uiq/mcp-server
+```
+
+Do **not** claim this package is published until registry publication really happens.
+
+## Minimal MCP Client Configuration
+
+### Repo-native today
+
+```json
+{
+  "mcpServers": {
+    "uiq": {
+      "command": "pnpm",
+      "args": ["mcp:start"],
+      "cwd": "/ABSOLUTE/PATH/TO/REPO",
+      "env": {
+        "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+        "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+      }
+    }
+  }
+}
+```
+
+### Publish-ready package shape (not live yet)
+
+```json
+{
+  "mcpServers": {
+    "uiq": {
+      "command": "npx",
+      "args": ["-y", "@uiq/mcp-server"],
+      "env": {
+        "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+        "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+      }
+    }
+  }
+}
+```
+
+## Environment Variables
+
+- `UIQ_MCP_API_BASE_URL`
+  Use this to point MCP at a different backend lane.
+- `UIQ_MCP_TOOL_GROUPS`
+  Use this to opt into optional MCP tool groups.
+- `UIQ_MCP_PERFECT_MODE`
+  Keeps stricter MCP defaults.
+- `AUTOMATION_API_TOKEN`
+  Needed only when token-protected HTTP/API surfaces are enabled.
+
+## Minimal Verification
+
+Run these from the repo root:
+
+```bash
+pnpm mcp:check
+pnpm mcp:build
+pnpm mcp:package:smoke
+pnpm mcp:doc:contract
+pnpm mcp:smoke
+```
+
+Expected result:
+
+- TypeScript check passes
+- build emits `services/mcp-server/dist/`
+- package smoke keeps the stdio server alive through startup
+- docs contract passes
+- MCP smoke passes
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the first review loop from [references/DEMO.md](references/DEMO.md)
+5. If attach or proof fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)

--- a/skills/prooflane-mcp/manifest.yaml
+++ b/skills/prooflane-mcp/manifest.yaml
@@ -1,0 +1,69 @@
+name: prooflane-mcp
+version: 0.1.0
+summary: >
+  Generic skill scaffold for teaching an agent to clone, install, configure,
+  verify, and use the Prooflane repo-native MCP server and local product paths.
+protocol: stdio
+entrypoint: SKILL.md
+package_shape: skill-folder
+registry_targets:
+  clawhub:
+    status: ready-but-not-listed
+    package_shape: skill-folder
+    submit_via: clawhub publish . --slug prooflane-mcp --name "Prooflane MCP Skill" --version 0.1.0 --tags mcp,proof,automation,review,prooflane
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/prooflane-mcp/ in OpenHands/extensions
+installation:
+  repo: https://github.com/xiaojiou176-open/ui-automation-control-plane
+  steps:
+    - git clone https://github.com/xiaojiou176-open/ui-automation-control-plane.git
+    - cd ui-automation-control-plane
+    - ./scripts/setup.sh
+configuration:
+  repo_native:
+    command: pnpm
+    args:
+      - mcp:start
+    cwd: /ABSOLUTE/PATH/TO/REPO
+    env:
+      UIQ_MCP_API_BASE_URL: http://127.0.0.1:18080
+      UIQ_MCP_TOOL_GROUPS: advanced,analysis,proof
+  publish_ready_shape:
+    command: npx
+    args:
+      - -y
+      - "@uiq/mcp-server"
+    env:
+      UIQ_MCP_API_BASE_URL: http://127.0.0.1:18080
+      UIQ_MCP_TOOL_GROUPS: advanced,analysis,proof
+    note: publish-ready scoped package shape only; not published yet; bin inside remains prooflane-mcp
+verification:
+  steps:
+    - pnpm mcp:check
+    - pnpm mcp:build
+    - pnpm mcp:package:smoke
+    - pnpm mcp:doc:contract
+    - pnpm mcp:smoke
+supported_agents:
+  - Codex
+  - Claude Code
+  - OpenClaw
+  - generic-mcp-client
+capabilities:
+  - local stress-lab first-look
+  - repo-native stdio MCP startup
+  - governed run and proof path orientation
+  - truthful distribution boundary guidance
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/prooflane-mcp/references/CAPABILITIES.md
+++ b/skills/prooflane-mcp/references/CAPABILITIES.md
@@ -1,0 +1,36 @@
+# Prooflane MCP Capabilities
+
+These are the current Prooflane tool families surfaced by the repo-native MCP
+server.
+
+## Best first tools
+
+1. `uiq_catalog`
+   - read the top-level surface and workflow catalog
+2. `uiq_run`
+   - inspect the current run lane when the user already has a run target
+3. `uiq_run_and_report`
+   - combine run execution context with a report-style summary
+4. `uiq_proof`
+   - inspect proof bundles and governed evidence surfaces
+
+## Good supporting reads
+
+- `uiq_api_workflow`
+- `uiq_api_automation`
+- `uiq_quality_read`
+- `uiq_read_artifact`
+- `uiq_list_runs`
+- `uiq_read_repo_doc`
+
+## Advanced follow-through tools
+
+- `uiq_read_run_ai_review`
+- `uiq_generate_release_brief`
+- `uiq_find_similar_failures`
+- `uiq_explain_template_feasibility`
+- `uiq_list_manual_gates`
+- `uiq_compare_perf`
+- `uiq_model_target_capabilities`
+
+Treat advanced tools as second-pass or reviewer-only surfaces.

--- a/skills/prooflane-mcp/references/DEMO.md
+++ b/skills/prooflane-mcp/references/DEMO.md
@@ -1,0 +1,30 @@
+# First-Success Path
+
+## Demo prompt
+
+Use Prooflane as a repo-native MCP surface. Start with `uiq_catalog` to confirm
+the server is attached. Then inspect one run or run summary with `uiq_run` or
+`uiq_run_and_report`. If proof artifacts are already present, follow with
+`uiq_proof` or `uiq_read_artifact`. Summarize the current lane, the most
+important proof artifact, and the next action without claiming a published
+marketplace listing.
+
+## Expected tool sequence
+
+1. `uiq_catalog`
+2. `uiq_run`
+3. `uiq_run_and_report`
+4. `uiq_proof` or `uiq_read_artifact`
+
+## Visible success criteria
+
+- the host attaches the repo-native MCP server
+- the agent cites one real run or artifact instead of a generic stress-lab
+  story
+- the answer stays grounded in current repo-native Prooflane surfaces
+
+## What to check if it fails
+
+1. `pnpm mcp:check` still passes
+2. `UIQ_MCP_API_BASE_URL` points at a reachable backend if live reads are needed
+3. the host config still points at the real repo checkout

--- a/skills/prooflane-mcp/references/INSTALL.md
+++ b/skills/prooflane-mcp/references/INSTALL.md
@@ -1,0 +1,37 @@
+# Install And Attach Prooflane MCP
+
+## Local repo setup
+
+```bash
+git clone https://github.com/xiaojiou176-open/ui-automation-control-plane.git
+cd ui-automation-control-plane
+./scripts/setup.sh
+```
+
+If you already trust the workspace toolchain, `pnpm install` is enough for JS
+dependencies.
+
+Before loading the host config snippets in this folder, replace
+`/ABSOLUTE/PATH/TO/REPO` with the real path to your local clone.
+
+## Start the current repo-native MCP server
+
+```bash
+pnpm mcp:start
+```
+
+## Verification commands
+
+```bash
+pnpm mcp:check
+pnpm mcp:build
+pnpm mcp:package:smoke
+pnpm mcp:doc:contract
+pnpm mcp:smoke
+```
+
+## Truth boundary
+
+This packet teaches the repo-native stdio MCP surface that works today.
+The package shape `@uiq/mcp-server` / `prooflane-mcp` is publish-ready but not
+yet published.

--- a/skills/prooflane-mcp/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/prooflane-mcp/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,17 @@
+{
+  "mcp": {
+    "servers": {
+      "uiq": {
+        "command": "pnpm",
+        "args": [
+          "mcp:start"
+        ],
+        "cwd": "/ABSOLUTE/PATH/TO/REPO",
+        "env": {
+          "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+          "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+        }
+      }
+    }
+  }
+}

--- a/skills/prooflane-mcp/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/prooflane-mcp/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "uiq": {
+      "command": "pnpm",
+      "args": [
+        "mcp:start"
+      ],
+      "cwd": "/ABSOLUTE/PATH/TO/REPO",
+      "env": {
+        "UIQ_MCP_API_BASE_URL": "http://127.0.0.1:18080",
+        "UIQ_MCP_TOOL_GROUPS": "advanced,analysis,proof"
+      }
+    }
+  }
+}

--- a/skills/prooflane-mcp/references/README.md
+++ b/skills/prooflane-mcp/references/README.md
@@ -1,0 +1,16 @@
+# Prooflane MCP References
+
+## File map
+
+- `INSTALL.md`
+  - clone, attach, and verification path
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-style `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-style `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - current Prooflane tool families and safe-first order
+- `DEMO.md`
+  - first-success prompt and expected tool sequence
+- `TROUBLESHOOTING.md`
+  - attach, backend, and proof failure checks

--- a/skills/prooflane-mcp/references/TROUBLESHOOTING.md
+++ b/skills/prooflane-mcp/references/TROUBLESHOOTING.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+## The host cannot attach the MCP server
+
+- confirm the `cwd` points at the real repo checkout
+- rerun `pnpm install`
+- rerun `pnpm mcp:check` and `pnpm mcp:build`
+
+## The MCP server starts but the live stack is unreachable
+
+- set `UIQ_MCP_API_BASE_URL=http://127.0.0.1:17380`
+- confirm the backend health endpoint is reachable
+- if the task does not need live API reads, stay on repo-native docs and proof
+  surfaces instead
+
+## The agent jumps into advanced tools too early
+
+- restart from `uiq_catalog`
+- keep `uiq_run`, `uiq_run_and_report`, and `uiq_proof` as the first-success path
+- treat release-analysis and similarity tools as second-pass reviewer aids

--- a/skills/prooftrail-mcp/README.md
+++ b/skills/prooftrail-mcp/README.md
@@ -1,0 +1,45 @@
+# ProofTrail MCP Public Skill
+
+This folder is the public, self-contained skill packet for ProofTrail's
+governed MCP surface.
+
+## Purpose
+
+Use it when you want one portable skill folder that teaches:
+
+- what ProofTrail helps an outer agent shell do
+- how to attach the current repo-native stdio MCP server
+- which tool families are safest first
+- what one concrete first-success path looks like
+- what future package, Docker, or listing claims are still out of bounds
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local skill import flows that expect one standalone folder with install,
+  capability, and demo notes
+
+## Current verified state
+
+- the ClawHub skill listing is live
+- npm and Docker publication are still not live
+- the OpenHands/extensions lane is still folder-ready, not merged
+
+## What this packet must not claim
+
+- no live OpenHands listing without fresh PR/read-back
+- no published npm package or Docker image unless the repo has fresh proof
+- no hosted ProofTrail SaaS or hosted MCP endpoint

--- a/skills/prooftrail-mcp/SKILL.md
+++ b/skills/prooftrail-mcp/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: prooftrail-mcp
+description: Teach an agent to install ProofTrail's governed stdio MCP server, use the safest read and proof tools first, and keep future package or listing claims honest.
+version: 0.1.1
+triggers:
+  - prooftrail
+  - prooftrail mcp
+  - browser evidence
+  - governed recovery
+  - uiq proof
+---
+
+# ProofTrail MCP Skill
+
+Teach the agent how to install, connect, and use ProofTrail's governed MCP
+surface as a browser-evidence and recovery layer.
+
+## Use this skill when
+
+- the host can attach a local stdio MCP server from a repo checkout
+- the user needs governed browser-evidence reads before broad automation
+- the operator wants a truthful packet that separates current repo-native MCP
+  from future package or Docker publication
+
+## What this package teaches
+
+- how to launch ProofTrail's current repo-native MCP server
+- how to choose the safest ProofTrail tool families first
+- how to move from catalog and read tools into governed run or proof tools
+- how to talk about future npm, Docker, or registry surfaces without
+  overclaiming publication
+
+## What ProofTrail is
+
+ProofTrail is an evidence-first browser automation and recovery layer.
+
+It helps AI agents and human operators:
+
+- run browser workflows through a governed path
+- inspect retained evidence after each run
+- recover from failures without pretending the browser layer is a generic bot
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the first-success path in [references/DEMO.md](references/DEMO.md)
+
+## Safe-first workflow
+
+1. `uiq_catalog`
+2. `uiq_read`
+3. `uiq_quality_read`
+4. `uiq_proof`
+5. only then widen into:
+   - `uiq_run`
+   - `uiq_run_and_report`
+   - `uiq_api_workflow`
+   - `uiq_api_automation`
+
+## Suggested first prompt
+
+Use ProofTrail as a governed browser-evidence layer. Start with `uiq_catalog`
+to confirm the MCP surface is attached. Then use `uiq_read` or
+`uiq_quality_read` to inspect one existing run or failure surface. If a real run
+is already present, follow with `uiq_proof` or `uiq_run_and_report` to show the
+retained evidence and summarize the most important next action.
+
+## Current / usable today
+
+Current install path:
+
+1. clone the ProofTrail repo
+2. run `pnpm install`
+3. point your MCP client at the repo-local stdio command
+4. start the MCP bridge with `pnpm mcp:start`
+
+Protocol and auth truth:
+
+- auth = `local-with-optional-backend-token`
+
+## Publish-ready but not yet published
+
+The following install surfaces are planned and not yet published:
+
+- npm package: `@prooftrail/mcp-server`
+- Docker image: `ghcr.io/xiaojiou176-open/prooftrail-mcp-server:0.1.1`
+
+Do not describe either surface as live until the package or image is actually
+published.
+
+## Success checks
+
+- the host attaches the repo-native MCP server successfully
+- the agent cites a real run, artifact, or proof bundle instead of describing a
+  generic browser story
+- the answer stays grounded in evidence instead of free-writing from memory
+
+## Boundaries
+
+- this packet is not an official plugin
+- ProofTrail is not a hosted service
+- ProofTrail is not a hosted SaaS service
+- ProofTrail is not a hosted MCP endpoint
+- this packet does not claim a live OpenHands or ClawHub listing
+- future npm or Docker shapes are publish-ready but not yet published
+
+## Local references
+
+- [references/INSTALL.md](references/INSTALL.md)
+- [references/CAPABILITIES.md](references/CAPABILITIES.md)
+- [references/DEMO.md](references/DEMO.md)
+- [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)

--- a/skills/prooftrail-mcp/manifest.yaml
+++ b/skills/prooftrail-mcp/manifest.yaml
@@ -1,0 +1,52 @@
+name: prooftrail-mcp
+version: 0.1.1
+description: Generic install skill for using ProofTrail as a governed stdio MCP surface.
+protocol: stdio
+transport: stdio
+auth: local-with-optional-backend-token
+entrypoint: SKILL.md
+package_shape: skill-folder
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/prooftrail-mcp
+    submit_via: clawhub publish . --slug prooftrail-mcp --name "ProofTrail MCP Skill" --version 0.1.1 --tags browser-evidence,mcp,recovery,prooftrail
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/prooftrail-mcp/ in OpenHands/extensions
+surfaces:
+  - repo-native MCP package
+  - repo-owned install skill
+  - publish-ready Docker surface
+supported_shells:
+  - Codex
+  - Claude Code
+  - OpenCode
+  - OpenClaw
+  - OpenHands
+install_modes:
+  - local-checkout-stdio
+  - clawhub-listed-live
+docs:
+  - apps/mcp-server/README.md
+  - docs/how-to/mcp-quickstart-1pager.md
+  - docs/reference/mcp-distribution-contract.md
+  - DISTRIBUTION.md
+  - INTEGRATIONS.md
+limitations:
+  - not an official plugin
+  - not a hosted service
+  - no live OpenHands/extensions listing yet
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/prooftrail-mcp/references/CAPABILITIES.md
+++ b/skills/prooftrail-mcp/references/CAPABILITIES.md
@@ -1,0 +1,34 @@
+# ProofTrail MCP Capabilities
+
+These are the current tool families surfaced by ProofTrail's governed MCP
+server.
+
+## Best first tools
+
+1. `uiq_catalog`
+   - read the top-level capability and surface catalog
+2. `uiq_read`
+   - inspect one run, artifact, or repo-owned proof surface
+3. `uiq_quality_read`
+   - summarize failures, quality, and gate posture without mutation
+4. `uiq_proof`
+   - inspect proof bundles and recovery/evidence surfaces
+
+## Good next actions
+
+- `uiq_run`
+- `uiq_run_and_report`
+- `uiq_api_workflow`
+- `uiq_api_automation`
+
+Use these only after the safe-first catalog and read path is already grounded.
+
+## Useful supporting tools
+
+- `uiq_model_target_capabilities`
+- `uiq_compare_perf`
+- `uiq_read_proof_report`
+- `uiq_export_proof_bundle`
+- `uiq_run_deep_load_localhost`
+
+Treat these as follow-through tools, not the first thing a reviewer should see.

--- a/skills/prooftrail-mcp/references/DEMO.md
+++ b/skills/prooftrail-mcp/references/DEMO.md
@@ -1,0 +1,30 @@
+# First-Success Path
+
+## Demo prompt
+
+Use ProofTrail as a governed browser-evidence layer. Start with `uiq_catalog`
+to confirm the MCP surface is attached. Then use `uiq_read` or
+`uiq_quality_read` to inspect one existing run or failure surface. If a real run
+is already present, follow with `uiq_proof` or `uiq_run_and_report` to show the
+retained evidence and summarize the most important next action.
+
+## Expected tool sequence
+
+1. `uiq_catalog`
+2. `uiq_read`
+3. `uiq_quality_read`
+4. `uiq_proof` or `uiq_run_and_report`
+
+## Visible success criteria
+
+- the host attaches the MCP server successfully
+- the agent cites a real repo-owned run, proof bundle, or failure surface
+- the answer stays grounded in evidence instead of generic browser-automation
+  claims
+
+## What to check if it fails
+
+1. `pnpm mcp:start` starts from the repo root
+2. `pnpm mcp:check` passes
+3. if you need live backend reads, `UIQ_MCP_API_BASE_URL` points at a reachable
+   backend

--- a/skills/prooftrail-mcp/references/INSTALL.md
+++ b/skills/prooftrail-mcp/references/INSTALL.md
@@ -1,0 +1,34 @@
+# Install And Attach ProofTrail MCP
+
+## Local repo setup
+
+```bash
+git clone https://github.com/xiaojiou176-open/prooftrail.git
+cd prooftrail
+pnpm install
+```
+
+## Start the current repo-native MCP server
+
+```bash
+pnpm mcp:start
+```
+
+Before loading the host config snippets in this folder, replace
+`/absolute/path/to/prooftrail` with the real path to your local clone.
+
+## Verification commands
+
+```bash
+pnpm mcp:check
+pnpm mcp:test
+pnpm mcp:smoke
+```
+
+Use `pnpm test:mcp-server:real` only when a real backend is already running and
+`UIQ_ENABLE_REAL_BACKEND_TESTS=true` is set.
+
+## Truth boundary
+
+This packet teaches the repo-native stdio MCP surface that works today.
+Future npm or Docker command shapes are publish-ready but not yet published.

--- a/skills/prooftrail-mcp/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/prooftrail-mcp/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,13 @@
+{
+  "mcp": {
+    "servers": {
+      "prooftrail": {
+        "command": "pnpm",
+        "args": [
+          "mcp:start"
+        ],
+        "cwd": "/absolute/path/to/prooftrail"
+      }
+    }
+  }
+}

--- a/skills/prooftrail-mcp/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/prooftrail-mcp/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "prooftrail": {
+      "command": "pnpm",
+      "args": [
+        "mcp:start"
+      ],
+      "cwd": "/absolute/path/to/prooftrail"
+    }
+  }
+}

--- a/skills/prooftrail-mcp/references/README.md
+++ b/skills/prooftrail-mcp/references/README.md
@@ -1,0 +1,16 @@
+# ProofTrail MCP References
+
+## File map
+
+- `INSTALL.md`
+  - clone, attach, and proof loop
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-style `mcpServers` snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-style `mcp.servers` snippet
+- `CAPABILITIES.md`
+  - current ProofTrail tool families and safe-first order
+- `DEMO.md`
+  - first-success prompt and expected tool sequence
+- `TROUBLESHOOTING.md`
+  - attach, backend, and proof failure checks

--- a/skills/prooftrail-mcp/references/TROUBLESHOOTING.md
+++ b/skills/prooftrail-mcp/references/TROUBLESHOOTING.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## The host cannot attach the MCP server
+
+- confirm the `cwd` points at the real repo checkout
+- rerun `pnpm install`
+- rerun `pnpm mcp:check`
+
+## The MCP server starts but cannot see live backend state
+
+- confirm whether this task actually needs live backend reads
+- if yes, set `UIQ_MCP_API_BASE_URL` and any required token env vars
+- otherwise stay on repo-owned proof and artifact surfaces only
+
+## The agent jumps straight into heavy run tools
+
+- restart from `uiq_catalog`, `uiq_read`, and `uiq_quality_read`
+- treat `uiq_run` and `uiq_api_automation` as second-pass tools
+- keep the first pass evidence-first and read-oriented

--- a/skills/shopflow-read-only-packet/README.md
+++ b/skills/shopflow-read-only-packet/README.md
@@ -1,0 +1,42 @@
+# Shopflow Read-only Packet Public Skill
+
+This folder is the public, self-contained skill packet for Shopflow's
+read-only MCP surface and packet-oriented distribution lane.
+
+Use it when you want one portable folder that teaches an agent four things:
+
+- how to attach Shopflow's local read-only MCP server
+- which capability packets are safe first
+- what a good first-success packet loop looks like
+- which claims stay outside the repo until a real listing or store publish
+  exists
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local packet import flows that expect one standalone folder
+
+## Current verified state
+
+- the ClawHub skill listing is live
+- the OpenHands/extensions lane is still folder-ready, not merged
+
+## What this packet must not claim
+
+- no live OpenHands/extensions listing without fresh PR or read-back
+- no official registry, marketplace, or Chrome Web Store listing unless fresh
+  receipt exists
+- no hosted runtime or public HTTP MCP transport

--- a/skills/shopflow-read-only-packet/SKILL.md
+++ b/skills/shopflow-read-only-packet/SKILL.md
@@ -1,0 +1,36 @@
+# Shopflow Read-only Packet
+
+Teach the agent how to install, connect, and use Shopflow as a read-only packet
+surface.
+
+## Use this skill when
+
+- the user wants integration or submission-readiness truth without live store
+  claims
+- the host can run Shopflow's local `stdio` MCP server
+- the operator wants a packet that explains install, capabilities, and proof in
+  one folder
+
+## What this packet teaches
+
+- how to attach the current Shopflow MCP server
+- which packet-oriented capabilities are safe first
+- how to read submission readiness without flattening it into fake live claims
+- how to keep the OpenClaw-facing install shell truthful
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the capability map in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the proof loop in [references/DEMO.md](references/DEMO.md)
+5. If the packet or attach path fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)
+
+## Must not claim
+
+- canonical Shopflow repo status beyond the packet truth
+- official OpenClaw listing already live
+- official OpenClaw org integration already approved

--- a/skills/shopflow-read-only-packet/manifest.yaml
+++ b/skills/shopflow-read-only-packet/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: shopflow-read-only-packet
+  display_name: Shopflow Read-only Packet
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/shopflow-read-only-packet
+    submit_via: clawhub publish . --slug shopflow-read-only-packet --name "Shopflow Read-only Packet" --version 1.0.0 --tags shopflow,mcp,read-only,distribution,packet
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/shopflow-read-only-packet/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Read-only Shopflow packet surface for integration, runtime seam, submission readiness, and public distribution bundle truth.
+  canonical_repo_version: 0.1.0
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No official registry or store listing exists yet
+    - No hosted runtime or public HTTP MCP transport is claimed
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/shopflow-read-only-packet/references/CAPABILITIES.md
+++ b/skills/shopflow-read-only-packet/references/CAPABILITIES.md
@@ -1,0 +1,25 @@
+# Shopflow MCP Capabilities
+
+Shopflow exposes a read-only packet surface for integration and distribution
+truth.
+
+## Safe-first packets and tools
+
+- `get_integration_surface`
+- `get_runtime_seam`
+- `get_submission_readiness`
+- `get_public_distribution_bundle`
+
+## Recommended first-use order
+
+1. `get_integration_surface`
+2. `get_submission_readiness`
+3. `get_public_distribution_bundle`
+4. `get_runtime_seam`
+
+## Boundary
+
+- good fit: packet review, submission readiness, runtime seam, and distribution
+  truth
+- not a fit: claiming live store listing, public HTTP transport, or hosted
+  runtime

--- a/skills/shopflow-read-only-packet/references/DEMO.md
+++ b/skills/shopflow-read-only-packet/references/DEMO.md
@@ -1,0 +1,24 @@
+# Shopflow MCP First-Success Demo
+
+This is the shortest packet loop that proves the skill is real.
+
+## Demo prompt
+
+Use Shopflow to inspect the current public distribution truth. Start with
+`get_integration_surface` and `get_submission_readiness`. If the packet looks
+healthy, read `get_public_distribution_bundle` and summarize which part is
+repo-ready, which part is owner-only later, and which claim is still out of
+bounds.
+
+## Expected tool sequence
+
+1. `get_integration_surface`
+2. `get_submission_readiness`
+3. `get_public_distribution_bundle`
+4. `get_runtime_seam`
+
+## Visible success criteria
+
+- the MCP server launches
+- the packet summary points to real repo-owned JSON surfaces
+- the answer separates repo-ready from store-ready instead of flattening them

--- a/skills/shopflow-read-only-packet/references/INSTALL.md
+++ b/skills/shopflow-read-only-packet/references/INSTALL.md
@@ -1,0 +1,42 @@
+# Install And Attach Shopflow MCP
+
+Use the current repo-native MCP path first.
+
+## Quickest local setup
+
+1. Clone the public repository:
+
+```bash
+git clone https://github.com/xiaojiou176-open/shopflow-suite.git
+cd shopflow-suite
+pnpm install
+```
+
+2. Start the read-only MCP surface:
+
+```bash
+pnpm mcp:stdio
+```
+
+3. Replace `/absolute/path/to/shopflow-suite` in the host config snippets with
+   the real path to your local clone before attach.
+
+4. Verify the packet surface:
+
+```bash
+pnpm verify:catalog
+pnpm verify:release-readiness
+```
+
+## Current truthful install mode
+
+- protocol: `stdio`
+- transport: `stdio`
+- public listing: not claimed
+- browser extension/store listing: not claimed
+
+## What to hand back to the agent
+
+- whether the MCP server launches
+- whether the capability packets are readable
+- whether the distribution bundle looks ready or still blocked

--- a/skills/shopflow-read-only-packet/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/shopflow-read-only-packet/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,11 @@
+{
+  "mcp": {
+    "servers": {
+      "shopflow": {
+        "command": "pnpm",
+        "args": ["mcp:stdio"],
+        "cwd": "/absolute/path/to/shopflow-suite"
+      }
+    }
+  }
+}

--- a/skills/shopflow-read-only-packet/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/shopflow-read-only-packet/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "shopflow": {
+      "command": "pnpm",
+      "args": ["mcp:stdio"],
+      "cwd": "/absolute/path/to/shopflow-suite"
+    }
+  }
+}

--- a/skills/shopflow-read-only-packet/references/README.md
+++ b/skills/shopflow-read-only-packet/references/README.md
@@ -1,0 +1,18 @@
+# Shopflow Read-only Packet References
+
+This folder keeps the public packet self-contained.
+
+## Files
+
+- `INSTALL.md`
+  - local install and attach guide
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-ready config snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-ready config snippet
+- `CAPABILITIES.md`
+  - safe-first capability map
+- `DEMO.md`
+  - first-success packet loop
+- `TROUBLESHOOTING.md`
+  - shortest checks before escalation

--- a/skills/shopflow-read-only-packet/references/TROUBLESHOOTING.md
+++ b/skills/shopflow-read-only-packet/references/TROUBLESHOOTING.md
@@ -1,0 +1,26 @@
+# Shopflow MCP Troubleshooting
+
+Use these checks before escalating.
+
+## 1. MCP will not start
+
+- run `pnpm install`
+- run `pnpm mcp:stdio`
+- confirm the command is being run from the real Shopflow repo root
+
+## 2. Capability packets look stale
+
+- rerun the packet-generating commands documented in `docs/ecosystem/examples/`
+- re-check `docs/ecosystem/examples/public-mcp-capability-map.json`
+- re-check `docs/ecosystem/examples/public-distribution-bundle.ready.md`
+
+## 3. The wording sounds stronger than reality
+
+Stop and re-check:
+
+- `DISTRIBUTION.md`
+- `docs/ecosystem/openclaw-comparison.md`
+- `docs/ecosystem/public-distribution-bundle.ready.md`
+
+Do not say ClawHub, OpenHands, registry, or Chrome Web Store are live unless
+fresh receipts exist.

--- a/skills/switchyard-runtime-diagnostics/README.md
+++ b/skills/switchyard-runtime-diagnostics/README.md
@@ -1,0 +1,44 @@
+# Switchyard Runtime Diagnostics Public Skill Packet
+
+This folder is the public, self-contained skill packet for Switchyard's
+read-only MCP runtime diagnostics lane.
+
+Use it when you want one portable skill folder that teaches an agent four
+things:
+
+- how to attach the current Switchyard MCP server
+- which read-only runtime and catalog tools are safe first
+- what one good first diagnostic loop looks like
+- which claims stay out of bounds until a real package, listing, or registry
+  entry exists
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/OPENHANDS_MCP_CONFIG.json`
+- `references/OPENCLAW_MCP_CONFIG.json`
+- `references/CAPABILITIES.md`
+- `references/DEMO.md`
+- `references/TROUBLESHOOTING.md`
+
+## Best-fit hosts
+
+- OpenHands/extensions contribution flow
+- ClawHub-style skill publication
+- repo-local import flows that expect a standalone folder with install, config,
+  capability, and demo notes
+
+## Current verified state
+
+- the ClawHub skill listing is live
+- the OpenHands/extensions lane is still folder-ready, not merged
+
+## What this packet must not claim
+
+- no live OpenHands/extensions listing without fresh PR or read-back
+- no published npm package or official MCP Registry listing without fresh
+  receipt
+- no execution-brain or full host-parity claim

--- a/skills/switchyard-runtime-diagnostics/SKILL.md
+++ b/skills/switchyard-runtime-diagnostics/SKILL.md
@@ -1,0 +1,34 @@
+# Switchyard Runtime Diagnostics
+
+Teach the agent how to install, connect, and use Switchyard's read-only MCP
+runtime diagnostics surface.
+
+## Use this skill when
+
+- the user wants to diagnose one provider or runtime boundary
+- the host can run the local `stdio` MCP server
+- the agent needs read-only runtime and catalog truth before any human action
+
+## What this packet teaches
+
+- how to attach the current Switchyard MCP server
+- which runtime and catalog tools are safe first
+- how to separate internal blockers from external blockers
+- how to keep claims grounded in `partial`, `read-only`, and `package-ready`
+
+## Start here
+
+1. Read [references/INSTALL.md](references/INSTALL.md)
+2. Load the right host config from:
+   - [references/OPENHANDS_MCP_CONFIG.json](references/OPENHANDS_MCP_CONFIG.json)
+   - [references/OPENCLAW_MCP_CONFIG.json](references/OPENCLAW_MCP_CONFIG.json)
+3. Skim the tool surface in [references/CAPABILITIES.md](references/CAPABILITIES.md)
+4. Run the first diagnostic loop in [references/DEMO.md](references/DEMO.md)
+5. If the attach or proof path fails, use
+   [references/TROUBLESHOOTING.md](references/TROUBLESHOOTING.md)
+
+## Guardrails
+
+- do not write to external accounts
+- do not turn `partial` into `supported`
+- do not turn `auth-status ready` into live-ready

--- a/skills/switchyard-runtime-diagnostics/manifest.yaml
+++ b/skills/switchyard-runtime-diagnostics/manifest.yaml
@@ -1,0 +1,41 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: switchyard-runtime-diagnostics
+  display_name: Switchyard Runtime Diagnostics
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: listed-live
+    package_shape: skill-folder
+    listing_url: https://www.clawhub.ai/skills/switchyard-runtime-diagnostics
+    submit_via: clawhub publish . --slug switchyard-runtime-diagnostics --name "Switchyard Runtime Diagnostics" --version 1.0.0 --tags switchyard,mcp,diagnostics,runtime,read-only
+  openhands-extensions:
+    status: review-pending
+    package_shape: skill-folder
+    submission_url: https://github.com/OpenHands/extensions/pull/160
+    submit_via: submit this folder as skills/switchyard-runtime-diagnostics/ in OpenHands/extensions
+
+boundaries:
+  product_identity: Read-only Switchyard runtime diagnostics and catalog routing through the repo-native MCP surface.
+  canonical_repo_version: 0.1.0
+  official_listing_state: clawhub-live-openhands-review-pending
+  not_claimed:
+    - No live OpenHands/extensions listing exists yet
+    - No official MCP Registry listing exists yet
+    - No full host parity or execution-brain claim is made
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/CAPABILITIES.md
+  - references/DEMO.md
+  - references/OPENHANDS_MCP_CONFIG.json
+  - references/OPENCLAW_MCP_CONFIG.json
+  - references/TROUBLESHOOTING.md

--- a/skills/switchyard-runtime-diagnostics/references/CAPABILITIES.md
+++ b/skills/switchyard-runtime-diagnostics/references/CAPABILITIES.md
@@ -1,0 +1,32 @@
+# Switchyard MCP Capabilities
+
+Switchyard exposes a read-only MCP surface for runtime diagnostics and catalog
+truth.
+
+## Safe-first tools
+
+- `switchyard.runtime.health`
+- `switchyard.providers.list`
+- `switchyard.provider.status`
+- `switchyard.provider.probe`
+- `switchyard.provider.support_bundle`
+- `switchyard.catalog.surface_catalog`
+- `switchyard.catalog.compat_target_catalog`
+- `switchyard.catalog.builder_kit_catalog`
+- `switchyard.catalog.skill_pack_catalog`
+- `switchyard.catalog.host_playbook`
+
+## Recommended first-use order
+
+1. `switchyard.runtime.health`
+2. `switchyard.providers.list`
+3. `switchyard.provider.status`
+4. `switchyard.provider.support_bundle`
+5. `switchyard.catalog.host_playbook`
+
+## Boundary
+
+- good fit: runtime health, provider diagnostics, starter-pack routing, and
+  read-only catalog inspection
+- not a fit: runtime invoke, acquisition write, browser automation, or full
+  host parity claims

--- a/skills/switchyard-runtime-diagnostics/references/DEMO.md
+++ b/skills/switchyard-runtime-diagnostics/references/DEMO.md
@@ -1,0 +1,25 @@
+# Switchyard MCP First-Success Demo
+
+This is the shortest diagnostic loop that proves the packet is real.
+
+## Demo prompt
+
+Use Switchyard to diagnose whether one provider is actually ready. Start with
+`switchyard.runtime.health`, list the available providers, then inspect one
+provider with `switchyard.provider.status` and
+`switchyard.provider.support_bundle`. Finish by telling me whether the next
+blocker is internal or external.
+
+## Expected tool sequence
+
+1. `switchyard.runtime.health`
+2. `switchyard.providers.list`
+3. `switchyard.provider.status`
+4. `switchyard.provider.support_bundle`
+
+## Visible success criteria
+
+- the MCP server launches from the provided config
+- the runtime health call returns a real response
+- the provider status and support bundle point to a concrete blocker
+- the answer stays read-only and truthful

--- a/skills/switchyard-runtime-diagnostics/references/INSTALL.md
+++ b/skills/switchyard-runtime-diagnostics/references/INSTALL.md
@@ -1,0 +1,42 @@
+# Install And Attach Switchyard MCP
+
+Use the current repo-native MCP path first.
+
+## Quickest local setup
+
+1. Clone the public repository:
+
+```bash
+git clone https://github.com/xiaojiou176-open/Switchyard.git
+cd Switchyard
+pnpm install
+```
+
+2. Start the read-only MCP surface:
+
+```bash
+pnpm run switchyard:mcp -- --base-url http://127.0.0.1:4010
+```
+
+Before loading the host config snippets in this folder, replace
+`/ABSOLUTE/PATH/TO/SWITCHYARD` with the real path to your local clone.
+
+3. Verify the surface:
+
+```bash
+pnpm run test:mcp:smoke
+pnpm run switchyard:cli -- mcp-tools --json
+```
+
+## Current truthful install mode
+
+- protocol: `stdio`
+- transport: `stdio`
+- package publication: not claimed
+- registry listing: not claimed
+
+## What to hand back to the agent
+
+- whether the local runtime at `http://127.0.0.1:4010` is reachable
+- whether the MCP server launches
+- whether the first tool call succeeds

--- a/skills/switchyard-runtime-diagnostics/references/OPENCLAW_MCP_CONFIG.json
+++ b/skills/switchyard-runtime-diagnostics/references/OPENCLAW_MCP_CONFIG.json
@@ -1,0 +1,17 @@
+{
+  "mcp": {
+    "servers": {
+      "switchyard": {
+        "command": "pnpm",
+        "args": [
+          "run",
+          "switchyard:mcp",
+          "--",
+          "--base-url",
+          "http://127.0.0.1:4010"
+        ],
+        "cwd": "/ABSOLUTE/PATH/TO/SWITCHYARD"
+      }
+    }
+  }
+}

--- a/skills/switchyard-runtime-diagnostics/references/OPENHANDS_MCP_CONFIG.json
+++ b/skills/switchyard-runtime-diagnostics/references/OPENHANDS_MCP_CONFIG.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "switchyard": {
+      "command": "pnpm",
+      "args": [
+        "run",
+        "switchyard:mcp",
+        "--",
+        "--base-url",
+        "http://127.0.0.1:4010"
+      ],
+      "cwd": "/ABSOLUTE/PATH/TO/SWITCHYARD"
+    }
+  }
+}

--- a/skills/switchyard-runtime-diagnostics/references/README.md
+++ b/skills/switchyard-runtime-diagnostics/references/README.md
@@ -1,0 +1,18 @@
+# Switchyard Runtime Diagnostics Packet References
+
+This folder keeps the public packet self-contained.
+
+## Files
+
+- `INSTALL.md`
+  - local install and attach guide
+- `OPENHANDS_MCP_CONFIG.json`
+  - OpenHands-ready config snippet
+- `OPENCLAW_MCP_CONFIG.json`
+  - OpenClaw-ready config snippet
+- `CAPABILITIES.md`
+  - safe-first tool map and capability boundaries
+- `DEMO.md`
+  - first-success runtime diagnostic loop
+- `TROUBLESHOOTING.md`
+  - shortest checks before escalation

--- a/skills/switchyard-runtime-diagnostics/references/TROUBLESHOOTING.md
+++ b/skills/switchyard-runtime-diagnostics/references/TROUBLESHOOTING.md
@@ -1,0 +1,26 @@
+# Switchyard MCP Troubleshooting
+
+Use these checks before escalating.
+
+## 1. MCP will not start
+
+- run `pnpm install`
+- run `pnpm run test:mcp:smoke`
+- confirm the runtime base URL is reachable
+
+## 2. The provider looks empty
+
+- run `switchyard.providers.list`
+- confirm you chose the right provider name
+- run `switchyard.provider.status` before asking for deeper diagnostics
+
+## 3. The answer sounds too strong
+
+Stop and re-check:
+
+- `DISTRIBUTION.md`
+- `INTEGRATIONS.md`
+- `docs/api/mcp-readonly-server.md`
+
+If the wording drifts from `partial`, `read-only`, or `package-ready`, the
+packet is overclaiming.


### PR DESCRIPTION
## What these skills teach

This PR adds six self-contained public skill packets that teach an agent how to install, attach, verify, and safely use repo-owned MCP surfaces without overclaiming hosted or marketplace state.

- `openui-workspace-delivery`
  - teaches local OpenUI MCP attach, safe-first UI generation, quality-gate flow, and review-bundle proof
- `movi-review-first-bundle`
  - teaches review-first batch inspection, manifest reads, safe-first analysis, and guarded mutation boundaries
- `switchyard-runtime-diagnostics`
  - teaches runtime/provider diagnostics, safe-first catalog reads, and truthful internal-vs-external blocker triage
- `prooftrail-mcp`
  - teaches governed browser-evidence MCP attach, read-first proof inspection, and truthful package/listing boundaries
- `shopflow-read-only-packet`
  - teaches submission-readiness and packet-truth inspection without fake live store claims
- `prooflane-mcp`
  - teaches repo-native MCP attach, governed run/proof inspection, and truthful publish-ready-vs-published boundaries

## Why these packets are different from prompt cards

Each skill folder is meant to stand alone for a reviewer or host:

- `SKILL.md` teaches the workflow
- `README.md` explains what the agent learns
- `manifest.yaml` captures current package/listing state
- `references/INSTALL.md` shows attach/setup
- `references/OPENHANDS_MCP_CONFIG.json` and `references/OPENCLAW_MCP_CONFIG.json` give host config examples
- `references/CAPABILITIES.md` maps the tool surface and safe-first order
- `references/DEMO.md` gives a first-success path and expected outcome shape
- `references/TROUBLESHOOTING.md` explains where to look when attach or first success fails

## Boundaries

These packets intentionally do not claim hosted runtimes, universal live marketplace presence, or publication that has not actually landed.

## Notes

- `openui-workspace-delivery`, `movi-review-first-bundle`, `switchyard-runtime-diagnostics`, `shopflow-read-only-packet`, and `prooftrail-mcp` are already live on ClawHub.
- `prooflane-mcp` is included here as a truthful repo-native packet even though its ClawHub new-skill publish is currently blocked by the platform's hourly new-skill rate limit.
