### PR TITLE
skill(openhands-automation): make preset choice cost-aware

### DIFF
--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -22,16 +22,17 @@ Create and manage automations that run in OpenHands Cloud sandboxes — triggere
 
 > **⚠️ CRITICAL — Agent behavior rules:**
 >
-> 1. **ALWAYS use preset endpoints** to create automations. They handle all SDK boilerplate, tarball packaging, and upload automatically:
->    - **Prompt preset** (`POST /v1/preset/prompt`) — for simple tasks with a natural language prompt
+> 0. **Does this task need an LLM at all? Check first.** Before picking a preset, ask whether the task actually requires reasoning, judgment, summarization, or open-ended tool use. If it is fully deterministic — fixed data transforms, scheduled HTTP calls, healthcheck pings, file rotation, picking from a known list, posting a templated message — an LLM-driven preset is overkill. Every run will spin up a sandbox and consume LLM tokens, which adds up fast at high frequencies (every 5 min ≈ 288 runs/day). Surface the trade-off to the user and offer the custom-script path (see `references/custom-automation.md`) as the cheaper, more reliable option. Be especially careful for cron schedules tighter than hourly.
+> 1. **For LLM-appropriate work, default to preset endpoints.** They handle all SDK boilerplate, tarball packaging, and upload automatically:
+>    - **Prompt preset** (`POST /v1/preset/prompt`) — for tasks expressed as a natural language prompt that benefit from agent reasoning
 >    - **Plugin preset** (`POST /v1/preset/plugin`) — when plugins with skills, MCP configs, or commands are needed
-> 2. **NEVER write custom SDK scripts or create tarballs.** Do not generate Python SDK code, `setup.sh` files, or tarball uploads unless the user explicitly asks for it.
-> 3. **If neither preset can satisfy the requirement**, do NOT silently fall back to custom automation. Instead, explain the available options to the user:
->    - **Prompt preset** — simple natural language prompt execution
+> 2. **Do not silently create custom SDK scripts.** Do not generate Python SDK code, `setup.sh` files, or tarball uploads without user consent. But *do* proactively recommend the custom path (per rule 0) when the task is deterministic or high-frequency — surface the option and let the user choose.
+> 3. **If neither preset is the right fit**, do NOT silently fall back to custom automation. Instead, explain the available options to the user:
+>    - **Prompt preset** — natural language prompt execution (LLM-driven)
 >    - **Plugin preset** — load plugins with extended capabilities (skills, MCP, hooks, commands)
->    - **Custom SDK script** — full control over code; point them to `references/custom-automation.md`
+>    - **Custom SDK script** — full control over code, no LLM required; point them to `references/custom-automation.md`
 >    - Let the user choose which approach to use.
-> 4. **Only create custom SDK scripts if the user explicitly requests it.** Refer to `references/custom-automation.md` for the full reference.
+> 4. **Only create custom SDK scripts after the user agrees to that path.** Refer to `references/custom-automation.md` for the full reference.
 
 ## Authentication
 
@@ -755,16 +756,21 @@ After a run completes, the sandbox is **kept alive** by default — users can vi
 
 ## Choosing the Right Preset
 
-| Use Case | Recommended Preset |
-|----------|-------------------|
-| Simple tasks with natural language prompt | **Prompt Preset** |
-| Need plugin skills, MCP configs, or commands | **Plugin Preset** |
-| Custom dependencies or non-Python entrypoint | **Custom Automation** (see below) |
+Pick based on **what the task needs**, not just **what is technically possible**. An LLM-driven preset can do almost anything, so "the preset can satisfy this" is not by itself a good reason to pick it — every run costs tokens and sandbox time.
 
-The **prompt preset** covers most use cases. Use the **plugin preset** when you need extended capabilities from plugins (skills, MCP configurations, hooks, commands). The plugin preset fetches plugins at runtime from their sources and loads them into the conversation.
+| Use Case | Recommended |
+|----------|-------------|
+| Reasoning, summarization, triage, code review, or open-ended tool use | **Prompt Preset** |
+| Needs plugin commands / skills / MCP configs / hooks | **Plugin Preset** |
+| **Deterministic task** (fixed data + scheduled action, e.g. healthcheck, templated notification, rotating from a known list) — especially if it runs frequently | **Custom SDK script** (no LLM) — see `references/custom-automation.md` |
+| Custom Python dependencies, non-Python entrypoint, multi-file project structure, direct SDK lifecycle control | **Custom Automation** (see below) |
 
