### PR TITLE
fix(pr-review): per-file diff budget with manifest, replacing byte-slice truncation

### DIFF
--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -88,8 +88,12 @@ from prompt import FILE_REVIEWER_SKILL, format_prompt  # noqa: E402
 
 logger = get_logger(__name__)
 
-# Maximum total diff size
-MAX_TOTAL_DIFF = 100000
+# Maximum total size of all patches combined in the prompt
+MAX_TOTAL_DIFF = 150000
+
+# Maximum size for a single file's patch body. Prevents a single huge file
+# (e.g. a regenerated lockfile) from starving smaller files' patches.
+MAX_PER_FILE_PATCH = 12000
 
 # Maximum size for review context to avoid overwhelming the prompt
 # Keeps context under ~7500 tokens (assuming ~4 chars/token average)
@@ -657,56 +661,188 @@ def get_pr_review_context(pr_number: str) -> str:
     return format_review_context(reviews, threads)
 
 
-def get_pr_diff_via_github_api(pr_number: str) -> str:
-    """Fetch the PR diff exactly as GitHub renders it.
+def get_pr_files(pr_number: str) -> list[dict[str, Any]]:
+    """Fetch every file in the PR via the `/pulls/{n}/files` REST endpoint.
 
-    Uses the GitHub REST API "Get a pull request" endpoint with an `Accept`
-    header requesting diff output. This avoids depending on local git refs
-    (often stale/missing in `pull_request_target` checkouts).
+    Returns structured per-file metadata (filename, status, +/- counts) plus
+    each file's `patch` text. Paginates with `per_page=100` until the page
+    is short or empty. GitHub caps the response at 3000 files; review of
+    larger PRs is out of scope.
     """
     repo = _get_required_env("REPO_NAME")
-    token = _get_required_env("GITHUB_TOKEN")
-
-    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
-    request = urllib.request.Request(url)
-    request.add_header("Accept", "application/vnd.github.v3.diff")
-    request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("X-GitHub-Api-Version", "2022-11-28")
-
-    try:
-        with urllib.request.urlopen(request, timeout=60) as response:
-            data = response.read()
-    except urllib.error.HTTPError as e:
-        details = (e.read() or b"").decode("utf-8", errors="replace").strip()
-        raise RuntimeError(
-            f"GitHub diff API request failed: HTTP {e.code} {e.reason}. {details}"
-        ) from e
-    except urllib.error.URLError as e:
-        raise RuntimeError(f"GitHub diff API request failed: {e.reason}") from e
-
-    return data.decode("utf-8", errors="replace")
+    files: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        url = (
+            f"/repos/{repo}/pulls/{pr_number}/files"
+            f"?per_page=100&page={page}"
+        )
+        page_files = _call_github_api(url)
+        if not isinstance(page_files, list) or not page_files:
+            break
+        files.extend(page_files)
+        if len(page_files) < 100:
+            break
+        page += 1
+    return files
 
 
-def truncate_text(diff_text: str, max_total: int = MAX_TOTAL_DIFF) -> str:
-    if len(diff_text) <= max_total:
-        return diff_text
-    total_chars = len(diff_text)
-    return (
-        diff_text[:max_total]
-        + f"\n\n... [total diff truncated, {total_chars:,} chars total, "
-        + f"showing first {max_total:,}] ..."
+def _format_file_stats(file: dict[str, Any]) -> str:
+    """Format adds/deletes for a single file: `+12/-3`, `+24`, `-7`, or ``."""
+    additions = file.get("additions", 0) or 0
+    deletions = file.get("deletions", 0) or 0
+    if additions and deletions:
+        return f"+{additions}/-{deletions}"
+    if additions:
+        return f"+{additions}"
+    if deletions:
+        return f"-{deletions}"
+    return ""
+
+
+def _format_file_status(file: dict[str, Any]) -> str:
+    """Map GitHub's status field to a short bracketed tag."""
+    status = (file.get("status") or "").lower()
+    if status == "renamed":
+        previous = file.get("previous_filename") or "?"
+        return f"[renamed from {previous}]"
+    if status in {"added", "modified", "removed", "copied", "changed"}:
+        return f"[{status}]"
+    return f"[{status}]" if status else ""
+
+
+def format_files_manifest(files: list[dict[str, Any]]) -> str:
+    """Build the 'Files Changed' manifest shown before the patch block.
+
+    Invariant: every file in `files` appears exactly once in the output,
+    regardless of patch size or budget. The patch block may abbreviate or
+    omit individual patches; the manifest never does.
+    """
+    if not files:
+        return "## Files Changed\n\n_(no files reported by GitHub)_\n"
+
+    total_additions = sum((f.get("additions") or 0) for f in files)
+    total_deletions = sum((f.get("deletions") or 0) for f in files)
+    header = (
+        f"## Files Changed ({len(files)} files, "
+        f"+{total_additions} / -{total_deletions})\n\n"
+        "All files in the PR are listed here. If a file's patch is missing "
+        "or abbreviated in the Patches section below, read the file from the "
+        "workspace (it is checked out) rather than treating it as absent.\n"
     )
 
