### PR TITLE
feat(automation): use dynamic host detection instead of hardcoded URL

### DIFF
--- a/skills/automation/SKILL.md
+++ b/skills/automation/SKILL.md
@@ -36,7 +36,18 @@ All requests require Bearer authentication:
 
 ## API Endpoints
 
-Production host: `app.all-hands.dev`
+### Determining the API Host
+
+**Before making API calls, detect the correct host from the environment:**
+
+```bash
+# The host is available in OH_ALLOW_CORS_ORIGINS_0 (includes https://)
+OPENHANDS_HOST="${OH_ALLOW_CORS_ORIGINS_0:-https://app.all-hands.dev}"
+```
+
+This automatically uses the correct host for the deployment environment (e.g., `https://staging.all-hands.dev` for staging, `https://app.all-hands.dev` for production).
+
+### Endpoints
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -73,7 +84,7 @@ Use the **preset/prompt endpoint** for simple automations. Provide a natural lan
 #### Request
 
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/prompt" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/prompt" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -134,7 +145,7 @@ Common schedules: `0 9 * * *` (daily 9 AM), `0 9 * * 1-5` (weekdays 9 AM), `0 9 
 
 **Daily report:**
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/prompt" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/prompt" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -146,7 +157,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/prompt" \
 
 **Weekly cleanup:**
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/prompt" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/prompt" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -175,7 +186,7 @@ Use the **preset/plugin endpoint** when you need to load one or more plugins tha
 #### Request
 
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/plugin" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -233,7 +244,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
 
 **Single plugin with version:**
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/plugin" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -248,7 +259,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
 
 **Multiple plugins:**
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/plugin" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -265,7 +276,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
 
 **Monorepo plugin:**
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/preset/plugin" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -285,7 +296,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/preset/plugin" \
 ### List Automations
 
 ```bash
-curl "https://app.all-hands.dev/api/automation/v1?limit=20" \
+curl "${OPENHANDS_HOST}/api/automation/v1?limit=20" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
@@ -293,17 +304,17 @@ curl "https://app.all-hands.dev/api/automation/v1?limit=20" \
 
 ```bash
 # Get details
-curl "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 
 # Update (fields: name, trigger, enabled, timeout)
-curl -X PATCH "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl -X PATCH "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"enabled": false}'
 
 # Delete
-curl -X DELETE "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl -X DELETE "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
@@ -311,11 +322,11 @@ curl -X DELETE "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
 
 ```bash
 # Manually trigger a run
-curl -X POST "https://app.all-hands.dev/api/automation/v1/{automation_id}/dispatch" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/dispatch" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 
 # List runs
-curl "https://app.all-hands.dev/api/automation/v1/{automation_id}/runs?limit=20" \
+curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/runs?limit=20" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 

--- a/skills/automation/references/custom-automation.md
+++ b/skills/automation/references/custom-automation.md
@@ -44,8 +44,16 @@ automation.tar.gz
 
 ### Upload the Tarball
 
+First, detect the API host from the environment:
+
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/uploads?name=my-automation&description=Weekly%20report%20generator" \
+OPENHANDS_HOST="${OH_ALLOW_CORS_ORIGINS_0:-https://app.all-hands.dev}"
+```
+
+Then upload:
+
+```bash
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/uploads?name=my-automation&description=Weekly%20report%20generator" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/gzip" \
   --data-binary @automation.tar.gz
@@ -79,7 +87,7 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1/uploads?name=my-automa
 Once you have a tarball uploaded (or an external URL), create the automation:
 
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -142,21 +150,21 @@ curl -X POST "https://app.all-hands.dev/api/automation/v1" \
 ### List Automations
 
 ```bash
-curl "https://app.all-hands.dev/api/automation/v1?limit=20" \
+curl "${OPENHANDS_HOST}/api/automation/v1?limit=20" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
 ### Get Automation Details
 
 ```bash
-curl "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
 ### Update Automation
 
 ```bash
-curl -X PATCH "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl -X PATCH "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"enabled": false}'
@@ -165,21 +173,21 @@ curl -X PATCH "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
 ### Delete Automation
 
 ```bash
-curl -X DELETE "https://app.all-hands.dev/api/automation/v1/{automation_id}" \
+curl -X DELETE "${OPENHANDS_HOST}/api/automation/v1/{automation_id}" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
 ### Manually Trigger a Run
 
 ```bash
-curl -X POST "https://app.all-hands.dev/api/automation/v1/{automation_id}/dispatch" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/dispatch" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
 ### List Automation Runs
 
 ```bash
-curl "https://app.all-hands.dev/api/automation/v1/{automation_id}/runs?limit=20" \
+curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/runs?limit=20" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
@@ -312,6 +320,9 @@ Your automation script receives these environment variables:
 ## Complete Example
 
 ```bash
+# 0. Detect the API host (do this first!)
+OPENHANDS_HOST="${OH_ALLOW_CORS_ORIGINS_0:-https://app.all-hands.dev}"
+
 # 1. Create your automation code
 mkdir my-automation && cd my-automation
 
@@ -359,7 +370,7 @@ tar -czf ../my-automation.tar.gz .
 
 # 3. Upload the tarball
 UPLOAD_RESPONSE=$(curl -s -X POST \
-  "https://app.all-hands.dev/api/automation/v1/uploads?name=my-automation" \
+  "${OPENHANDS_HOST}/api/automation/v1/uploads?name=my-automation" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/gzip" \
   --data-binary @my-automation.tar.gz)
@@ -367,7 +378,7 @@ UPLOAD_RESPONSE=$(curl -s -X POST \
 TARBALL_PATH=$(echo "$UPLOAD_RESPONSE" | jq -r '.tarball_path')
 
 # 4. Create the automation
-curl -X POST "https://app.all-hands.dev/api/automation/v1" \
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \
   -d "{


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When running in non-production environments (e.g., `https://staging.all-hands.dev/`), the automation skill was hardcoded to use `https://app.all-hands.dev/`, causing API calls to go to the wrong host.

## Summary

- Updated the automation skill to detect the API host dynamically from `OH_ALLOW_CORS_ORIGINS_0` environment variable
- Added a "Determining the API Host" section with instructions for the agent
- Updated all curl examples in both `SKILL.md` and `references/custom-automation.md` to use `${OPENHANDS_HOST}` instead of hardcoded URLs
- Falls back to `https://app.all-hands.dev` if the environment variable is not set

## Issue Number

N/A

## How to Test

1. In a staging environment, verify that `OH_ALLOW_CORS_ORIGINS_0` is set to the staging URL (e.g., `https://staging.all-hands.dev`)
2. Use the automation skill to create an automation
3. Verify that the API calls go to the staging host instead of production

Alternatively, test by running:
```bash
# Check the environment variable is available
echo $OH_ALLOW_CORS_ORIGINS_0

# The skill instructs the agent to run:
OPENHANDS_HOST="${OH_ALLOW_CORS_ORIGINS_0:-https://app.all-hands.dev}"
echo $OPENHANDS_HOST
```

## Video/Screenshots

N/A - Documentation/skill changes only

## Notes

This PR was created by an AI assistant (OpenHands) on behalf of the user.

The environment variable `OH_ALLOW_CORS_ORIGINS_0` was chosen because it's already set by the OpenHands runtime and contains the full base URL (including `https://`). An alternative approach would be to extract the host from `OH_WEBHOOKS_0_BASE_URL`, but `OH_ALLOW_CORS_ORIGINS_0` is cleaner.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/893a47ba-bd5c-4684-90d2-dcb0f9e01f16)