### PR TITLE
plugins/pr-review: add opt-in enable-uv-cache input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - The `code-review` and `codereview-roasted` skills have been merged into a single `code-review` skill. The `/codereview-roasted` trigger is kept as an alias for backward compatibility. The `review-style` action input is deprecated and ignored.
 - `plugins/pr-review` supports an optional `require-evidence` action input that tells the reviewer to require end-to-end proof in the PR description that the code works; test output alone is not sufficient evidence.
 - The corresponding `REQUIRE_EVIDENCE` env flag is consumed by `plugins/pr-review/scripts/agent_script.py` and injected into the review prompt via `plugins/pr-review/scripts/prompt.py`.
+- `plugins/pr-review` exposes an `enable-uv-cache` input (default `'false'`) that toggles `setup-uv`'s GitHub Actions cache. Default stays off because a prompt-injected reviewer could poison a shared cache that higher-privilege workflows later consume; opt in only on single-tenant self-hosted runners. The README's "Caching and Security" section documents the threat model and recommends a host-level uv cache volume as the preferred alternative for self-hosted setups.
 - GitHub review suggestions that only delete lines can look empty in `PullRequestReviewComment.body`; the rendered content is available via `bodyText`/`bodyHTML`, so review-context formatting should fall back there before treating a suggestion as empty.
 - Prompt coverage for this behavior lives in `tests/test_pr_review_prompt.py`.
 

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -146,6 +146,28 @@ PR reviews are automatically triggered when:
 | `llm-api-key` | Yes | - | LLM API key |
 | `github-token` | Yes | - | GitHub token for API access |
 | `lmnr-api-key` | No | `''` | Laminar API key for observability |
+| `enable-uv-cache` | No | `'false'` | Enable setup-uv's GitHub Actions cache for Python deps. Default `false` for security (see [Caching and Security](#caching-and-security)). |
+
+## Caching and Security
+
+Python dependency caching is **disabled by default**. `uv run --with ...` re-downloads OpenHands SDK and its transitive deps on every run, which is slow but safe.
+
+**Why it's off by default:** Prompt injection can coerce the reviewer into executing arbitrary commands during the review. A compromised review run could write a malicious wheel into the shared GitHub Actions cache. Any later, higher-privilege workflow in the same repository that hits the same cache key would silently execute the attacker's code — a supply-chain pivot.
+
+**Enabling it is safe when:**
+- The runner is single-tenant (e.g. your own self-hosted runner, not shared with untrusted workflows).
+- You do not run other privileged workflows in the same repository that would consume setup-uv's cache.
+- You accept the residual risk in exchange for faster runs / lower disk writes.
+
+**Self-hosted runners:** Consider mounting a host-level uv cache volume (e.g. `/home/runner/.cache` as a Docker volume) instead of — or in addition to — this option. A local volume is faster than a round trip to GHA cache storage and does not cross any trust boundary.
+
+```yaml
+- uses: OpenHands/extensions/plugins/pr-review@main
+  with:
+    enable-uv-cache: true   # opt in on trusted self-hosted runners
+    llm-api-key: ${{ secrets.LLM_API_KEY }}
+    github-token: ${{ secrets.CORGI_BOT_GITHUB_PAT }}
+```
 
 ## A/B Testing Multiple Models
 

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -161,14 +161,6 @@ Python dependency caching is **disabled by default**. `uv run --with ...` re-dow
 
 **Self-hosted runners:** Consider mounting a host-level uv cache volume (e.g. `/home/runner/.cache` as a Docker volume) instead of — or in addition to — this option. A local volume is faster than a round trip to GHA cache storage and does not cross any trust boundary.
 
-```yaml
-- uses: OpenHands/extensions/plugins/pr-review@main
-  with:
-    enable-uv-cache: true   # opt in on trusted self-hosted runners
-    llm-api-key: ${{ secrets.LLM_API_KEY }}
-    github-token: ${{ secrets.CORGI_BOT_GITHUB_PAT }}
-```
-
 ## A/B Testing Multiple Models
 
 Test different LLM models by providing a comma-separated list:

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -45,6 +45,17 @@ inputs:
         description: Laminar API key for observability (optional)
         required: false
         default: ''
+    enable-uv-cache:
+        description: >
+            Enable setup-uv's GitHub Actions cache for Python dependencies.
+            Default is 'false' for security: shared caches can become a pivot
+            into more privileged workflows (prompt-injected reviewer could
+            write a malicious wheel into cache; subsequent higher-privilege
+            workflow hits poisoned cache). Only opt in when you control the
+            runner environment (e.g. self-hosted, single-tenant) and accept
+            the trade-off.
+        required: false
+        default: 'false'
 
 runs:
     using: composite
@@ -71,13 +82,14 @@ runs:
           with:
               python-version: '3.12'
 
-        # Security: keep GitHub Actions caching disabled in this workflow.
-        # Prompt injection can coerce the reviewer into running commands, and
-        # shared caches can become a pivot into more privileged workflows.
+        # Security: caching is disabled by default. Prompt injection can coerce
+        # the reviewer into running commands, and shared caches can become a
+        # pivot into more privileged workflows. Opt in via `enable-uv-cache`
+        # only when the runner is single-tenant / self-hosted.
         - name: Install uv
           uses: astral-sh/setup-uv@v6
           with:
-              enable-cache: false
+              enable-cache: ${{ inputs.enable-uv-cache }}
 
         - name: Install GitHub CLI
           shell: bash


### PR DESCRIPTION
## What

Adds `enable-uv-cache` input (default `false`, wired to `astral-sh/setup-uv@v6`'s `enable-cache`). Default behavior is unchanged.

## Why

Every PR review currently re-downloads OpenHands SDK + its transitive deps. Measured on a self-hosted runner: **~500 MB disk writes + ~300 MB PyPI traffic per review**, concentrated in 20-30 second spikes that saturate single SSDs when multiple runners trigger concurrently.

The existing comment explains the reason caching is off:

> shared caches can become a pivot into more privileged workflows

That's a valid concern for hosted runners and any repo where the review workflow and higher-privilege workflows share cache storage — a prompt-injected reviewer could write a malicious wheel that a later workflow consumes. **The default should stay `false`.**

Single-tenant self-hosted runners don't cross that trust boundary. Both the reviewer and any other consumer of the cache are operated by the same team. For those users, opting into caching cuts the per-run overhead substantially with no new attack surface.

## Changes

- `action.yml`: new `enable-uv-cache` input (default `'false'`), threaded to `setup-uv`'s `enable-cache`
- `README.md`: new "Caching and Security" section explaining the threat model, when to opt in, and an alternative for self-hosted runners (host-level uv cache volume via Docker)

## Backward compat

Default is unchanged — existing users see no behavior difference until they explicitly set `enable-uv-cache: 'true'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)