### PR TITLE
chore(ci): rename ALLHANDS_BOT_GITHUB_PAT to PAT_TOKEN

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -11,7 +11,7 @@
 #   - LLM_API_KEY: API key for your LLM provider (OpenAI, Anthropic, etc.)
 #
 # OPTIONAL SECRETS:
-#   - ALLHANDS_BOT_GITHUB_PAT: GitHub PAT for creating PRs (uses GITHUB_TOKEN if not set)
+#   - PAT_TOKEN: GitHub PAT for creating PRs (uses GITHUB_TOKEN if not set)
 #
 # The action will:
 #   1. Run a Trivy security scan
@@ -75,7 +75,7 @@ jobs:
                   llm-model: ${{ inputs.llm_model || 'anthropic/claude-sonnet-4-5-20250929' }}
                   llm-base-url: ${{ inputs.llm_base_url || '' }}
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || secrets.GITHUB_TOKEN }}
+                  github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
             - name: Summary
               run: |


### PR DESCRIPTION
## Summary
- Rename `ALLHANDS_BOT_GITHUB_PAT` → `PAT_TOKEN` in `pr-review-by-openhands.yml` and `vulnerability-scan.yml`
- Completes the org-wide rename started in `software-agent-sdk` (commit aa829596)
- Both secret names point to the same underlying token — this unifies naming ahead of the credential rotation planned in OpenHands/evaluation#428

## Prerequisite
Ensure `PAT_TOKEN` is configured as a repo secret (pointing to the same value as `ALLHANDS_BOT_GITHUB_PAT`).

## Test plan
- [ ] Verify `PAT_TOKEN` secret exists in repo settings (or add it)
- [ ] After merge, trigger a PR review and verify it still posts comments
- [ ] After merge, trigger vulnerability scan and verify it works (falls back to `GITHUB_TOKEN` if `PAT_TOKEN` not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)