### PR TITLE
pr-review: enable parallel sub-agent delegation with tool_concurrency_limit=4

### DIFF
--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -873,15 +873,21 @@ def create_conversation(
         tools.append(Tool(name=TaskToolSet.name))
         logger.info("Sub-agent delegation enabled — TaskToolSet added")
 
-    agent = Agent(
-        llm=llm,
-        tools=tools,
-        agent_context=agent_context,
-        system_prompt_kwargs={"cli_mode": True},
-        condenser=get_default_condenser(
+    agent_kwargs: dict[str, Any] = {
+        "llm": llm,
+        "tools": tools,
+        "agent_context": agent_context,
+        "system_prompt_kwargs": {"cli_mode": True},
+        "condenser": get_default_condenser(
             llm=llm.model_copy(update={"usage_id": "condenser"})
         ),
-    )
+    }
+    if use_sub_agents:
+        # Enable parallel tool execution so the coordinator can launch
+        # multiple file_reviewer sub-agents concurrently via TaskToolSet.
+        agent_kwargs["tool_concurrency_limit"] = 4
+
+    agent = Agent(**agent_kwargs)
 
     # The plugin directory is the parent of the scripts/ directory
     plugin_dir = script_dir.parent  # plugins/pr-review/

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -873,21 +873,22 @@ def create_conversation(
         tools.append(Tool(name=TaskToolSet.name))
         logger.info("Sub-agent delegation enabled — TaskToolSet added")
 
-    agent_kwargs: dict[str, Any] = {
-        "llm": llm,
-        "tools": tools,
-        "agent_context": agent_context,
-        "system_prompt_kwargs": {"cli_mode": True},
-        "condenser": get_default_condenser(
+    # When sub-agents are enabled, allow the coordinator to launch
+    # multiple file_reviewer sub-agents concurrently via TaskToolSet.
+    concurrency_kwargs: dict[str, int] = {}
+    if use_sub_agents:
+        concurrency_kwargs["tool_concurrency_limit"] = 4
+
+    agent = Agent(
+        llm=llm,
+        tools=tools,
+        agent_context=agent_context,
+        system_prompt_kwargs={"cli_mode": True},
+        condenser=get_default_condenser(
             llm=llm.model_copy(update={"usage_id": "condenser"})
         ),
-    }
-    if use_sub_agents:
-        # Enable parallel tool execution so the coordinator can launch
-        # multiple file_reviewer sub-agents concurrently via TaskToolSet.
-        agent_kwargs["tool_concurrency_limit"] = 4
-
-    agent = Agent(**agent_kwargs)
+        **concurrency_kwargs,
+    )
 
     # The plugin directory is the parent of the scripts/ directory
     plugin_dir = script_dir.parent  # plugins/pr-review/


### PR DESCRIPTION
## Summary

When sub-agent delegation is enabled (`USE_SUB_AGENTS=true`), the coordinator agent can now launch multiple `file_reviewer` sub-agents **concurrently** via `TaskToolSet`.

## Changes

Set `tool_concurrency_limit=4` on the coordinator `Agent` when `use_sub_agents=True`. This allows the SDK's `ParallelToolExecutor` to run up to 4 `task` tool calls simultaneously instead of executing them serially.

### Why this is safe

`TaskTool.declared_resources()` returns `DeclaredResources(keys=(), declared=True)` — empty keys with `declared=True` means **no resource locking** is needed. Each sub-agent runs in its own isolated `LocalConversation`, so parallel task calls don't conflict.

### Context

This change is a precursor to changing the SDK's default `tool_concurrency_limit` from 1 → 4 (see [software-agent-sdk discussion](https://github.com/OpenHands/software-agent-sdk)). We're testing with an explicit value here first to validate the behavior in a real-world use case before merging the SDK default change.

Refs: #208

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/36c44e19-d96a-43e5-9542-53f7728cd93e)