### PR TITLE
ci: resync plugin workflow mirrors with canonical copies

### DIFF
--- a/plugins/pr-review/workflows/pr-review-by-openhands.yml
+++ b/plugins/pr-review/workflows/pr-review-by-openhands.yml
@@ -46,5 +46,5 @@ jobs:
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/plugins/vulnerability-remediation/workflows/vulnerability-scan.yml
+++ b/plugins/vulnerability-remediation/workflows/vulnerability-scan.yml
@@ -75,7 +75,7 @@ jobs:
                   llm-model: ${{ inputs.llm_model || 'anthropic/claude-sonnet-4-5-20250929' }}
                   llm-base-url: ${{ inputs.llm_base_url || '' }}
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
 
             - name: Summary
               run: |


### PR DESCRIPTION
## What

Sync two plugin workflow mirror files with their canonical copies under `.github/workflows/`:

- `plugins/pr-review/workflows/pr-review-by-openhands.yml`
- `plugins/vulnerability-remediation/workflows/vulnerability-scan.yml`

Both had drifted from the canonical versions on exactly one line each:

```diff
-github-token: ${{ secrets.PAT_TOKEN }}
+github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
```

```diff
-github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
```

## Why

[#189](https://github.com/OpenHands/extensions/pull/189) (`chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC instead of PAT_TOKEN`) updated the canonical `.github/workflows/*.yml` files but did not update the mirrored copies under `plugins/*/workflows/`. `tests/test_workflow_sync.py::test_workflow_files_are_in_sync` asserts the two trees are byte-identical, so the `Tests` workflow has been red on `main` since that merge.

This PR restores the invariant. Pure `cp`, no semantic changes — the mirrors now match what [#189](https://github.com/OpenHands/extensions/pull/189) intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)