### PR TITLE
Add agent-exporter archive governance workbench skill

### DIFF
--- a/skills/agent-exporter-archive-governance-workbench/README.md
+++ b/skills/agent-exporter-archive-governance-workbench/README.md
@@ -1,0 +1,46 @@
+# agent-exporter Archive Governance Workbench
+
+This skill helps OpenHands attach the local `agent-exporter` stdio bridge from a repo checkout and use the archive, retrieval, and governance workflow without pretending there is a hosted platform.
+
+## What this skill does
+
+- attaches the local stdio bridge
+- publishes a local archive shell for a workspace
+- runs semantic or hybrid retrieval and saves local reports
+- reads governance evidence, policy packs, and baseline history
+
+## Product truth
+
+- `agent-exporter` is a local-first archive and governance workbench
+- the current primary surface is still `CLI-first`
+- this OpenHands skill is a secondary public lane, not the flagship packet
+- the bridge exposes read-mostly archive, retrieval, and governance tools
+- browser pages organize proof; they do not execute retrieval
+
+## First-success path
+
+1. Wire the local stdio bridge from a repo checkout.
+2. Call `integration_evidence_policy_list` first.
+3. If the workspace already has transcript HTML receipts, call `publish_archive_index` on that workspace.
+4. Move to retrieval or evidence comparison only after the bridge works.
+
+## Good fit
+
+- local archive workspaces
+- transcript browsing and report workflows
+- governance evidence and baseline review
+- hosts that can launch a local stdio server
+
+## Must not claim
+
+- no hosted archive platform
+- no listed-live status for this skill without fresh host read-back
+- no full-CLI MCP parity
+- no change to the flagship `CLI-first` product story
+
+## Public proof links
+
+- Landing: https://xiaojiou176-open.github.io/agent-exporter/
+- Archive shell proof: https://xiaojiou176-open.github.io/agent-exporter/archive-shell-proof.html
+- Repo map: https://xiaojiou176-open.github.io/agent-exporter/repo-map/
+- Releases: https://github.com/xiaojiou176-open/agent-exporter/releases

--- a/skills/agent-exporter-archive-governance-workbench/SKILL.md
+++ b/skills/agent-exporter-archive-governance-workbench/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: agent-exporter-archive-governance-workbench
+description: Use when an agent needs to attach the local agent-exporter stdio bridge, publish a local archive shell, save retrieval reports, or read governance evidence and baseline history from a repo checkout. This skill teaches the archive/retrieval/governance lane split without overclaiming hosted or listed-live status.
+triggers:
+- agent-exporter
+- archive shell
+- governance evidence
+- semantic retrieval
+- hybrid retrieval
+- local stdio mcp
+---
+
+# agent-exporter Archive Governance Workbench
+
+Use this skill when an agent needs to operate the local `agent-exporter` bridge from a repo checkout.
+
+## What this skill teaches
+
+- how to attach the local stdio bridge
+- how to prove the bridge on a safe first-success path
+- how to publish a local archive shell
+- how to save local retrieval reports
+- how to read governance evidence without claiming a hosted platform
+
+## Product truth
+
+- `agent-exporter` is a local-first archive and governance workbench
+- the current primary surface is still `CLI-first`
+- this OpenHands skill is a secondary public lane
+- the bridge exposes archive, retrieval, and governance tools
+- browser pages organize proof; they do not execute retrieval
+
+## First-success flow
+
+1. Wire the bridge from a local repo checkout.
+2. Call `integration_evidence_policy_list` first.
+3. If the workspace already has transcript HTML receipts, call `publish_archive_index`.
+4. Move to retrieval or evidence comparison only after the bridge works.
+
+## Example prompts
+
+- "Attach the local agent-exporter bridge and list the available governance policies."
+- "Publish the archive shell for this workspace and tell me where it landed."
+- "Run semantic retrieval for this workspace and save a local report."
+- "Compare two saved integration evidence snapshots and explain the readiness delta."
+
+## Good truth language
+
+- local stdio bridge
+- secondary public lane
+- archive and governance workbench
+
+## Forbidden truth language
+
+- hosted platform
+- listed-live skill without fresh host read-back
+- full CLI exposed through MCP


### PR DESCRIPTION
## Summary
- add a new OpenHands skill for the local `agent-exporter` archive/governance workbench
- keep the skill clearly secondary to the flagship CLI-first public packet
- document a safe first-success path for the local stdio bridge

## Why
`agent-exporter` already exposes a local stdio bridge for archive, retrieval, and governance workflows. This skill packages that shape for host-native review without overclaiming hosted or listed-live status.

## Boundaries
- local stdio bridge only
- no hosted platform claim
- no full-CLI MCP parity claim
- no listed-live claim for this skill
