### PR TITLE
feat(code-review): add AI resolution instructions to review message

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -167,7 +167,11 @@ Note: The custom guideline file must include `triggers: [/codereview]` in its YA
 
 ---
 
-> **Improve this review?** Edit (or create) `.agents/skills/custom-codereview-guide.md` on your branch to add repo-specific context, then re-request a review. [How to customize](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
+> **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
+>
+> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with the `/codereview` trigger and the context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). See the [customization docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) for the required frontmatter format.
+> 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
+> 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
 >
 > **Resolve with AI?** Comment `@openhands /iterate` on this PR, or install the [iterate skill](https://github.com/OpenHands/extensions/tree/main/skills/iterate) in your own agent and run `/iterate`.
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -174,6 +174,11 @@ Note: The custom guideline file must include `triggers: [/codereview]` in its YA
 > 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
 >
 > [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
+>
+> **Resolve comments with AI?** You can use a coding agent to automatically address review feedback and iterate until the PR is approved:
+>
+> - **Using [OpenHands](https://github.com/apps/openhands):** Comment `@openhands /iterate` on the PR to have OpenHands address all review comments, fix CI failures, and loop until the PR is merge-ready. [Learn more about the /iterate command](https://github.com/OpenHands/extensions/tree/main/skills/iterate).
+> - **Using other coding agents:** Install the [OpenHands extensions](https://github.com/OpenHands/extensions) into your agent's workspace by adding the `iterate` skill to `.agents/skills/` ([instructions](https://docs.openhands.dev/overview/skills)), then use the `/iterate` command to drive the PR to completion.
 
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -167,18 +167,9 @@ Note: The custom guideline file must include `triggers: [/codereview]` in its YA
 
 ---
 
-> **Improve this review?** If any feedback above seems incorrect or irrelevant to this repository, you can teach the reviewer to do better:
+> **Improve this review?** Edit (or create) `.agents/skills/custom-codereview-guide.md` on your branch to add repo-specific context, then re-request a review. [How to customize](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
 >
-> 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with the `/codereview` trigger and the context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). See the [customization docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) for the required frontmatter format.
-> 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
-> 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
->
-> [Learn more about customizing code review](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization)
->
-> **Resolve comments with AI?** You can use a coding agent to automatically address review feedback and iterate until the PR is approved:
->
-> - **Using [OpenHands](https://github.com/apps/openhands):** Comment `@openhands /iterate` on the PR to have OpenHands address all review comments, fix CI failures, and loop until the PR is merge-ready. [Learn more about the /iterate command](https://github.com/OpenHands/extensions/tree/main/skills/iterate).
-> - **Using other coding agents:** Install the [OpenHands extensions](https://github.com/OpenHands/extensions) into your agent's workspace by adding the `iterate` skill to `.agents/skills/` ([instructions](https://docs.openhands.dev/overview/skills)), then use the `/iterate` command to drive the PR to completion.
+> **Resolve with AI?** Comment `@openhands /iterate` on this PR, or install the [iterate skill](https://github.com/OpenHands/extensions/tree/main/skills/iterate) in your own agent and run `/iterate`.
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the self-improvement message at the end of every code review to also teach PR authors how to use coding agents to automatically resolve review comments.

## What the reviewer will now append

The existing "Improve this review?" block now includes an additional section:

> **Resolve comments with AI?** You can use a coding agent to automatically address review feedback and iterate until the PR is approved:
>
> - **Using OpenHands:** Comment `@openhands /iterate` on the PR to have OpenHands address all review comments, fix CI failures, and loop until the PR is merge-ready.
> - **Using other coding agents:** Install the OpenHands extensions into your agent's workspace by adding the `iterate` skill to `.agents/skills/`, then use the `/iterate` command to drive the PR to completion.

## Why

This closes the full loop from the review process improvements discussed in the Agent Team meeting:

1. **Bot reviews the PR** and flags issues
2. **Author learns how to fix false positives** (the existing self-improvement message)
3. **Author can invoke AI to resolve all comments** (this new addition) - either via OpenHands directly on the PR, or by using the iterate skill in any other coding agent

The `/iterate` skill drives a PR through CI, review, and QA until it's merge-ready - exactly what you need after getting a batch of review comments.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._
