### PR TITLE
feat(code-review): add self-improvement disclaimer to every review output

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -163,13 +163,13 @@ REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
 Every review you produce that includes any of the following: inline comments, critical issues, improvement opportunities, testing gaps, or a non-approval verdict **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
 
-Note: The `.agents/skills/` directory is auto-discovered by OpenHands as always-on context. Any `.md` file placed there is loaded into the reviewer's context at the start of every review. The reviewer reads this file from the PR branch, so guidelines take effect immediately on re-review.
+Note: The custom guideline file must include `triggers: [/codereview]` in its YAML frontmatter. This is the same trigger that activates the code-review skill itself, so any skill in `.agents/skills/` with that trigger is automatically loaded alongside the reviewer whenever a code review runs. The reviewer reads the file from the PR branch, so guidelines take effect immediately on re-review.
 
 ---
 
 > **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
 >
-> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y").
+> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with the `/codereview` trigger and the context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). See the [customization docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) for the required frontmatter format.
 > 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
 > 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
 >

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -161,15 +161,17 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 
 REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
-Every review you produce that includes feedback or findings **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
+Every review you produce that includes feedback or findings **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
+
+Note: The `.agents/skills/` directory is auto-discovered by OpenHands as always-on context. Any `.md` file placed there is loaded into the reviewer's context at the start of every review. The reviewer reads this file from the PR branch, so guidelines take effect immediately on re-review.
 
 ---
 
 > **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
 >
-> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your repo (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y").
-> 2. Re-request a review - the bot will pick up the updated guidelines automatically.
-> 3. Open a PR with the guideline change - it will go through normal code review by repository maintainers before being merged.
+> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). This file is auto-loaded as always-on context from `.agents/skills/`.
+> 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
+> 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
 >
 > [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -161,7 +161,7 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 
 REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
-Every review you produce **must** end with the following message, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
+Every review you produce that includes feedback or findings **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
 
 ---
 
@@ -169,7 +169,7 @@ Every review you produce **must** end with the following message, placed after t
 >
 > 1. Add a `.agents/skills/custom-codereview-guide.md` file to your repo (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y").
 > 2. Re-request a review - the bot will pick up the updated guidelines automatically.
-> 3. The guideline change goes through normal code review when the PR is merged.
+> 3. Open a PR with the guideline change - it will go through normal code review by repository maintainers before being merged.
 >
 > [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -161,7 +161,7 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 
 REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
-Every review you produce that includes feedback or findings **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
+Every review you produce that includes any of the following: inline comments, critical issues, improvement opportunities, testing gaps, or a non-approval verdict **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
 
 Note: The `.agents/skills/` directory is auto-discovered by OpenHands as always-on context. Any `.md` file placed there is loaded into the reviewer's context at the start of every review. The reviewer reads this file from the PR branch, so guidelines take effect immediately on re-review.
 
@@ -169,7 +169,7 @@ Note: The `.agents/skills/` directory is auto-discovered by OpenHands as always-
 
 > **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
 >
-> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). This file is auto-loaded as always-on context from `.agents/skills/`.
+> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y").
 > 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
 > 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
 >

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -159,6 +159,22 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 **KEY INSIGHT:**
 [One sentence summary of the most important architectural observation]
 
+REVIEW SELF-IMPROVEMENT DISCLAIMER (MANDATORY):
+
+Every review you produce **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
+
+---
+
+> **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
+>
+> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your repo (or edit it if one already exists) with context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y").
+> 2. Re-request a review - the bot will pick up the updated guidelines automatically.
+> 3. The guideline change goes through normal code review when the PR is merged.
+>
+> [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
+
+---
+
 COMMUNICATION STYLE:
 - Be direct and technically precise
 - Focus on engineering fundamentals, not personal preferences

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -159,9 +159,9 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 **KEY INSIGHT:**
 [One sentence summary of the most important architectural observation]
 
-REVIEW SELF-IMPROVEMENT DISCLAIMER (MANDATORY):
+REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
-Every review you produce **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
+Every review you produce **must** end with the following message, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly:
 
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -161,7 +161,7 @@ If HIGH: **Recommendation**: Do not auto-merge. Request review from a human arch
 
 REVIEW SELF-IMPROVEMENT MESSAGE (MANDATORY):
 
-Every review you produce that includes any of the following: inline comments, critical issues, improvement opportunities, testing gaps, or a non-approval verdict **must** end with the following disclaimer block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
+Every review you produce that includes any of the following: inline comments, critical issues, improvement opportunities, testing gaps, or a non-approval verdict **must** end with the following message block, placed after the Risk Assessment and Verdict sections. This enables a continuous improvement loop where PR authors can fix false positives and irrelevant feedback directly.
 
 Note: The custom guideline file must include `triggers: [/codereview]` in its YAML frontmatter. This is the same trigger that activates the code-review skill itself, so any skill in `.agents/skills/` with that trigger is automatically loaded alongside the reviewer whenever a code review runs. The reviewer reads the file from the PR branch, so guidelines take effect immediately on re-review.
 


### PR DESCRIPTION
## Summary

Adds a mandatory self-improvement disclaimer to the end of every code review produced by the `code-review` skill. This applies to **all repositories** using the OpenHands PR review bot.

## What changes

The review bot now appends this block at the end of every review:

> **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your repo (or edit it if one already exists) with context the reviewer is missing.
> 2. Re-request a review - the bot will pick up the updated guidelines automatically.
> 3. The guideline change goes through normal code review when the PR is merged.
>
> [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)

## Why

This creates a continuous improvement loop:
- **PR authors** learn how to fix false positives instead of ignoring them or asking humans to override
- **Guidelines accumulate** over time, making the bot increasingly accurate for each repo
- **Changes are safe** - guideline edits go through normal human review on merge (maintainers-only merge)

Previously, when the bot flagged something irrelevant (e.g., security concerns on an eval harness), the only recourse was to ask a human maintainer to override it. Now authors can teach the bot directly.

## Related

- SDK repo PR adding bot approval gate + evidence artifacts: https://github.com/OpenHands/software-agent-sdk/pull/2980

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._