-**When neither preset is sufficient** (e.g., custom Python dependencies, non-Python entrypoint, multi-file project structure, direct SDK lifecycle control), explain the options to the user and let them decide. Do not attempt custom automation without explicit user request. If they choose the custom route, refer to `references/custom-automation.md`.
+The **prompt preset** is the right default for genuinely agent-shaped work — anything that benefits from reasoning over context, calling tools dynamically, or producing a non-templated output. Use the **plugin preset** when you need extended capabilities from plugins (skills, MCP configurations, hooks, commands).
+
+**Watch for deterministic, high-frequency patterns.** Requests like "send a daily standup reminder", "ping a healthcheck URL every minute", "post a random quote every 5 minutes", or "rotate a fact-of-the-day message" do not need an LLM. Surface this to the user explicitly with a rough cost framing (e.g. "this schedule will invoke your LLM ~288 times/day") before defaulting to a preset. As a rule of thumb, any cron tighter than hourly deserves a deliberate "should this really be agent-driven?" check.
+
+**When neither preset is the right fit** (deterministic task, custom Python dependencies, non-Python entrypoint, multi-file project structure, direct SDK lifecycle control), explain the options to the user and let them decide. Do not attempt custom automation without explicit user agreement. If they choose the custom route, refer to `references/custom-automation.md`.
 
 ## Reference Files
 
-- **`references/custom-automation.md`** — Detailed guide for custom automations: tarball uploads, SDK code structure, environment variables, validation rules, and complete examples. Only use when the user explicitly requests a custom automation.
+- **`references/custom-automation.md`** — Detailed guide for custom automations: tarball uploads, SDK code structure, environment variables, validation rules, and complete examples. Consult this whenever you need to evaluate or recommend the custom path (including for deterministic / cost-sensitive tasks per rule 0). Only *implement* a custom automation after the user agrees to that path.


### PR DESCRIPTION
> _This PR was opened by an AI agent (OpenHands) on behalf of @tofarr, based on a hands-on session where the current rules steered the agent into using the LLM-backed prompt preset for a deterministic "post a quote to Slack every 5 minutes" task. The conversation that motivated this change is summarised below._

## Problem

The current `openhands-automation` skill optimises the preset choice for **functional capability** ("can a preset do this?") rather than **task fit** ("should an LLM do this?"). The four critical rules at the top of `SKILL.md` are effectively:

1. ALWAYS use a preset.
2. NEVER write custom SDK scripts unless the user explicitly asks.
3. If neither preset fits, ask the user — but the fit criteria are entirely about technical features (plugins / non-Python entrypoints / multi-file projects).
4. Same as 2.

Both presets wrap a full `Conversation` from the Agent SDK, so every scheduled run boots a sandbox, pulls the user's LLM credentials, and burns tokens. That is correct and useful for genuinely agent-shaped work (triage, summarisation, code review, on-call response).

It is **not** the right default for deterministic, high-frequency work — e.g. "post a templated message to Slack every 5 minutes" (≈ 288 LLM-driven sandbox starts/day for a job that is literally `random.choice(quotes)` + one HTTP POST). The current rules give the agent no signal to flag this trade-off, and rule 2's hard ban prevents it from even *suggesting* a script-based alternative.

## Changes

Surgical edits to **`skills/openhands-automation/SKILL.md`** only:

1. **Added a "Step 0" agent rule** at the top of the critical-rules block: *does this task need an LLM at all?* Calls out fixed data transforms, healthcheck pings, templated notifications, and rotating from a known list as patterns that should default to a custom script. Explicitly notes the cost shape (e.g. every-5-min ≈ 288 runs/day) and asks the agent to be especially careful with sub-hourly crons.
2. **Softened rule 2** from "NEVER write custom SDK scripts unless the user asks" to "do not silently create custom scripts, but *do* proactively recommend the custom path when the task is deterministic or high-frequency." Custom automations still require user consent before implementation — they just stop being invisible to the agent's decision making.
3. **Expanded the "Choosing the Right Preset" decision table** to add a row for deterministic tasks pointing at the custom-script path, and replaced the "Simple tasks with natural language prompt → Prompt Preset" row with criteria that actually describe agent-shaped work (reasoning, summarisation, triage, open-ended tool use).
4. **Named the deterministic-delivery pattern** explicitly (standup reminders, healthchecks, quote rotations, fact-of-the-day messages) and added a high-frequency tripwire: any cron tighter than hourly deserves a deliberate "should this really be agent-driven?" check.
5. **Loosened the "Reference Files" note** so the agent can consult `references/custom-automation.md` when *evaluating* the custom path. Implementing one still requires explicit user agreement.

No changes to API contracts, examples, or `references/custom-automation.md`. The intent is to recalibrate defaults, not to rewrite the skill.

## Diff stats

```
 skills/openhands-automation/SKILL.md | 36 +++++++++++++++++++++---------------
 1 file changed, 21 insertions(+), 15 deletions(-)
```

## Not in scope (worth a follow-up?)

- A first-class **`/preset/script`** endpoint (inline Python/bash on cron, no SDK / no `Conversation`) would let the skill say "for deterministic tasks, use `/preset/script`" without forcing the agent into the more error-prone custom-tarball path. That is a product change against the automation service rather than a skill change.
- Per-run cost estimation surfaced in the API response (token budget × schedule frequency) so the agent has concrete numbers to share with the user.

## Status

Drafted for review — feedback on wording, scope, and whether to fold in the follow-ups above all welcome.

---
_This PR was opened by an AI agent (OpenHands) on behalf of @tofarr._