### PR TITLE
iterate skill: add review thread reply and resolve guidance

### DIFF
--- a/skills/iterate/SKILL.md
+++ b/skills/iterate/SKILL.md
@@ -223,14 +223,75 @@ Review items come from:
 
 When a comment is actionable and correct:
 1. Fix the code.
-2. Commit with `chore: address PR review feedback (#<n>)`.
-3. Push and continue the loop.
+2. Reply to the review thread explaining what you changed (be specific).
+3. Resolve the thread.
+4. Commit with `chore: address PR review feedback (#<n>)`.
+5. Push and continue the loop.
 
 When a comment is non-actionable, already addressed, or you disagree:
-continue the loop.
+reply briefly explaining why, then resolve the thread. Do not leave
+threads dangling without a response.
 
 If a review thread is already resolved in GitHub, ignore it unless new
 unresolved follow-up appears.
+
+### Replying to and resolving review threads
+
+Every inline review comment creates a thread. After addressing a comment
+(or deciding it's non-actionable), you must:
+
+1. **Reply** to the thread so the reviewer can see how you addressed it:
+
+   ```bash
+   gh api "repos/{owner}/{repo}/pulls/{number}/comments" \
+     -F "body=Fixed — <describe what you changed>" \
+     -F "in_reply_to=<comment_database_id>"
+   ```
+
+   Use `-F` (not `-f`) for `in_reply_to` so it is sent as a number.
+
+2. **Resolve** the thread via GraphQL:
+
+   ```bash
+   gh api graphql \
+     -f query='mutation($id: ID!) {
+       resolveReviewThread(input: { threadId: $id }) {
+         thread { isResolved }
+       }
+     }' \
+     -f id="<thread_node_id>"
+   ```
+
+To discover unresolved threads and their IDs:
+
+```bash
+gh api graphql -f query='
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(last: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes { databaseId author { login } body }
+          }
+        }
+      }
+    }
+  }
+}' -f owner="{owner}" -f repo="{repo}" -F pr="{number}" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved == false)'
+```
+
+**Rules:**
+- Reply to every thread, even nits. A brief "Done" or "Kept as-is because…" is fine.
+- Resolve threads you have addressed. Do not leave resolved-in-code threads
+  showing as unresolved in the GitHub UI.
+- Before marking the PR ready, verify zero unresolved threads remain.
 
 ### Requesting re-review
 
@@ -286,8 +347,10 @@ Stop **only** when:
 
 ## When done — mark PR ready
 
-Once all present verification layers pass on the current SHA, convert the
-draft PR to ready for review:
+Once all present verification layers pass on the current SHA:
+
+1. Verify all review threads are resolved (zero unresolved remaining).
+2. Convert the draft PR to ready for review:
 
 ```bash
 gh pr ready
@@ -327,6 +390,7 @@ Final summary should include:
 - Mergeability / conflict status
 - Fixes pushed
 - Flaky retry cycles used
+- Review threads resolved (count)
 - Remaining unresolved failures or review comments
 
 ## References

--- a/skills/iterate/SKILL.md
+++ b/skills/iterate/SKILL.md
@@ -223,10 +223,10 @@ Review items come from:
 
 When a comment is actionable and correct:
 1. Fix the code.
-2. Reply to the review thread explaining what you changed (be specific).
-3. Resolve the thread.
-4. Commit with `chore: address PR review feedback (#<n>)`.
-5. Push and continue the loop.
+2. Commit with `chore: address PR review feedback (#<n>)`.
+3. Push and continue the loop.
+4. Reply to the review thread referencing the commit SHA.
+5. Resolve the thread.
 
 When a comment is non-actionable, already addressed, or you disagree:
 reply briefly explaining why, then resolve the thread. Do not leave


### PR DESCRIPTION
## Summary

The `/iterate` skill previously told the agent to fix code and push when addressing review feedback, but never mentioned replying to individual review threads or resolving them. This left threads dangling in the GitHub UI even after the underlying code was fixed.

## Changes

### Updated review comment workflow (steps)
- **Actionable comments**: added "reply to thread" and "resolve thread" as explicit steps before commit/push
- **Non-actionable comments**: now requires a brief reply explaining why before resolving, instead of silently continuing

### New subsection: "Replying to and resolving review threads"
- Concrete `gh` CLI commands for replying (REST API with `-F` for numeric `in_reply_to`)
- Concrete `gh` CLI command for resolving threads (GraphQL `resolveReviewThread` mutation)
- GraphQL query for discovering all unresolved threads and their IDs
- Rules: reply to every thread (even nits), resolve addressed threads, verify zero unresolved before marking PR ready

### Updated "When done" section
- Added step to verify all review threads are resolved before `gh pr ready`

### Updated final summary output
- Added "Review threads resolved (count)" to the list of items in the final summary

## Motivation

This was discovered during a real iteration on PR #205, where all review feedback was addressed in code but none of the 10 review threads were replied to or resolved. The reviewer experience was poor — they had to manually check each thread to see if it was addressed. The iterate skill should close the loop properly.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._