### PR TITLE
code-review: data-driven skill improvements to cut false positives and focus on high-value categories

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -71,7 +71,7 @@ Watch for:
 - Dependencies that could affect existing users
 
 5. **Security and Correctness** (Critical Issues Only — Highest-Value Category)
-This is the reviewer's **highest-value contribution** — where automated review catches things humans miss (71% precision, 81% recall). Invest your attention here. Focus on real security risks, not theoretical ones:
+This is the reviewer's **highest-value contribution** — where automated review catches things humans miss. Invest your attention here. Focus on real security risks, not theoretical ones:
 - Unsanitized user input (e.g., in SQL, shell, or web contexts)
 - Hardcoded secrets or credentials
 - Incorrect use of cryptographic libraries
@@ -84,7 +84,7 @@ This is the reviewer's **highest-value contribution** — where automated review
 **Important**: When evaluating CVEs or security advisories, always check the system clock (`date`) to determine the current year. Do not assume the current year based on training data—CVE identifiers from years beyond your training cutoff are valid if the system date confirms we are in that year.
 
 6. **Testing and Regression Proof** (High-Value Category)
-Testing gaps are another area where automated review consistently adds value (62% precision, 83% recall). If this change adds new components/modules/endpoints or changes user-visible behavior, and the repository has a test infrastructure, there should be tests that prove the behavior.
+Testing gaps are another area where automated review consistently adds value. If this change adds new components/modules/endpoints or changes user-visible behavior, and the repository has a test infrastructure, there should be tests that prove the behavior.
 
 Do not accept "tests" that are just a pile of mocks asserting that functions were called:
 - Prefer tests that exercise real code paths (e.g., parsing, validation, business logic) and assert on outputs/state.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -45,8 +45,7 @@ Identify:
 - Functions doing multiple things (violating single responsibility)
 - Complex conditional logic that obscures the core algorithm
 - Code that could be 3 lines instead of 10
-- Poor naming that obscures intent
-- Missing inline documentation for non-obvious logic
+- Only flag documentation gaps for **public API surfaces** (exported functions, classes, modules) that have no docstring at all. Do NOT suggest rewording existing comments, adding explanatory comments to implementation details, or "clarifying" comments that are already present. Inline comments are the author's domain.
 
 3. **Pragmatic Problem Analysis**
 "Theory and practice sometimes clash. Theory loses. Every single time."
@@ -139,8 +138,7 @@ Then provide analysis (skip if 🟢):
 - [src/processor.py, Line B] **Simplification**: These 10 lines can be 3
 - [src/feature.py, Line C] **Pragmatism**: Solving imaginary problem, focus on real issues
 
-**[STYLE NOTES]** (Skip most of these - only mention if it genuinely hurts maintainability)
-- Generally skip style comments. Linters exist for a reason.
+**[STYLE NOTES]** — Do NOT post style, naming, or formatting comments. This includes variable renames, blank-line adjustments, import ordering, PEP 8 cosmetics, and "more descriptive name" suggestions. Linters and formatters own this category. The only exception: a name that is actively *misleading* (makes the reader believe the opposite of what the code does).
 - Do NOT post comments for code that is acceptable or fine. No "🟢 Acceptable" or "🟢 Nit" inline comments — they are noise that creates review threads without providing actionable value. If code is good, just don't comment on it.
 
 **[TESTING GAPS]** (If behavior changed, this is not optional)

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -49,7 +49,7 @@ Identify:
 - Special cases that could be eliminated with better design
 - Functions doing multiple things (violating single responsibility)
 - Complex conditional logic that obscures the core algorithm
-- Code that could be 3 lines instead of 10
+- Flag complexity only when it introduces a **concrete risk**: a function so complex it's likely to have bugs, or a structure that makes the next change dangerous. Do not suggest refactoring working code that is merely verbose.
 - Only flag documentation gaps for **public API surfaces** (exported functions, classes, modules) that have no docstring at all. Do NOT suggest rewording existing comments, adding explanatory comments to implementation details, or "clarifying" comments that are already present. Inline comments are the author's domain.
 
 3. **Pragmatic Problem Analysis**
@@ -60,6 +60,8 @@ Evaluate:
 - Are we over-engineering for theoretical edge cases?
 - Could this be solved with existing, simpler mechanisms?
 
