### PR TITLE
Add docsiphon doc corpus operator skill

### DIFF
--- a/marketplaces/default.json
+++ b/marketplaces/default.json
@@ -471,6 +471,19 @@
                 "verification",
                 "sample"
             ]
+        },
+        {
+            "name": "docsiphon-doc-corpus-operator",
+            "source": "./docsiphon-doc-corpus-operator",
+            "description": "Run the Docsiphon CLI to export a small documentation subtree into a reviewable local Markdown corpus with manifest and report artifacts.",
+            "category": "documentation",
+            "keywords": [
+                "docs",
+                "documentation",
+                "corpus",
+                "rag",
+                "markdown"
+            ]
         }
     ]
 }

--- a/skills/docsiphon-doc-corpus-operator/README.md
+++ b/skills/docsiphon-doc-corpus-operator/README.md
@@ -1,0 +1,64 @@
+# docsiphon Doc Corpus Operator
+
+This folder is a host-native public skill packet for `docsiphon`.
+
+The flagship public story is still:
+
+- GitHub repo front door
+- `uvx` quickstart
+- release assets / example profiles
+
+This packet exists for host reviewers who need a self-contained folder that
+teaches an agent how to run the Docsiphon CLI, export one small documentation
+corpus, and inspect the resulting audit artifacts without turning Docsiphon
+into a hosted platform or an MCP-first product.
+
+## What this packet teaches
+
+This packet teaches an agent how to:
+
+1. install or invoke Docsiphon through the current CLI-first path
+2. run one small, scoped export against a documentation subtree
+3. inspect the resulting manifest and report artifacts
+4. stay inside the current product boundary instead of promising a generic site
+   mirror or hosted browser workflow
+
+## What this packet includes
+
+- `SKILL.md`
+- `manifest.yaml`
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/DEMO.md`
+- `references/CAPABILITIES.md`
+- `references/TROUBLESHOOTING.md`
+
+## First-success path
+
+1. read `SKILL.md`
+2. follow `references/INSTALL.md`
+3. run the small scoped export in `references/DEMO.md`
+4. inspect `manifest.jsonl`, `report.json`, `toc.md`, and `report.html`
+
+## Current registry truth
+
+- `ClawHub`: `not submitted yet`
+- `OpenHands/extensions`: `not submitted yet`
+
+This packet is still a **secondary host-native lane**.
+It does not replace the current `CLI-first` primary surface.
+
+## What this packet must not claim
+
+- no hosted documentation export platform
+- no listed-live ClawHub entry yet
+- no listed-live OpenHands/extensions entry yet
+- no MCP-first product positioning
+
+## Source of truth
+
+Canonical product truth still lives in:
+
+- `README.md`
+- `AGENTS.md`
+- `docs/README.md`

--- a/skills/docsiphon-doc-corpus-operator/SKILL.md
+++ b/skills/docsiphon-doc-corpus-operator/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: docsiphon-doc-corpus-operator
+description: Use when an agent needs to run Docsiphon through the CLI-first path, export a small documentation subtree, and inspect the resulting audit artifacts without overclaiming hosted or MCP-first product status.
+triggers:
+  - docsiphon
+  - documentation corpus export
+  - llms.txt
+  - sitemap
+  - manifest.jsonl
+  - report.html
+---
+
+# docsiphon Doc Corpus Operator
+
+Use this skill when an agent needs to run the current Docsiphon CLI flow and
+inspect the resulting export artifacts from a repo checkout or `uvx` path.
+
+## Product truth
+
+- `docsiphon` is currently `CLI-first`
+- this packet is a host-native secondary lane
+- the packet teaches export and artifact inspection, not a hosted browser
+  workflow
+- any future MCP-aware surface remains future secondary until it ships its own
+  install contract, verification gate, public packet, and lane truth
+
+## Current registry truth
+
+- `ClawHub`: `not submitted yet`
+- `OpenHands/extensions`: `not submitted yet`
+
+## First-success flow
+
+1. Follow `references/INSTALL.md`
+2. Run the small scoped export in `references/DEMO.md`
+3. Inspect `manifest.jsonl`, `report.json`, `toc.md`, and `report.html`
+4. Only after the first export works, move to bigger site scopes or custom
+   profiles
+
+## Preferred evidence order
+
+1. `references/INSTALL.md`
+2. `references/DEMO.md`
+3. `references/CAPABILITIES.md`
+4. `references/TROUBLESHOOTING.md`
+
+## Truth language
+
+- Good: `CLI-first`
+- Good: `scoped export`
+- Good: `audit artifacts`
+- Good: `host-native secondary lane`
+- Forbidden: `hosted platform`
+- Forbidden: `listed-live` without fresh host read-back
+- Forbidden: `MCP-first`
+
+## Read next
+
+- `references/README.md`
+- `references/INSTALL.md`
+- `references/DEMO.md`
+- `references/CAPABILITIES.md`
+- `references/TROUBLESHOOTING.md`

--- a/skills/docsiphon-doc-corpus-operator/manifest.yaml
+++ b/skills/docsiphon-doc-corpus-operator/manifest.yaml
@@ -1,0 +1,36 @@
+schema_version: 1
+artifact: public-skill-listing-manifest
+
+skill:
+  name: docsiphon-doc-corpus-operator
+  display_name: docsiphon Doc Corpus Operator
+  version: 1.0.0
+  entrypoint: SKILL.md
+  package_shape: skill-folder
+
+registry_targets:
+  clawhub:
+    status: not-submitted-yet
+    package_shape: skill-folder
+  openhands-extensions:
+    status: not-submitted-yet
+    package_shape: skill-folder
+
+boundaries:
+  product_identity: CLI-first documentation corpus export packet for Docsiphon.
+  canonical_repo_version: 0.1.2
+  listing_state_summary: ClawHub and OpenHands/extensions not submitted yet.
+  not_claimed:
+    - No listed-live ClawHub entry exists yet
+    - No listed-live OpenHands/extensions entry exists yet
+    - No hosted docs export platform exists yet
+    - No MCP-first product claim exists yet
+
+pair_with:
+  - SKILL.md
+  - README.md
+  - references/README.md
+  - references/INSTALL.md
+  - references/DEMO.md
+  - references/CAPABILITIES.md
+  - references/TROUBLESHOOTING.md

--- a/skills/docsiphon-doc-corpus-operator/references/CAPABILITIES.md
+++ b/skills/docsiphon-doc-corpus-operator/references/CAPABILITIES.md
@@ -1,0 +1,16 @@
+# Capabilities
+
+This packet can honestly teach an agent to:
+
+- run the current Docsiphon CLI
+- export a small documentation subtree
+- preserve source-path hierarchy in local output
+- inspect `manifest.jsonl`, `report.json`, `toc.md`, and `report.html`
+- distinguish Markdown-first exports from generic site mirrors
+
+This packet must not claim:
+
+- hosted docs export
+- generic browser automation
+- pixel-perfect site archiving
+- current MCP-first product positioning

--- a/skills/docsiphon-doc-corpus-operator/references/DEMO.md
+++ b/skills/docsiphon-doc-corpus-operator/references/DEMO.md
@@ -1,0 +1,23 @@
+# Demo
+
+Use this exact first-success path before trying bigger targets:
+
+```bash
+uvx --from git+https://github.com/xiaojiou176-open/docsiphon.git \
+  docsiphon "https://developerdocs.instructure.com/services/canvas" \
+  --scope-prefix /services/canvas \
+  --max-pages 6 \
+  --out ./_outputs \
+  --site-root auto
+```
+
+After the command finishes, inspect these artifacts:
+
+- `_outputs/canvas/`
+- `manifest.jsonl`
+- `report.json`
+- `toc.md`
+- `report.html`
+
+That is the proof layer this packet is built around:
+one small, reviewable export with auditable output.

--- a/skills/docsiphon-doc-corpus-operator/references/INSTALL.md
+++ b/skills/docsiphon-doc-corpus-operator/references/INSTALL.md
@@ -1,0 +1,26 @@
+# Install
+
+Docsiphon currently ships through the CLI-first path.
+
+## Fastest path
+
+1. install `uv`
+2. run Docsiphon directly from GitHub with `uvx`
+
+```bash
+uvx --from git+https://github.com/xiaojiou176-open/docsiphon.git \
+  docsiphon --help
+```
+
+If you already have a local checkout, you can also install the repo locally:
+
+```bash
+uv sync --group dev
+uv run docsiphon --help
+```
+
+## What this install does not mean
+
+- it does not create a hosted service
+- it does not create a browser automation workflow
+- it does not mean a current MCP-aware surface is live

--- a/skills/docsiphon-doc-corpus-operator/references/README.md
+++ b/skills/docsiphon-doc-corpus-operator/references/README.md
@@ -1,0 +1,18 @@
+# Packet References
+
+This folder holds the minimum supporting material for the
+`docsiphon-doc-corpus-operator` host-native packet.
+
+Use these files in this order:
+
+1. `INSTALL.md`
+2. `DEMO.md`
+3. `CAPABILITIES.md`
+4. `TROUBLESHOOTING.md`
+
+The goal is simple:
+get one small, reviewable export through the current CLI-first path before you
+claim anything bigger.
+
+There is no MCP config in this packet because this skill teaches the current
+CLI-first export lane rather than a shipped MCP bridge.

--- a/skills/docsiphon-doc-corpus-operator/references/TROUBLESHOOTING.md
+++ b/skills/docsiphon-doc-corpus-operator/references/TROUBLESHOOTING.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## `uvx` is not installed
+
+Install `uv` first:
+https://docs.astral.sh/uv/getting-started/installation/
+
+If you already have a checkout, you can recover the local path with:
+
+```bash
+uv sync --group dev
+uv run docsiphon --help
+```
+
+## The export ran, but I do not know what success looks like
+
+Check for these files:
+
+- `manifest.jsonl`
+- `report.json`
+- `toc.md`
+- `report.html`
+
+If those files do not exist, the export did not produce the expected audit
+bundle.
+
+## I need a bigger or more specialized export
+
+Start from `examples/README.md` in the repository and only move to larger
+profiles after the small demo succeeds.
+
+## I need a hosted API or browser automation workflow
+
+That is outside the current product boundary.


### PR DESCRIPTION
## Summary
- add a new `docsiphon-doc-corpus-operator` skill under `skills/`
- include a self-contained packet with README, SKILL, manifest, and references for the current CLI-first Docsiphon flow
- register the skill in both marketplace manifests

## Why
Docsiphon is currently CLI-first, but this packet creates a host-native secondary lane that teaches agents how to run one small, reviewable documentation export without overclaiming hosted or MCP-first product status.

## Notes
- current registry truth in the packet is intentionally conservative: ClawHub is already live, while this OpenHands lane is review-pending until this PR merges
