### PR TITLE
fix(pr-review): use UV_PYTHON instead of UV_PYTHON_PREFERENCE

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -149,7 +149,10 @@ runs:
         - name: Run PR review
           shell: bash
           env:
-              UV_PYTHON_PREFERENCE: only-system
+              # Pin uv to the exact Python installed by setup-python so it
+              # ignores any .python-version in the PR repo checkout (which
+              # could be older *or* newer than 3.12).
+              UV_PYTHON: '3.12'
               LLM_MODEL: ${{ steps.select-model.outputs.selected_model }}
               LLM_BASE_URL: ${{ inputs.llm-base-url }}
               REVIEW_STYLE: ${{ inputs.review-style }}


### PR DESCRIPTION
## Problem

PR #200 (merged today) added `UV_PYTHON_PREFERENCE=only-system` to prevent the target repo's `.python-version` from overriding `setup-python`. That fixed repos with **older** Python (e.g. `.python-version: 3.11` → uv would download 3.11 → `openhands-sdk` install fails since it needs ≥3.12).

But it breaks repos with **newer** Python. The `software-agent-sdk` repo has `.python-version: 3.13`, so `uv` tries to find Python 3.13 on the system, can't (only 3.12 is installed), and `only-system` prevents it from downloading:

```
error: No interpreter found for Python 3.13 in virtual environments or search path
hint: A managed Python download is available for Python 3.13, but the Python preference is set to 'only system'
```

**Failing run:** https://github.com/OpenHands/software-agent-sdk/actions/runs/24844346484/job/72727131723

## Fix

Replace `UV_PYTHON_PREFERENCE=only-system` with `UV_PYTHON=3.12`. This explicitly tells `uv` which interpreter to use, ignoring `.python-version` in **either** direction (older or newer).

_This PR was created by an AI assistant (OpenHands) on behalf of a user._