### PR TITLE
Add review permission preflight to pr-review plugin

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -161,6 +161,8 @@ runs:
                   --jq '.id'
               )"; then
                 echo "Failed to create pending review during preflight smoke test"
+                echo "The GITHUB_TOKEN lacks 'pull_requests: write' permission."
+                echo "Add 'permissions: { pull-requests: write }' to your workflow job."
                 exit 1
               fi
 
@@ -169,9 +171,11 @@ runs:
                 exit 1
               fi
 
-              gh api \
+              if ! gh api \
                 -X DELETE \
-                repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${REVIEW_ID}
+                repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${REVIEW_ID}; then
+                echo "Warning: Failed to delete preflight review (ID: ${REVIEW_ID}). This is cosmetic and won't affect the workflow."
+              fi
 
         - name: Run PR review
           shell: bash

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -148,6 +148,31 @@ runs:
                 echo "LLM base URL: ${{ inputs.llm-base-url }}"
               fi
 
+        - name: Preflight review permission smoke test
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+          run: |
+              if ! REVIEW_ID="$(
+                gh api \
+                  -X POST \
+                  repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+                  -f body='Preflight review permission smoke test. This pending review will be deleted immediately.' \
+                  --jq '.id'
+              )"; then
+                echo "Failed to create pending review during preflight smoke test"
+                exit 1
+              fi
+
+              if [ -z "$REVIEW_ID" ]; then
+                echo "Preflight smoke test returned an empty review id"
+                exit 1
+              fi
+
+              gh api \
+                -X DELETE \
+                repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${REVIEW_ID}
+
         - name: Run PR review
           shell: bash
           env:


### PR DESCRIPTION
## Summary
- add a preflight smoke test to the `plugins/pr-review` composite action that creates and immediately deletes a pending review before running the agent
- fail fast when the supplied GitHub token can read the PR but cannot actually submit pull request reviews
- surface repo-specific permission problems earlier, before the workflow spends LLM time and finishes without a visible review

## Testing
- parsed `plugins/pr-review/action.yml` with PyYAML after the change

_This PR was created by an AI agent (OpenHands) on behalf of the user._
