### PR TITLE
Remove `@openhands /iterate` from code review skill to prevent bot loops

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -172,8 +172,6 @@ Note: The custom guideline file must include `triggers: [/codereview]` in its YA
 > 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with the `/codereview` trigger and the context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). See the [customization docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) for the required frontmatter format.
 > 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
 > 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
->
-> **Resolve with AI?** Comment `@openhands /iterate` on this PR, or install the [iterate skill](https://github.com/OpenHands/extensions/tree/main/skills/iterate) in your own agent and run `/iterate`.
 
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -172,6 +172,8 @@ Note: The custom guideline file must include `triggers: [/codereview]` in its YA
 > 1. Add a `.agents/skills/custom-codereview-guide.md` file to your branch (or edit it if one already exists) with the `/codereview` trigger and the context the reviewer is missing (e.g., "Security concerns about X do not apply here because Y"). See the [customization docs](https://docs.openhands.dev/openhands/usage/use-cases/code-review#customization) for the required frontmatter format.
 > 2. Re-request a review - the reviewer reads guidelines from the PR branch, so your changes take effect immediately.
 > 3. When your PR is merged, the guideline file goes through normal code review by repository maintainers.
+>
+> **Resolve with AI?** Install the [iterate skill](https://github.com/OpenHands/extensions/tree/main/skills/iterate) in your agent and run `/iterate` to automatically drive this PR through CI, review, and QA until it's merge-ready.
 
 ---
 


### PR DESCRIPTION
## Problem

The code review skill's "Resolve with AI?" paragraph contained `@openhands /iterate`, which was being output verbatim in review bot comments. This triggered other OpenHands bots to pick up the mention and act on it, creating an unintended bot-calls-bot feedback loop.

Example: https://github.com/OpenHands/OpenHands/pull/14171#issuecomment-4336427870

## Fix

Removed the "Resolve with AI?" paragraph from the review self-improvement message template in `skills/code-review/SKILL.md`. The "Improve this review?" section with customization instructions is preserved.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/de407863-f69a-42cd-8e48-a0d912074a0e)