### PR TITLE
Add PR review public skills toggle

### DIFF
--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -58,6 +58,13 @@ inputs:
             (see issue #208). Set to 'true' to opt in.
         required: false
         default: 'false'
+    load-public-skills:
+        description: >
+            Load the public skills repository into the review agent context.
+            Disable this to keep PR review prompts limited to project skills
+            and the pr-review plugin skills.
+        required: false
+        default: 'true'
     extensions-repo:
         description: GitHub repository for extensions (owner/repo)
         required: false
@@ -240,6 +247,7 @@ runs:
               REVIEW_STYLE: ${{ inputs.review-style }}
               REQUIRE_EVIDENCE: ${{ inputs.require-evidence }}
               USE_SUB_AGENTS: ${{ inputs.use-sub-agents }}
+              LOAD_PUBLIC_SKILLS: ${{ inputs.load-public-skills }}
               LLM_API_KEY: ${{ inputs.llm-api-key }}
               GITHUB_TOKEN: ${{ inputs.github-token }}
               LMNR_PROJECT_API_KEY: ${{ inputs.lmnr-api-key }}

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -41,6 +41,8 @@ Environment Variables:
         as a coordinator that delegates per-file review work to
         file_reviewer sub-agents via the TaskToolSet, then consolidates
         findings into a single GitHub PR review.
+    LOAD_PUBLIC_SKILLS: Whether to load the public skills repository
+        ('true'/'false', default: 'true')
 
 For setup instructions, usage examples, and GitHub Actions integration,
 see README.md in this directory.
@@ -784,6 +786,7 @@ def validate_environment() -> dict[str, Any]:
         "base_url": os.getenv("LLM_BASE_URL"),
         "require_evidence": _get_bool_env("REQUIRE_EVIDENCE"),
         "use_sub_agents": use_sub_agents,
+        "load_public_skills": _get_bool_env("LOAD_PUBLIC_SKILLS", default=True),
         "pr_info": {
             "number": os.getenv("PR_NUMBER"),
             "title": os.getenv("PR_TITLE"),
@@ -887,9 +890,11 @@ def create_conversation(
         f"Loaded {len(project_skills)} project skills: "
         f"{[s.name for s in project_skills]}"
     )
+    load_public_skills = config.get("load_public_skills", True)
+    logger.info("Load public skills: %s", load_public_skills)
 
     agent_context = AgentContext(
-        load_public_skills=True,
+        load_public_skills=load_public_skills,
         skills=project_skills,
     )
 

--- a/skills/openhands-sdk/SKILL.md
+++ b/skills/openhands-sdk/SKILL.md
@@ -200,6 +200,7 @@ Source: [`examples/`](https://github.com/OpenHands/software-agent-sdk/tree/main/
 - [`09_acp_agent_with_remote_runtime.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/09_acp_agent_with_remote_runtime.py)
 - [`10_cloud_workspace_share_credentials.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/10_cloud_workspace_share_credentials.py)
 - [`11_conversation_fork.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/11_conversation_fork.py)
+- [`12_settings_and_secrets_api.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/12_settings_and_secrets_api.py)
 - [`hook_scripts`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server/hook_scripts)
 
 ### [`03_github_workflows/`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/03_github_workflows)


### PR DESCRIPTION
## Summary

Adds a `load-public-skills` input to the PR review action. The default remains `true`, preserving current behavior, but callers can set it to `false` to keep ACP/OpenHands review prompts limited to project skills plus the pr-review plugin skills.

## Why

Large public skill injection can add unrelated skills to PR review prompts and make ACP-backed review runs harder to debug. This gives workflows a narrow prompt mode without changing the default rollout.

## Validation

- `python3 -m py_compile plugins/pr-review/scripts/agent_script.py`
