### PR TITLE
docs: align openhands-api references with V1 source of truth

### DIFF
--- a/skills/openhands-api/README.md
+++ b/skills/openhands-api/README.md
@@ -18,16 +18,6 @@ python skills/openhands-api/scripts/openhands_api.py search-conversations --limi
 
 The Python client prefers `OPENHANDS_CLOUD_API_KEY` and falls back to `OPENHANDS_API_KEY`.
 
-## Source of truth
-
-This skill is aligned against:
-
-- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
-- `OpenHands/docs/openhands/usage/api/v1.mdx`
-- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
-- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
-- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`
-
 ## Delegating work with new Cloud conversations
 
 Use `POST /api/v1/app-conversations` to create a separate OpenHands Cloud conversation for a self-contained task, then poll `GET /api/v1/app-conversations/start-tasks?ids=...` until you have an `app_conversation_id`.
@@ -46,3 +36,13 @@ If `app_conversation_id` is missing from the initial response, fetch it via:
 - `GET /api/v1/app-conversations/start-tasks?ids=<start_task_id>`
 
 (If you accidentally use a start-task id with `/download`, you’ll get `404 Not Found`.)
+
+## Source of truth
+
+This skill is aligned against:
+
+- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
+- `OpenHands/docs/openhands/usage/api/v1.mdx`
+- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`

--- a/skills/openhands-api/README.md
+++ b/skills/openhands-api/README.md
@@ -18,6 +18,16 @@ python skills/openhands-api/scripts/openhands_api.py search-conversations --limi
 
 The Python client prefers `OPENHANDS_CLOUD_API_KEY` and falls back to `OPENHANDS_API_KEY`.
 
+## Source of truth
+
+This skill is aligned against:
+
+- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
+- `OpenHands/docs/openhands/usage/api/v1.mdx`
+- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`
+
 ## Delegating work with new Cloud conversations
 
 Use `POST /api/v1/app-conversations` to create a separate OpenHands Cloud conversation for a self-contained task, then poll `GET /api/v1/app-conversations/start-tasks?ids=...` until you have an `app_conversation_id`.

--- a/skills/openhands-api/SKILL.md
+++ b/skills/openhands-api/SKILL.md
@@ -19,16 +19,6 @@ It is intentionally focused on common OpenHands Cloud workflows:
 - Includes a few **agent server** endpoints (inside a sandbox) that use `X-Session-API-Key`.
 - Covers the **multi-conversation delegation pattern**: start separate Cloud conversations when you want fresh context windows or background work.
 
-## Source of truth
-
-This skill is aligned against the current V1 docs and implementation:
-
-- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
-- `OpenHands/docs/openhands/usage/api/v1.mdx`
-- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
-- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
-- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`
-
 ## When to use this skill
 
 Use this skill when you need to:
@@ -396,3 +386,14 @@ See also:
 - `skills/openhands-api/scripts/openhands_api.py`
 - The original inspiration client: `enyst/llm-playground` → `openhands-api-client-v1/scripts/cloud_api_v1.py`
 - Troubleshooting content and real-world usage feedback → `https://github.com/jpshackelford/.openhands/tree/main/skills/openhands-cloud-api`
+
+## Source of truth
+
+This skill is aligned against the current V1 docs and implementation:
+
+- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
+- `OpenHands/docs/openhands/usage/api/v1.mdx`
+- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`
+

--- a/skills/openhands-api/SKILL.md
+++ b/skills/openhands-api/SKILL.md
@@ -19,6 +19,16 @@ It is intentionally focused on common OpenHands Cloud workflows:
 - Includes a few **agent server** endpoints (inside a sandbox) that use `X-Session-API-Key`.
 - Covers the **multi-conversation delegation pattern**: start separate Cloud conversations when you want fresh context windows or background work.
 
+## Source of truth
+
+This skill is aligned against the current V1 docs and implementation:
+
+- `OpenHands/docs/openhands/usage/cloud/cloud-api.mdx`
+- `OpenHands/docs/openhands/usage/api/v1.mdx`
+- `OpenHands/OpenHands/openhands/app_server/v1_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_router.py`
+- `OpenHands/OpenHands/openhands/app_server/app_conversation/app_conversation_models.py`
+
 ## When to use this skill
 
 Use this skill when you need to:

--- a/skills/openhands-api/references/README.md
+++ b/skills/openhands-api/references/README.md
@@ -12,8 +12,22 @@ Key concepts:
 - **App server** endpoints use Bearer auth (`Authorization: Bearer <OPENHANDS_CLOUD_API_KEY>`).
 - **Agent server** endpoints are served by the sandbox runtime and use session auth (`X-Session-API-Key`).
 
-If you need deeper, up-to-date definitions, check the OpenHands main repository for the latest server route implementations. In that repo, the V1 app server routes typically live under:
+## Official docs
 
-- `openhands/app_server/routes/`
+- https://docs.openhands.dev/openhands/usage/cloud/cloud-api
+- https://docs.openhands.dev/openhands/usage/api/v1
 
-(The legacy V0 API routes live under `openhands/server/routes/`.)
+## Implementation source of truth
+
+If you need deeper, up-to-date definitions, prefer the current app-server implementation in `OpenHands/OpenHands`:
+
+- `openhands/app_server/v1_router.py`
+- `openhands/app_server/app_conversation/app_conversation_router.py`
+- `openhands/app_server/app_conversation/app_conversation_models.py`
+
+For the authored docs source, see `OpenHands/docs`:
+
+- `openhands/usage/cloud/cloud-api.mdx`
+- `openhands/usage/api/v1.mdx`
+
+(The legacy V0 API routes still live under `openhands/server/routes/`, but new integrations should use V1.)


### PR DESCRIPTION
## Summary
- add explicit source-of-truth references for the `skills/openhands-api` skill
- point maintainers to the canonical V1 docs in `OpenHands/docs`
- replace a stale implementation path reference with the actual V1 router/model locations in `OpenHands/OpenHands`

## Validation
- ran `python3 scripts/sync_extensions.py --check`

## Notes
- the skill is already V1-oriented; this PR tightens the references so future updates stay aligned with the canonical docs and implementation

_This PR was created by an AI agent (OpenHands) on behalf of the user._