+**Do not suggest refactoring in review.** A code review is not the place to propose alternative designs for working code. If the code works, is correct, and isn't dangerously complex, the author's structural choices stand. Refactoring is a separate task with its own PR.
+
 4. **Breaking Change Risk Assessment**
 "We don't break user space!"
 Watch for:
@@ -68,8 +70,8 @@ Watch for:
 - Assumptions about backward compatibility
 - Dependencies that could affect existing users
 
-5. **Security and Correctness** (Critical Issues Only)
-Focus on real security risks, not theoretical ones:
+5. **Security and Correctness** (Critical Issues Only — Highest-Value Category)
+This is the reviewer's **highest-value contribution** — where automated review catches things humans miss (71% precision, 81% recall). Invest your attention here. Focus on real security risks, not theoretical ones:
 - Unsanitized user input (e.g., in SQL, shell, or web contexts)
 - Hardcoded secrets or credentials
 - Incorrect use of cryptographic libraries
@@ -77,11 +79,12 @@ Focus on real security risks, not theoretical ones:
 - Real privilege escalation or data exposure risks
 - Memory safety issues in unsafe languages
 - Concurrency bugs that cause data corruption (race conditions, null dereferencing, off-by-one errors)
+- Missing or inadequate error handling: unchecked return values, bare except clauses that swallow errors, missing error propagation, or error paths that leave the system in an inconsistent state
 
 **Important**: When evaluating CVEs or security advisories, always check the system clock (`date`) to determine the current year. Do not assume the current year based on training data—CVE identifiers from years beyond your training cutoff are valid if the system date confirms we are in that year.
 
-6. **Testing and Regression Proof**
-If this change adds new components/modules/endpoints or changes user-visible behavior, and the repository has a test infrastructure, there should be tests that prove the behavior.
+6. **Testing and Regression Proof** (High-Value Category)
+Testing gaps are another area where automated review consistently adds value (62% precision, 83% recall). If this change adds new components/modules/endpoints or changes user-visible behavior, and the repository has a test infrastructure, there should be tests that prove the behavior.
 
 Do not accept "tests" that are just a pile of mocks asserting that functions were called:
 - Prefer tests that exercise real code paths (e.g., parsing, validation, business logic) and assert on outputs/state.