+    lines = [header]
+    for file in files:
+        path = file.get("filename", "?")
+        status = _format_file_status(file)
+        stats = _format_file_stats(file)
+        suffix_parts: list[str] = []
+        if not file.get("patch") and (
+            file.get("additions") or file.get("deletions")
+        ):
+            suffix_parts.append("(binary or unavailable, no patch)")
+        bits = [f"- `{path}`", status, stats, *suffix_parts]
+        lines.append(" ".join(b for b in bits if b))
 
-def get_truncated_pr_diff() -> str:
-    """Get the PR diff with truncation.
+    return "\n".join(lines) + "\n"
 
-    This uses GitHub as the source of truth so the review matches the PR's
-    "Files changed" view.
+
+def _abbreviate_patch(patch: str, limit: int) -> tuple[str, bool]:
+    """Truncate a single file's patch to `limit` chars on a line boundary.
+
+    Returns `(text, truncated)`. The truncated text ends on a complete line
+    so the closing `[patch abbreviated]` marker isn't dangling mid-line.
     """
-    pr_number = _get_required_env("PR_NUMBER")
-    diff_text = get_pr_diff_via_github_api(pr_number)
-    return truncate_text(diff_text)
+    if len(patch) <= limit:
+        return patch, False
+    cut = patch.rfind("\n", 0, limit)
+    if cut <= 0:
+        cut = limit
+    return patch[:cut], True
+
+
+def format_patches(
+    files: list[dict[str, Any]],
+    max_total: int = MAX_TOTAL_DIFF,
+    max_per_file: int = MAX_PER_FILE_PATCH,
+) -> str:
+    """Assemble per-file patches into a single diff block within budget.
+
+    Every file gets at least its diff header. Patches are taken from each
+    file's `patch` field (the same text the raw-diff endpoint returns) and
+    abbreviated to `max_per_file` chars; if the running total would exceed
+    `max_total`, later files get a header-only stub. Each abbreviation is
+    annotated inline so the agent can tell "I was given a short patch" from
+    "no patch was given" — both are visible.
+    """
+    sections: list[str] = []
+    total = 0
+    for file in files:
+        path = file.get("filename", "?")
+        previous = file.get("previous_filename")
+        status = (file.get("status") or "").lower()
+        header_lines = [f"diff --git a/{previous or path} b/{path}"]
+        if status == "renamed":
+            header_lines.append(f"rename from {previous}")
+            header_lines.append(f"rename to {path}")
+        if status == "added":
+            header_lines.append("new file")
+        elif status == "removed":
+            header_lines.append("deleted file")
+        header = "\n".join(header_lines) + "\n"
+
+        patch = file.get("patch") or ""
+        remaining_budget = max_total - total
+        if remaining_budget <= len(header):
+            sections.append(
+                header
+                + f"[patch omitted: total budget of {max_total:,} chars reached; "
+                f"read `{path}` from the workspace to inspect]\n"
+            )
+            total += len(sections[-1])
+            continue
+
+        if not patch:
+            note = (
+                "[no patch available — likely a binary file, rename without "
+                "content change, or otherwise unrepresentable as text]\n"
+                if status not in {"added", "removed"}
+                or (file.get("additions") or file.get("deletions"))
+                else ""
+            )
+            sections.append(header + note)
+            total += len(sections[-1])
+            continue
+
+        per_file_cap = min(max_per_file, remaining_budget - len(header))
+        truncated_patch, was_truncated = _abbreviate_patch(patch, per_file_cap)
+        section = header + truncated_patch
+        if not section.endswith("\n"):
+            section += "\n"
+        if was_truncated:
+            section += (
+                f"[patch abbreviated: {len(patch):,} chars total, showing first "
+                f"{len(truncated_patch):,}; read `{path}` from the workspace "
+                "to inspect the rest]\n"
+            )
+        sections.append(section)
+        total += len(section)
+
+    return "\n".join(sections)
+
+
+def get_pr_diff_payload(pr_number: str) -> tuple[str, str]:
+    """Fetch PR files and produce `(manifest, patches)` for the prompt.
+
+    The manifest is rendered as markdown above the patch fence so the agent
+    always sees the complete file list, even when individual patches are
+    abbreviated. The patches string is what goes inside the ```diff fence.
+    """
+    files = get_pr_files(pr_number)
+    logger.info(f"Fetched {len(files)} files for PR #{pr_number}")
+    manifest = format_files_manifest(files)
+    patches = format_patches(files)
+    return manifest, patches
 
 
 def get_head_commit_sha(repo_dir: Path | None = None) -> str:
@@ -798,17 +934,19 @@ def validate_environment() -> dict[str, Any]:
     }
 
 
-def fetch_pr_context(pr_number: str) -> tuple[str, str, str]:
-    """Fetch PR diff, commit SHA, and review context.
-
-    Args:
-        pr_number: The PR number
+def fetch_pr_context(pr_number: str) -> tuple[str, str, str, str]:
+    """Fetch PR manifest, patches, commit SHA, and review context.
 
     Returns:
-        Tuple of (diff, commit_id, review_context)
+        Tuple of (manifest, patches, commit_id, review_context).
+        `manifest` is the markdown 'Files Changed' block; `patches` is the
+        per-file diff text to render inside the ```diff fence.
     """
-    pr_diff = get_truncated_pr_diff()
-    logger.info(f"Got PR diff with {len(pr_diff)} characters")
+    manifest, patches = get_pr_diff_payload(pr_number)
+    logger.info(
+        f"Got PR diff: manifest {len(manifest)} chars, "
+        f"patches {len(patches)} chars"
+    )
 
     commit_id = get_head_commit_sha()
     logger.info(f"HEAD commit SHA: {commit_id}")
@@ -819,7 +957,7 @@ def fetch_pr_context(pr_number: str) -> tuple[str, str, str]:
     else:
         logger.info("No previous review context found")
 
-    return pr_diff, commit_id, review_context
+    return manifest, patches, commit_id, review_context
 
 
 def _create_file_reviewer_agent(llm: LLM) -> Agent:
@@ -1087,7 +1225,9 @@ def main():
     logger.info(f"Agent kind: {config['agent_kind']}")
 
     try:
-        pr_diff, commit_id, review_context = fetch_pr_context(pr_info["number"])
+        manifest, patches, commit_id, review_context = fetch_pr_context(
+            pr_info["number"]
+        )
 
         skill_trigger = "/codereview"
         logger.info(f"Using skill trigger: {skill_trigger}")
@@ -1101,7 +1241,8 @@ def main():
             head_branch=pr_info.get("head_branch", "N/A"),
             pr_number=pr_info["number"],
             commit_id=commit_id,
-            diff=pr_diff,
+            diff=patches,
+            files_manifest=manifest,
             review_context=review_context,
             require_evidence=require_evidence,
             use_sub_agents=use_sub_agents,

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -89,11 +89,11 @@ from prompt import FILE_REVIEWER_SKILL, format_prompt  # noqa: E402
 logger = get_logger(__name__)
 
 # Maximum total size of all patches combined in the prompt
-MAX_TOTAL_DIFF = 150000
+MAX_TOTAL_DIFF = 100000
 
 # Maximum size for a single file's patch body. Prevents a single huge file
 # (e.g. a regenerated lockfile) from starving smaller files' patches.
-MAX_PER_FILE_PATCH = 12000
+MAX_PER_FILE_PATCH = 8000
 
 # Maximum size for review context to avoid overwhelming the prompt
 # Keeps context under ~7500 tokens (assuming ~4 chars/token average)

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -69,8 +69,10 @@ Review the PR changes below and identify issues that need to be addressed.
 - **Commit ID**: {commit_id}
 
 {review_context_section}{evidence_requirements_section}
+{files_manifest}
+## Patches
 
-## Git Diff
+The fenced block below contains the per-file patches. Individual patches may be **abbreviated** (look for `[patch abbreviated: ...]`) or **omitted** (look for `[patch omitted: ...]`) when they exceed the per-file or total budget. Files that appear in the manifest above but whose patch is missing or short here are still present in the PR — read the file from the workspace to inspect them. Do not flag them as missing from the PR.
 
 ```diff
 {diff}
@@ -162,6 +164,7 @@ def format_prompt(
     pr_number: str,
     commit_id: str,
     diff: str,
+    files_manifest: str = "",
     review_context: str = "",
     require_evidence: bool = False,
     use_sub_agents: bool = False,
@@ -212,6 +215,7 @@ def format_prompt(
         commit_id=commit_id,
         review_context_section=review_context_section,
         evidence_requirements_section=evidence_requirements_section,
+        files_manifest=files_manifest,
         diff=diff,
     )
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -26,6 +26,16 @@ Before reviewing, ask these Three Questions:
 TASK:
 Provide brutally honest, technically rigorous feedback on code changes. Be direct and critical while remaining constructive. Focus on fundamental engineering principles over style preferences. DO NOT modify the code; only provide specific, actionable feedback. If the code is good, just approve it - don't manufacture feedback.
 
+GROUNDING (read before flagging anything as missing):
+
+The prompt includes a **Files Changed** manifest listing every file in the PR, followed by per-file patches that may be **abbreviated** or **omitted** to fit the prompt budget (`[patch abbreviated: ...]` / `[patch omitted: ...]` markers). Before claiming a file, function, or change is missing from the PR:
+
+1. Check the Files Changed manifest. If the file is listed, it is in the PR — its patch may just be cut.
+2. Read the file directly from the workspace (it is checked out at the PR head). Use `cat`, `grep`, or `view`.
+3. Only after both checks come up empty should you flag something as missing. Even then, prefer "I could not locate X" over "X is missing" — the file may be in a path you haven't searched.
+
+Before posting an **inline review comment that names a specific line number**, verify the line maps to what you think it does (`sed -n 'X,Yp' <file>` or `view`). Line numbers derived by counting `+`/`-`/context lines from a `@@` hunk header are not reliable; ground them against the file.
+
 CODE REVIEW SCENARIOS:
 
 1. **Data Structure Analysis** (Highest Priority)

--- a/tests/test_pr_review_diff_payload.py
+++ b/tests/test_pr_review_diff_payload.py
@@ -1,0 +1,202 @@
+"""Tests for the per-file diff payload introduced to replace the global byte-
+slice truncation in agent_script.py.
+
+The legacy `truncate_text()` cut the raw diff at byte 100,000, which silently
+dropped files whose patches lived past that point (issue #233). These tests
+exercise the replacement: a manifest that lists every file plus per-file
+budgeted patches that mark abbreviation/omission explicitly.
+"""
+
+from __future__ import annotations
+
+# Re-use the module loader from the review-context test file so we don't
+# duplicate ~130 lines of openhands-SDK stubbing.
+from test_pr_review_review_context import _load_agent_script_module
+
+
+def _file(
+    filename: str,
+    *,
+    status: str = "modified",
+    additions: int = 0,
+    deletions: int = 0,
+    patch: str | None = "",
+    previous_filename: str | None = None,
+) -> dict:
+    return {
+        "filename": filename,
+        "status": status,
+        "additions": additions,
+        "deletions": deletions,
+        "patch": patch,
+        "previous_filename": previous_filename,
+    }
+
+
+# --- manifest -----------------------------------------------------------
+
+
+def test_manifest_lists_every_file():
+    module = _load_agent_script_module()
+    files = [
+        _file("a.py", status="added", additions=10),
+        _file("b.py", status="modified", additions=2, deletions=3),
+        _file("c.py", status="removed", deletions=15),
+    ]
+    manifest = module.format_files_manifest(files)
+    assert "`a.py`" in manifest
+    assert "`b.py`" in manifest
+    assert "`c.py`" in manifest
+    assert "[added]" in manifest
+    assert "[modified]" in manifest
+    assert "[removed]" in manifest
+    assert "+10" in manifest
+    assert "+2/-3" in manifest
+    assert "-15" in manifest
+
+
+def test_manifest_includes_totals_in_header():
+    module = _load_agent_script_module()
+    files = [
+        _file("a.py", additions=10, deletions=2),
+        _file("b.py", additions=5, deletions=1),
+    ]
+    manifest = module.format_files_manifest(files)
+    assert "2 files" in manifest
+    assert "+15" in manifest
+    assert "-3" in manifest
+
+
+def test_manifest_handles_renames():
+    module = _load_agent_script_module()
+    files = [
+        _file(
+            "new.py",
+            status="renamed",
+            additions=1,
+            deletions=1,
+            previous_filename="old.py",
+        ),
+    ]
+    manifest = module.format_files_manifest(files)
+    assert "`new.py`" in manifest
+    assert "renamed from old.py" in manifest
+
+
+def test_manifest_flags_binary_files():
+    module = _load_agent_script_module()
+    files = [
+        _file("logo.png", status="modified", additions=1, deletions=1, patch=""),
+    ]
+    manifest = module.format_files_manifest(files)
+    assert "`logo.png`" in manifest
+    assert "binary or unavailable" in manifest
+
+
+# --- patch formatting ---------------------------------------------------
+
+
+def test_patches_include_header_for_every_file():
+    """Every file gets a diff header even when only a stub fits."""
+    module = _load_agent_script_module()
+    files = [
+        _file("a.py", status="added", additions=1, patch="@@ -0,0 +1 @@\n+x\n"),
+        _file("b.py", status="added", additions=1, patch="@@ -0,0 +1 @@\n+y\n"),
+    ]
+    out = module.format_patches(files)
+    assert "diff --git a/a.py b/a.py" in out
+    assert "diff --git a/b.py b/b.py" in out
+
+
+def test_patches_below_budget_passthrough():
+    module = _load_agent_script_module()
+    patch = "@@ -1,2 +1,2 @@\n-foo\n+bar\n"
+    files = [_file("a.py", patch=patch)]
+    out = module.format_patches(files, max_total=10000, max_per_file=10000)
+    assert patch in out
+    assert "[patch abbreviated" not in out
+
+
+def test_per_file_cap_abbreviates_huge_single_file():
+    """A single large patch is abbreviated, not dropped."""
+    module = _load_agent_script_module()
+    big_patch = "@@ -0,0 +1,1000 @@\n" + "".join(
+        f"+line {i}\n" for i in range(1000)
+    )
+    files = [_file("big.py", status="added", patch=big_patch)]
+    out = module.format_patches(files, max_total=100000, max_per_file=500)
+    assert "diff --git a/big.py b/big.py" in out
+    # The marker is the contract — the agent knows the patch was cut.
+    assert "[patch abbreviated" in out
+    # Should reference the actual file path so the agent knows where to look.
+    assert "`big.py`" in out
+    # Must not contain the full patch text.
+    assert len(out) < len(big_patch)
+
+
+def test_total_budget_omits_late_files_with_marker_not_silence():
+    """When total budget is exhausted, later files become header-only stubs
+    with an explicit `[patch omitted]` marker — never silently dropped."""
+    module = _load_agent_script_module()
+    fat_patch = "@@ -0,0 +1,100 @@\n" + "".join(f"+x{i}\n" for i in range(100))
+    files = [
+        _file("first.py", status="added", patch=fat_patch),
+        _file("second.py", status="added", patch=fat_patch),
+        _file("third.py", status="added", patch=fat_patch),
+    ]
+    # Budget that comfortably fits one full patch but not three.
+    out = module.format_patches(files, max_total=800, max_per_file=10000)
+
+    # All three files appear in the patch block — at minimum as headers.
+    assert "diff --git a/first.py b/first.py" in out
+    assert "diff --git a/second.py b/second.py" in out
+    assert "diff --git a/third.py b/third.py" in out
+    # At least one of the later files is marked omitted.
+    assert "[patch omitted" in out
+
+
+def test_no_patch_field_is_annotated_not_silent():
+    """A file with no patch text (binary, rename, etc) gets a clear note."""
+    module = _load_agent_script_module()
+    files = [_file("logo.png", additions=1, deletions=1, patch="")]
+    out = module.format_patches(files)
+    assert "diff --git a/logo.png b/logo.png" in out
+    assert "no patch available" in out
+
+
+def test_smoking_gun_pr_14401_shape():
+    """Regression for issue #233 — the specific failure mode that triggered
+    the redesign. Earlier files have huge patches; the implementation file
+    of interest sits past the byte-100K mark of the original raw diff. With
+    a per-file budget the late file's *patch* may still be abbreviated, but
+    its *presence* must always be visible in both manifest and patch block."""
+    module = _load_agent_script_module()
+
+    # Two heavy files dominate the byte budget.
+    bulk_patch = "@@ -1 +1,2000 @@\n" + "".join(
+        f"+filler {i}\n" for i in range(2000)
+    )
+    # The implementation file the bot kept missing.
+    target = (
+        "@@ -0,0 +1,55 @@\n"
+        + "".join(f"+line {i}\n" for i in range(55))
+    )
+    files = [
+        _file("enterprise/poetry.lock", patch=bulk_patch),
+        _file("openhands/long_module.py", patch=bulk_patch),
+        _file(
+            "frontend/src/utils/shell-tokenize.ts",
+            status="added",
+            additions=55,
+            patch=target,
+        ),
+    ]
+
+    manifest = module.format_files_manifest(files)
+    patches = module.format_patches(files, max_total=2000, max_per_file=600)
+
+    # Manifest always names the target file — this is the property that
+    # prevents the bot from claiming the file is missing.
+    assert "`frontend/src/utils/shell-tokenize.ts`" in manifest
+    # Patch block lists it too, even when its content is abbreviated/omitted.
+    assert "diff --git a/frontend/src/utils/shell-tokenize.ts" in patches


### PR DESCRIPTION
Closes #233.

## Why

The PR review bot's diff truncation (`MAX_TOTAL_DIFF = 100000` + naive byte slice) silently dropped any patch whose bytes landed past 100K. Because the GitHub raw-diff endpoint returns files alphabetically, this systematically punished late-alphabet frontend files and *all* `openhands/**/*.py` backend changes on large PRs. The bot then confidently flagged dropped files as "missing from the diff" — see [OpenHands/OpenHands#14401](https://github.com/OpenHands/OpenHands/pull/14401), where it blocked approval four times on a file that was actually in the PR but lived past byte 105,151 of a 190KB diff.

## What changed

**`agent_script.py`** — replace the raw-diff API + byte slice with `/pulls/{n}/files` + per-file budget:

- New `get_pr_files()`: paginated fetch of structured per-file objects (filename, status, additions, deletions, patch).
- New `format_files_manifest()`: lists **every** file in the PR with status and +/- counts. Invariant: every file in the input appears exactly once, regardless of budget.
- New `format_patches()`: emits each file's patch up to `MAX_PER_FILE_PATCH = 8000` chars; when the running total would exceed `MAX_TOTAL_DIFF = 100000` chars, later files get a header-only stub with an explicit `[patch omitted: ...]` marker. Per-file truncation is annotated inline with `[patch abbreviated: ...]`. Never silently drops a file.
- Caps unchanged from the prior code (100K total, 8K per file). With the manifest + per-file budget, the cap no longer drops whole files — abbreviated patches and the "read from workspace" skill rule cover the rest.

**`prompt.py`** — add `{files_manifest}` slot **above** the ```diff fence, with explanatory text telling the agent that abbreviated/omitted patches are still in the PR and should be read from the workspace.

**`code-review/SKILL.md`** — new `GROUNDING` section requiring: (a) check the manifest + read the file from workspace before flagging anything as missing; (b) verify inline-comment line numbers with `sed -n` / `view` rather than counting from `@@` hunk headers (which LLMs do unreliably).

**`tests/test_pr_review_diff_payload.py`** — 10 new tests, including a regression test that mirrors the PR #14401 shape (small file behind two large ones).

## Test plan

- [x] `uv run --group test pytest tests/test_pr_review_diff_payload.py tests/test_pr_review_prompt.py tests/test_pr_review_review_context.py` — 23/23 pass.
- [x] Full suite (rebased on #235): 269/269 pass.
- [x] CI green: `test`, `sync-sdk-skill`, `sync-extensions`, `validate-claude-code` all pass.
- [ ] Live verification on a large PR after merge — confirm manifest renders and large files no longer trigger "file missing" findings.

## Out of scope

- **Line-number hallucinations** — the skill change addresses this with a "verify before commenting" rule, but a deeper fix (e.g. inline line-number annotations in patches) is a separate PR.
- **Cross-round dedup of false positives** — the existing soft "don't repeat" instruction in `prompt.py` is unchanged. Improvement needs measurement, not just more prompting.

A matching README fix lands as a separate PR in software-agent-sdk (#3239).

🤖 Generated with [Claude Code](https://claude.com/claude-code)