### PR TITLE
feat(code-review): auto-verify GitHub Actions runner version from CI logs

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -99,7 +99,17 @@ Require:
 8. **Dependency Changes**
 If dependency lock changes have downgraded a dependency, comment pointing that out to make sure it was intentional.
 
-9. **Risk and Safety Evaluation**
+9. **GitHub Actions Version Upgrades**
+When a PR updates GitHub Action versions in `.github/workflows/*.yml` files:
+- Check the upgraded action's release notes for **runner version requirements** (e.g., "requires Actions Runner v2.327.1 or later" for Node 24 runtime upgrades).
+- If a runner version requirement exists, **verify it from the PR's own CI logs** instead of asking the PR author to check manually. When you are already looking at the CI workflow job that ran the upgraded action to confirm it passed, also extract the runner version from that same job's logs:
+     `gh api "repos/{owner}/{repo}/actions/jobs/{job_id}/logs" 2>&1 | grep "Current runner version:"`
+     The runner version appears on the first line of every job log as: `Current runner version: '2.333.1'`
+- Compare the actual runner version against the requirement. In your review comment, **state the verified runner version** and whether it meets the requirement. For example:
+  > ✅ Runner version verified: GitHub-hosted runners used v2.333.1, which exceeds the v2.327.1 minimum required by docker/login-action v4 (Node 24 runtime).
+- If the CI workflow using the upgraded action has not run or has failed, note that the runner compatibility could not be verified from CI and flag it for manual confirmation.
+
+10. **Risk and Safety Evaluation**
 Read `references/risk-evaluation.md` for the full risk evaluation framework including risk levels (🟢 Low / 🟡 Medium / 🔴 High), risk factors, escalation guidance, and repo-specific risk rules.
 
 CRITICAL REVIEW OUTPUT FORMAT:

--- a/tests/test_code_review_risk_evaluation.py
+++ b/tests/test_code_review_risk_evaluation.py
@@ -67,6 +67,38 @@ class TestRiskEvaluationReference:
         assert "Risk Assessment" in content
 
 
+class TestGitHubActionsRunnerVerification:
+    """Verify the GitHub Actions runner verification section is complete."""
+
+    def test_has_github_actions_section(self):
+        content = get_code_review_skill()
+        assert "GitHub Actions Version Upgrades" in content
+
+    def test_section_appears_after_dependency_before_risk(self):
+        content = get_code_review_skill()
+        dep_pos = content.index("8. **Dependency Changes**")
+        actions_pos = content.index("9. **GitHub Actions Version Upgrades**")
+        risk_pos = content.index("10. **Risk and Safety Evaluation**")
+        assert dep_pos < actions_pos < risk_pos
+
+    def test_instructs_to_verify_from_ci_logs(self):
+        content = get_code_review_skill()
+        assert "verify it from the PR's own CI logs" in content
+
+    def test_includes_api_commands(self):
+        content = get_code_review_skill()
+        assert "gh api" in content
+        assert "Current runner version" in content
+
+    def test_includes_example_output(self):
+        content = get_code_review_skill()
+        assert "Runner version verified" in content
+
+    def test_handles_unavailable_ci(self):
+        content = get_code_review_skill()
+        assert "could not be verified" in content
+
+
 class TestCodeReviewSkillReferencesRisk:
     """Verify the unified code-review skill references the risk evaluation."""
 
@@ -81,7 +113,7 @@ class TestCodeReviewSkillReferencesRisk:
     def test_risk_section_appears_after_dependency_section(self):
         content = get_code_review_skill()
         dep_pos = content.index("8. **Dependency Changes**")
-        risk_pos = content.index("9. **Risk and Safety Evaluation**")
+        risk_pos = content.index("10. **Risk and Safety Evaluation**")
         assert risk_pos > dep_pos
 
     def test_always_include_risk_instruction(self):


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

When the code review skill reviews a PR that upgrades a GitHub Action (e.g., `docker/login-action` v3→v4), it currently flags the runner version requirement from the release notes but asks the PR author to manually verify compatibility. The agent is already looking at the CI workflow job that ran the upgraded action to confirm it passed — it should extract the runner version from that same job's logs and report it directly, removing unnecessary manual work.

## Summary

- Added section 9 "GitHub Actions Version Upgrades" to the code review skill (`skills/code-review/SKILL.md`) that instructs the agent to extract the runner version from the CI job it is already inspecting, compare it against the requirement, and report the verified result.
- Updated the existing "Risk and Safety Evaluation" section number from 9 to 10.
- Added 6 tests for the new section and updated 1 existing test for the renumbered section.

## Issue Number

Related to review comment [r3094412910](https://github.com/OpenHands/OpenHands/pull/13960/changes#r3094412910) on OpenHands/OpenHands#13960.

## How to Test

Run the test suite:
```bash
python -m pytest tests/test_code_review_risk_evaluation.py -v
```
All 17 tests pass (6 new + 11 existing).

## Notes

- The `plugins/pr-review/skills/code-review/` directory is a symlink to `skills/code-review/`, so the pr-review plugin automatically picks up this change.
- This PR was created by an AI agent (OpenHands) on behalf of the user.