### PR TITLE
fix: disable sub-agent delegation by default

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -45,7 +45,7 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
-                  use-sub-agents: 'true' # Matches the default; kept for clarity
+                  use-sub-agents: 'false' # Disabled by default (issue #208: high cost / timeouts)
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -142,7 +142,7 @@ PR reviews are automatically triggered when:
 | `llm-base-url` | No | `''` | Custom LLM endpoint URL |
 | `review-style` | No | `roasted` | **[DEPRECATED]** Previously chose between `standard` and `roasted` review styles. Now ignored — the styles have been merged into a single unified skill. |
 | `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with end-to-end proof: screenshots/videos for frontend work, commands and runtime output for backend or scripts, and an agent conversation link when applicable. Test output alone does not qualify. |
-| `use-sub-agents` | No | `'true'` | Enable sub-agent delegation for file-level reviews. The main agent acts as a coordinator that delegates per-file review work to `file_reviewer` sub-agents via the SDK TaskToolSet, then consolidates findings into a single PR review. Useful for large PRs with many changed files. To restore the previous single-agent behavior, set to `'false'`. |
+| `use-sub-agents` | No | `'false'` | Enable sub-agent delegation for file-level reviews. The main agent acts as a coordinator that delegates per-file review work to `file_reviewer` sub-agents via the SDK TaskToolSet, then consolidates findings into a single PR review. Useful for large PRs with many changed files. **Disabled by default** due to high token costs and potential timeouts (see [#208](https://github.com/OpenHands/extensions/issues/208)). Set to `'true'` to opt in. |
 | `extensions-repo` | No | `OpenHands/extensions` | Extensions repository |
 | `extensions-version` | No | `main` | Git ref (tag, branch, or SHA) |
 | `llm-api-key` | Yes | - | LLM API key |

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -32,9 +32,10 @@ inputs:
             Enable sub-agent delegation for file-level reviews.
             When true, the agent gets the TaskToolSet and decides at runtime
             whether to delegate based on diff size and complexity.
-            Set to 'false' to restore the previous single-agent behavior.
+            Disabled by default due to high token costs and potential timeouts
+            (see issue #208). Set to 'true' to opt in.
         required: false
-        default: 'true'
+        default: 'false'
     extensions-repo:
         description: GitHub repository for extensions (owner/repo)
         required: false

--- a/plugins/pr-review/workflows/pr-review-by-openhands.yml
+++ b/plugins/pr-review/workflows/pr-review-by-openhands.yml
@@ -45,7 +45,7 @@ jobs:
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   # [DEPRECATED] review-style is no longer used; standard and roasted are merged
                   # review-style: roasted
-                  use-sub-agents: 'true' # Matches the default; kept for clarity
+                  use-sub-agents: 'false' # Disabled by default (issue #208: high cost / timeouts)
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/tests/test_pr_review_prompt.py
+++ b/tests/test_pr_review_prompt.py
@@ -2,6 +2,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import yaml
+
 
 def _load_prompt_module():
     script_path = (
@@ -130,3 +132,21 @@ def test_file_reviewer_skill_content():
     assert "file_editor" in content
     # Sub-agent returns results via finish tool
     assert "finish" in content
+
+
+# --- action.yml default guard ---
+
+
+def test_use_sub_agents_defaults_to_false():
+    """Guard: use-sub-agents must default to 'false' until cost issues are resolved (#208)."""
+    action_yml = (
+        Path(__file__).parent.parent / "plugins" / "pr-review" / "action.yml"
+    )
+    with open(action_yml) as f:
+        action = yaml.safe_load(f)
+
+    default = action["inputs"]["use-sub-agents"]["default"]
+    assert default == "false", (
+        f"use-sub-agents default should be 'false' (got {default!r}). "
+        "See https://github.com/OpenHands/extensions/issues/208"
+    )


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Sub-agent delegation in the `pr-review` action causes ~15-minute hangs (hitting job timeouts) and extremely high token costs (4M+ prompt tokens per review, ~$3+ per run). The parent agent receives the entire sub-agent trace rather than just the final result, causing context to balloon and the review to never complete.

This was reported in #208 and confirmed independently on multiple PRs across different repos. Single-agent mode works normally.

## Summary

- Flip `use-sub-agents` default from `'true'` to `'false'` in `action.yml`
- Update both workflow copies (`.github/workflows/` and `plugins/pr-review/workflows/`) to match
- Update the README to document the new default and link to #208
- Add a guard test (`test_use_sub_agents_defaults_to_false`) to prevent accidental re-enablement

Users can still opt in by setting `use-sub-agents: 'true'` in their workflow.

## Issue Number

Closes #208

## How to Test

```bash
python -m pytest tests/test_pr_review_prompt.py tests/test_workflow_sync.py -v
```

All 9 tests pass, including the new guard test and the workflow sync check.

## Notes

- This is a configuration-only change — no application logic is modified
- The sub-agent feature remains available as an opt-in for users who want it
- This PR was created by an AI agent (OpenHands) on behalf of the user


@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43188ac6-dedf-4282-8924-1dc0a824d8c3)