### PR TITLE
ci: add 7-day Dependabot cooldown for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "npm"


### PR DESCRIPTION
## Summary
- add a 7-day Dependabot cooldown for npm version updates
- avoid adopting brand-new package releases before they have had time to age
- keep the rest of the update policy intentionally simple

## Testing
- not run (configuration-only change)

_This PR was created by an AI agent (OpenHands) on behalf of the user._