### PR TITLE
fix(pr-review): use both UV_PYTHON and UV_PYTHON_PREFERENCE

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -149,10 +149,11 @@ runs:
         - name: Run PR review
           shell: bash
           env:
-              # Pin uv to the exact Python installed by setup-python so it
-              # ignores any .python-version in the PR repo checkout (which
-              # could be older *or* newer than 3.12).
+              # Pin uv to the Python installed by setup-python and block
+              # managed downloads so the PR repo's .python-version (older
+              # *or* newer than 3.12) cannot override the interpreter.
               UV_PYTHON: '3.12'
+              UV_PYTHON_PREFERENCE: only-system
               LLM_MODEL: ${{ steps.select-model.outputs.selected_model }}
               LLM_BASE_URL: ${{ inputs.llm-base-url }}
               REVIEW_STYLE: ${{ inputs.review-style }}


### PR DESCRIPTION
## Problem

PR #203 replaced `UV_PYTHON_PREFERENCE=only-system` with `UV_PYTHON=3.12`. This fixed repos with newer Python (e.g. `.python-version: 3.13`) but re-broke repos with older Python (e.g. `.python-version: 3.11`) — `UV_PYTHON` alone doesn't prevent `uv` from downloading the version specified in `.python-version`.

Evidence: [MizzenAI/Personality](https://github.com/MizzenAI/Personality) (which has `.python-version: 3.11`) started failing again after #203:
```
Downloading cpython-3.11.15-linux-x86_64-gnu (download) (29.9MiB)
× No solution found when resolving `--with` dependencies:
╰─▶ Because the current Python version (3.11.15) does not satisfy Python>=3.12
    and all versions of openhands-sdk depend on Python>=3.12, ...
```

## Fix

Use **both** env vars:
- `UV_PYTHON=3.12` — tells `uv` which version to request (fixes .python-version > 3.12)
- `UV_PYTHON_PREFERENCE=only-system` — blocks managed downloads (fixes .python-version < 3.12)

Together they handle `.python-version` in either direction.

_This PR was created by an AI assistant (OpenHands) on behalf of a user._