### PR TITLE
fix(ci): catch up with openhands-sdk v1.22.0 import path changes

### DIFF
--- a/plugins/qa-changes/scripts/agent_script.py
+++ b/plugins/qa-changes/scripts/agent_script.py
@@ -40,7 +40,7 @@ from typing import Any
 
 from lmnr import Laminar
 from openhands.sdk import LLM, Agent, AgentContext, Conversation, get_logger
-from openhands.sdk.context.skills import load_project_skills
+from openhands.sdk.skills import load_project_skills
 from openhands.sdk.conversation import get_agent_final_response
 from openhands.sdk.git.utils import run_git_command
 from openhands.sdk.plugin import PluginSource

--- a/plugins/release-notes/scripts/agent_script.py
+++ b/plugins/release-notes/scripts/agent_script.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from openhands.sdk import LLM, Agent, AgentContext, Conversation, get_logger
-from openhands.sdk.context.skills import load_project_skills
+from openhands.sdk.skills import load_project_skills
 from openhands.sdk.conversation import get_agent_final_response
 from openhands.tools.preset.default import get_default_condenser, get_default_tools
 

--- a/skills/openhands-sdk/SKILL.md
+++ b/skills/openhands-sdk/SKILL.md
@@ -186,6 +186,7 @@ Source: [`examples/`](https://github.com/OpenHands/software-agent-sdk/tree/main/
 - [`46_agent_settings.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/46_agent_settings.py)
 - [`47_defense_in_depth_security.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/47_defense_in_depth_security.py)
 - [`48_conversation_fork.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/48_conversation_fork.py)
+- [`49_switch_llm_tool.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/49_switch_llm_tool.py)
 
 ### [`02_remote_agent_server/`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server)
 
@@ -201,6 +202,7 @@ Source: [`examples/`](https://github.com/OpenHands/software-agent-sdk/tree/main/
 - [`10_cloud_workspace_share_credentials.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/10_cloud_workspace_share_credentials.py)
 - [`11_conversation_fork.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/11_conversation_fork.py)
 - [`12_settings_and_secrets_api.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/12_settings_and_secrets_api.py)
+- [`13_workspace_get_llm.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/02_remote_agent_server/13_workspace_get_llm.py)
 - [`hook_scripts`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server/hook_scripts)
 
 ### [`03_github_workflows/`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/03_github_workflows)

--- a/tests/test_sdk_loading.py
+++ b/tests/test_sdk_loading.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 import pytest
-from openhands.sdk.context.skills import Skill
-from openhands.sdk.plugin import Marketplace, MarketplacePluginEntry
+from openhands.sdk.skills import Skill
+from openhands.sdk.marketplace import Marketplace, MarketplacePluginEntry
 
 
 def get_repo_root():


### PR DESCRIPTION
## Summary

CI on `main` is broken because SDK v1.22.0 moved a few imports. Each plugin / test was hitting the old paths. Surgical 1-line import fixes plus a regenerated SDK skill file.

- `Skill`: `openhands.sdk.context.skills` → `openhands.sdk.skills` (test only)
- `Marketplace`, `MarketplacePluginEntry`: `openhands.sdk.plugin` → `openhands.sdk.marketplace`
- `load_project_skills`: `openhands.sdk.context.skills` → `openhands.sdk.skills` (qa-changes + release-notes plugins)
- `skills/openhands-sdk/SKILL.md` regenerated via `python scripts/sync_openhands_sdk_skill.py` — picks up two new SDK examples (`49_switch_llm_tool.py`, `13_workspace_get_llm.py`)

Blocks #234 (and any other PR currently red on these jobs).

## Test plan

- [x] `uv run --group test pytest tests/` — 259 passed (was 246 + 13 errors on `main`).
- [x] `python scripts/sync_openhands_sdk_skill.py --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)