### PR TITLE
Fix pr-review plugin.json Claude Code compatibility and add per-plugin CI validation

### DIFF
--- a/.github/workflows/check-extensions.yml
+++ b/.github/workflows/check-extensions.yml
@@ -21,8 +21,24 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Validate marketplace manifest
-        run: claude plugin validate .
+      - name: Validate all plugins with Claude Code
+        run: |
+          failed=0
+          for plugin_dir in plugins/*/; do
+            if [ -d "${plugin_dir}.plugin" ]; then
+              echo "Validating ${plugin_dir}..."
+              if ! claude plugin validate "${plugin_dir}"; then
+                echo "❌ Validation failed for ${plugin_dir}"
+                failed=1
+              else
+                echo "✅ ${plugin_dir} is valid"
+              fi
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::One or more plugins failed Claude Code validation"
+            exit 1
+          fi
 
   sync-extensions:
     runs-on: ubuntu-latest

--- a/plugins/pr-review/.plugin/plugin.json
+++ b/plugins/pr-review/.plugin/plugin.json
@@ -2,7 +2,12 @@
   "name": "pr-review",
   "version": "0.1.0",
   "description": "Automated PR code review — analyzes diffs and posts inline review comments via the GitHub API",
-  "author": "OpenHands",
+  "author": {
+    "name": "OpenHands",
+    "email": "contact@all-hands.dev"
+  },
+  "homepage": "https://github.com/OpenHands/extensions",
+  "repository": "https://github.com/OpenHands/extensions",
   "license": "MIT",
-  "repository": "https://github.com/OpenHands/extensions"
+  "keywords": ["pr-review", "code-review", "github", "automation"]
 }

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,0 +1,83 @@
+"""Test that all plugin.json manifests are valid and Claude Code compatible."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def get_plugins_directory():
+    """Get the path to the plugins directory."""
+    test_dir = Path(__file__).parent
+    return test_dir.parent / "plugins"
+
+
+def get_all_plugin_manifests():
+    """Yield (plugin_name, manifest_path) for every plugin with a .plugin/plugin.json."""
+    plugins_dir = get_plugins_directory()
+    for plugin_dir in sorted(plugins_dir.iterdir()):
+        if not plugin_dir.is_dir() or plugin_dir.name.startswith("."):
+            continue
+        manifest = plugin_dir / ".plugin" / "plugin.json"
+        if manifest.exists():
+            yield plugin_dir.name, manifest
+
+
+REQUIRED_FIELDS = ["name", "description", "author", "version"]
+
+
+@pytest.fixture(params=list(get_all_plugin_manifests()), ids=lambda p: p[0])
+def plugin_manifest(request):
+    """Parametrized fixture returning (name, path, parsed_json) for each plugin."""
+    name, path = request.param
+    data = json.loads(path.read_text())
+    return name, path, data
+
+
+def test_plugin_has_required_fields(plugin_manifest):
+    name, path, data = plugin_manifest
+    for field in REQUIRED_FIELDS:
+        assert field in data, (
+            f"Plugin '{name}' is missing required field '{field}' in {path}"
+        )
+
+
+def test_plugin_author_is_object(plugin_manifest):
+    """Claude Code requires 'author' to be an object with at least a 'name' key."""
+    name, path, data = plugin_manifest
+    author = data.get("author")
+    assert isinstance(author, dict), (
+        f"Plugin '{name}': 'author' must be an object (got {type(author).__name__}). "
+        f"Use {{\"name\": \"...\", \"email\": \"...\"}} format for Claude Code compatibility."
+    )
+    assert "name" in author, (
+        f"Plugin '{name}': 'author' object must contain a 'name' field."
+    )
+
+
+def test_plugin_json_is_valid(plugin_manifest):
+    """Ensure plugin.json is valid JSON with expected types."""
+    name, path, data = plugin_manifest
+    assert isinstance(data.get("name"), str), f"Plugin '{name}': 'name' must be a string"
+    assert isinstance(data.get("version"), str), f"Plugin '{name}': 'version' must be a string"
+    assert isinstance(data.get("description"), str), f"Plugin '{name}': 'description' must be a string"
+
+
+def test_all_plugins_have_manifest():
+    """Ensure every plugin directory has a .plugin/plugin.json manifest."""
+    plugins_dir = get_plugins_directory()
+    plugin_dirs = [
+        d.name
+        for d in plugins_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    ]
+    assert len(plugin_dirs) > 0, "No plugin directories found"
+
+    missing = [
+        name
+        for name in plugin_dirs
+        if not (plugins_dir / name / ".plugin" / "plugin.json").exists()
+    ]
+    assert len(missing) == 0, (
+        f"Plugins missing .plugin/plugin.json: {', '.join(missing)}"
+    )


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The `pr-review` plugin's `plugin.json` manifest uses a string for the `author` field (`"author": "OpenHands"`), but Claude Code expects `author` to be an object with `name` and `email` keys. This causes a validation error:

```
author: Invalid input: expected object, received string
```

Additionally, the CI workflow only ran `claude plugin validate .` at the repo root, which didn't validate individual plugin manifests.

## Summary

- **Fix `pr-review` plugin.json**: Changed `author` from a string to an object (`{"name": "OpenHands", "email": "contact@all-hands.dev"}`), matching the format used by all other plugins. Also added missing `homepage` and `keywords` fields for consistency.
- **Update CI to validate ALL plugins**: Changed `check-extensions.yml` to iterate over every plugin directory and run `claude plugin validate` on each one individually, failing the build if any plugin is invalid.
- **Add `test_plugin_manifest.py`**: New test file that validates all `plugin.json` files have required fields, correct types, and that `author` is an object (not a string) — preventing future regressions.

## Issue Number

Fixes #178

## How to Test

Run the test suite:
```bash
uv run --group test pytest tests/test_plugin_manifest.py -v
```

All 28 tests pass, including the `test_plugin_author_is_object` test for every plugin.

## Notes

_This PR was created by an AI assistant (OpenHands)._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3bc9d41c-70c0-4b34-8cbc-d258600becf4)