@@ -121,6 +124,8 @@ When a PR only changes GitHub Action versions in workflow files (`.github/workfl
 **Example**: A Dependabot PR bumps both `actions/upload-artifact` (v5→v7) and `actions/checkout` (v4→v6). You must verify that BOTH actions have successful checks - e.g., the "Upload Artifacts" step passed AND a workflow using `checkout` passed. If only one is verified, do not approve.
 
 **Note**: This scenario overrides the evidence requirements in scenario #7 for action-only version updates. Successful CI runs that exercise the updated actions serve as sufficient evidence that the new versions work correctly. No additional `Evidence` section, screenshots, or manual verification is required.
+
+**CI/CD and configuration files** (`.github/workflows/*`, `*.yml` config, Dockerfiles, Makefiles, shell scripts): Limit feedback to **correctness issues only** - a syntax error, a secret leak, a step that will clearly fail. Do not suggest restructuring workflows, changing shell patterns, adding error checking to scripts, or optimising CI configuration. These files are deeply context-dependent and the reviewer almost certainly lacks the operational context to make useful suggestions.
 
 CRITICAL REVIEW OUTPUT FORMAT:
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,6 +15,9 @@ CORE PHILOSOPHY:
 3. **Pragmatism**: Solve real problems, not imaginary ones. Reject over-engineering and "theoretically perfect" but practically complex solutions.
 4. **Simplicity Obsession**: If it needs more than 3 levels of indentation, it's broken and needs redesign.
 5. **No Bikeshedding**: Skip style nits and formatting - that's what linters are for. Focus on what matters.
+6. **Every Inline Comment Must Request a Specific Change**: Do not leave observational comments ("this is interesting", "consider whether…", "you might want to…"), informational notes ("note that this also affects X"), or praise ("nice use of Y"). If a comment doesn't ask the author to change a specific line of code, don't post it.
+
+**Comment budget**: Post only issues you are confident matter. If you have a single marginal observation, omit it - a review body with no inline comments is a perfectly valid review. The cost of a false-positive comment (the human reads it, evaluates it, decides to ignore it) is higher than the cost of staying silent on a borderline issue. When in doubt, leave it out.
 
 CRITICAL ANALYSIS FRAMEWORK:
 
@@ -25,6 +28,8 @@ Before reviewing, ask these Three Questions:
 
 TASK:
 Provide brutally honest, technically rigorous feedback on code changes. Be direct and critical while remaining constructive. Focus on fundamental engineering principles over style preferences. DO NOT modify the code; only provide specific, actionable feedback. If the code is good, just approve it - don't manufacture feedback.
+
+**Small / routine changes**: For PRs that clearly follow existing patterns (adding a new endpoint matching existing conventions, bumping a version, renaming across files, adding a test for existing behaviour), default to a review body with no inline comments. Only leave inline comments on small PRs if you spot a **correctness bug** or a **security issue**. The smaller the PR, the higher the bar for commenting.
 
 CODE REVIEW SCENARIOS:
 


### PR DESCRIPTION
Data-driven improvements to `skills/code-review/SKILL.md` based on recent experiments analyzing 604 bot-reviewed merged PRs. The changes cut low-precision comment categories, add guardrails on comment volume, and direct attention toward the categories where automated review actually helps.

## Changes

### Fix 1 - Comment budget ("when in doubt, leave it out")
The bot's inline comments have a 71% dismiss rate. PRs with only 1-2 bot comments have the *worst* dismiss rates (75-84%), meaning low-confidence "might as well mention it" comments are almost pure noise. Added a comment budget paragraph: a review body with no inline comments is a perfectly valid review.

### Fix 2 - Hard-ban style / naming / formatting comments
Style and naming suggestions land at 38% precision (humans achieve 80% on the same topics). The previous wording ("Skip most of these") was too soft. Replaced with a hard prohibition on variable renames, blank-line adjustments, import ordering, PEP 8 cosmetics, and "more descriptive name" suggestions. Only exception: a name that is actively misleading. Also removed the "Poor naming that obscures intent" bullet from Scenario 2 - the main loophole for naming nits.

### Fix 3 - Gate documentation suggestions to public-API-only
Documentation suggestions are the #1 source of bot comments by volume (234 total) at only 55% precision (~105 rejected). Meanwhile, missing docstrings on public APIs perform well (37 incorporated vs 13 rejected). Replaced the open-ended "Missing inline documentation for non-obvious logic" with a public-API-only gate.

### Fix 4 - Stay silent on small / routine PRs
9.1% of reviewed PRs are pure noise - every bot comment was ignored and no commits followed. These average only 78 lines and 2.1 bot comments. Added guidance to default to no inline comments on small, pattern-following PRs unless there's a correctness bug or security issue.

### Fix 5 - Stop suggesting refactoring
Refactoring suggestions land at 46% precision. The keyword "simplif" appears in suggestions with a 76% rejection rate. Replaced "Code that could be 3 lines instead of 10" with risk-focused complexity guidance, and added an explicit "do not suggest refactoring in review" note to Scenario 3.

### Fix 6 - Suppress CI / workflow / config suggestions
Workflow & CI/CD has the worst precision of any topic at 32% (humans achieve 90%). Configuration Management is at 37%. Added guidance restricting feedback on CI/config files to correctness issues only - syntax errors, secret leaks, steps that will clearly fail.

### Fix 7 - Emphasise high-precision categories
Security (71% precision), testing (62%), and error handling (58%) are where the bot catches things humans miss. Added "Highest-Value Category" and "High-Value Category" labels to Scenarios 5 and 6 to direct attention. Added an explicit error handling check (unchecked return values, bare excepts, missing error propagation, inconsistent error-path state).

### Fix 8 - Every inline comment must request a specific change
The 71% dismiss rate includes observational and hedged comments across all categories. Added as CORE PHILOSOPHY #6: no "consider whether…", no "you might want to…", no informational notes, no praise. If a comment doesn't ask the author to change a specific line, it doesn't get posted.

---

_This PR was created by an AI agent (OpenHands) on behalf of CalvinSmith._
