### PR TITLE
feat: add openhands-verification-stack marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Browse available plugins in [`plugins/`](plugins/).
 ## Extensions Catalog
 
 <!-- BEGIN AUTO-GENERATED CATALOG -->
-This repository contains **2 marketplace(s)** with **45 extensions** (36 skills, 9 plugins).
+This repository contains **3 marketplace(s)** with **47 extensions** (37 skills, 10 plugins).
 
 ### Quick Start
 
@@ -134,6 +134,17 @@ Official skills and plugins for OpenHands — the open-source AI software engine
 | uv | skill | Common project, dependency, and environment operations using uv. | — |
 | vercel | skill | Deploy and manage applications on Vercel, including preview deployments and deployment protection. | — |
 | vulnerability-remediation | plugin | Automated security vulnerability scanning and AI-powered remediation. Scans repositories, skips when no issues found,... | — |
+
+### openhands-verification-stack
+
+End-to-end verification bundle for OpenHands — onboard a repository for AI-agent readiness, then iterate on pull requests through CI, code review, and QA until merge-ready.
+
+**2 extensions** (1 skills, 1 plugins)
+
+| Name | Type | Description | Commands |
+|------|------|-------------|----------|
+| iterate | skill | Iterate on a GitHub pull request — drive it through CI, code review, and QA until merge-ready. Monitors state, fixes ... | `/iterate`, `/verify`, `/babysit` |
+| onboarding | plugin | Assess repository agent-readiness across five pillars, propose high-impact fixes, and generate repo-specific AGENTS.m... | — |
 <!-- END AUTO-GENERATED CATALOG -->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Browse available plugins in [`plugins/`](plugins/).
 ## Extensions Catalog
 
 <!-- BEGIN AUTO-GENERATED CATALOG -->
-This repository contains **3 marketplace(s)** with **47 extensions** (37 skills, 10 plugins).
+This repository contains **3 marketplace(s)** with **49 extensions** (37 skills, 12 plugins).
 
 ### Quick Start
 
@@ -139,12 +139,14 @@ Official skills and plugins for OpenHands — the open-source AI software engine
 
 End-to-end verification bundle for OpenHands — onboard a repository for AI-agent readiness, then iterate on pull requests through CI, code review, and QA until merge-ready.
 
-**2 extensions** (1 skills, 1 plugins)
+**4 extensions** (1 skills, 3 plugins)
 
 | Name | Type | Description | Commands |
 |------|------|-------------|----------|
 | iterate | skill | Iterate on a GitHub pull request — drive it through CI, code review, and QA until merge-ready. Monitors state, fixes ... | `/iterate`, `/verify`, `/babysit` |
 | onboarding | plugin | Assess repository agent-readiness across five pillars, propose high-impact fixes, and generate repo-specific AGENTS.m... | — |
+| pr-review | plugin | Automated PR code review — analyzes diffs and posts inline review comments via the GitHub API. | — |
+| qa-changes | plugin | Validate pull request changes by actually running the code — setting up the environment, exercising changed behavior,... | — |
 <!-- END AUTO-GENERATED CATALOG -->
 
 ## Contributing

--- a/marketplaces/openhands-verification-stack.json
+++ b/marketplaces/openhands-verification-stack.json
@@ -1,0 +1,41 @@
+{
+  "name": "openhands-verification-stack",
+  "owner": {
+    "name": "OpenHands",
+    "email": "contact@all-hands.dev"
+  },
+  "metadata": {
+    "description": "End-to-end verification bundle for OpenHands — onboard a repository for AI-agent readiness, then iterate on pull requests through CI, code review, and QA until merge-ready.",
+    "maintainer": "OpenHands",
+    "homepage": "https://github.com/OpenHands/extensions"
+  },
+  "plugins": [
+    {
+      "name": "onboarding",
+      "source": "./plugins/onboarding",
+      "description": "Assess repository agent-readiness across five pillars, propose high-impact fixes, and generate repo-specific AGENTS.md files.",
+      "category": "productivity",
+      "keywords": [
+        "onboarding",
+        "readiness",
+        "agents-md",
+        "agent-readiness",
+        "assessment"
+      ]
+    },
+    {
+      "name": "iterate",
+      "source": "./skills/iterate",
+      "description": "Iterate on a GitHub pull request — drive it through CI, code review, and QA until merge-ready. Monitors state, fixes failures, addresses review feedback, retries flaky checks, and pushes fixes in one continuous loop.",
+      "category": "productivity",
+      "keywords": [
+        "github",
+        "ci",
+        "review",
+        "qa",
+        "pull-request",
+        "iterate"
+      ]
+    }
+  ]
+}

--- a/marketplaces/openhands-verification-stack.json
+++ b/marketplaces/openhands-verification-stack.json
@@ -24,6 +24,31 @@
       ]
     },
     {
+      "name": "pr-review",
+      "source": "./plugins/pr-review",
+      "description": "Automated PR code review — analyzes diffs and posts inline review comments via the GitHub API.",
+      "category": "code-quality",
+      "keywords": [
+        "pr-review",
+        "code-review",
+        "github",
+        "automation"
+      ]
+    },
+    {
+      "name": "qa-changes",
+      "source": "./plugins/qa-changes",
+      "description": "Validate pull request changes by actually running the code — setting up the environment, exercising changed behavior, and posting a structured QA report.",
+      "category": "quality-assurance",
+      "keywords": [
+        "qa",
+        "testing",
+        "pull-request",
+        "validation",
+        "automation"
+      ]
+    },
+    {
       "name": "iterate",
       "source": "./skills/iterate",
       "description": "Iterate on a GitHub pull request — drive it through CI, code review, and QA until merge-ready. Monitors state, fixes failures, addresses review feedback, retries flaky checks, and pushes fixes in one continuous loop.",


### PR DESCRIPTION
## Summary

Add a new marketplace bundle called `openhands-verification-stack` that combines the four verification layers into a single installable package:

| # | Plugin/Skill | Type | Role |
|---|---|---|---|
| 1 | **onboarding** | plugin | Assess repo agent-readiness, generate AGENTS.md |
| 2 | **pr-review** | plugin | Automated code review with inline GitHub comments |
| 3 | **qa-changes** | plugin | Run-the-code QA validation with structured reports |
| 4 | **iterate** | skill | Continuous PR loop through CI, review, and QA until merge-ready |

Together they form an end-to-end verification stack: onboard a repository for AI-agent readiness, review code changes, validate them by actually running the code, and iterate until all verification layers pass.

## Changes

- **`marketplaces/openhands-verification-stack.json`** — New marketplace definition following the same format as `large-codebase.json`.
- **`README.md`** — Auto-generated catalog section updated by `sync_extensions.py`.

## Dependencies

> **Merge PR #135 first** — the `qa-changes` plugin is being merged via [#135](https://github.com/OpenHands/extensions/pull/135). This PR should be merged after #135 lands on main.

## Validation

- `python scripts/sync_extensions.py --check` passes ✓ (qa-changes coverage warning is expected until #135 merges)
- 60/61 plugin manifest tests pass (`qa-changes` manifest test will pass once #135 is merged)

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*