### PR TITLE
review: block approvals for fresh dependency releases

### DIFF
--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -56,6 +56,8 @@ PROMPT = """{skill_trigger}
 
 When posting a review, keep the review body brief unless your active review instructions require a longer structured format.
 
+If the PR adds or updates dependencies, do **NOT** approve it when any target version was published less than 7 days ago. Use the active code-review skill's supply-chain checklist before approving older dependency updates.
+
 Review the PR changes below and identify issues that need to be addressed.
 
 ## Pull Request Information

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -109,7 +109,9 @@ Require:
 8. **Dependency Changes**
 If dependency lock changes have downgraded a dependency, comment pointing that out to make sure it was intentional.
 
-When a PR adds a new dependency or bumps an existing one, review the upstream release for supply chain risk. Read `references/supply-chain-security.md` for the full verification checklist including risk-based scrutiny tiers, concrete commands for checking release provenance, and escalation guidance.
+When a PR adds a new dependency or bumps an existing one, check how old the target version is before approving it. If any target version was published less than 7 days ago, do **NOT** approve the PR. Leave a blocking review comment that cites the 7-day minimum age policy.
+
+For dependency updates that meet the 7-day minimum age, do a quick supply-chain sanity check before approving. Read `references/supply-chain-security.md` for the exact checklist: confirm the release age, check for obvious yanked/deprecated versions, and look for suspicious install-time behavior or active compromise signals.
 
 9. **Risk and Safety Evaluation**
 Read `references/risk-evaluation.md` for the full risk evaluation framework including risk levels (🟢 Low / 🟡 Medium / 🔴 High), risk factors, escalation guidance, and repo-specific risk rules.
@@ -142,7 +144,7 @@ Then provide analysis (skip if 🟢):
 - [src/handler.py, Line Y] **Complexity**: >3 levels of nesting - redesign required
 - [src/api.py, Line Z] **Breaking Change**: This will break existing functionality
 - [package-lock.json, Line X] **Dependency Downgrade**: library-name downgraded from 2.1.0 to 1.9.5 - was this intentional? Check for breaking changes or security implications.
-- [requirements.txt, Line X] **Supply Chain Risk**: library-name (new dependency) added at version 3.2.0 which was published <48 hours ago with no release notes or matching source tag. Verify release provenance before merging - recent supply chain attacks (LiteLLM, PyTorch Lightning) followed this exact pattern.
+- [requirements.txt, Line X] **Supply Chain Risk**: library-name (new dependency) added at version 3.2.0 which was published <7 days ago. Do not approve until it satisfies the 7-day minimum age policy, then verify release provenance before merging.
 
 **[IMPROVEMENT OPPORTUNITIES]** (Should fix - violates good taste)
 - [src/utils.py, Line A] **Special Case**: Can be eliminated with better design

--- a/skills/code-review/references/supply-chain-security.md
+++ b/skills/code-review/references/supply-chain-security.md
@@ -2,30 +2,32 @@
 
 When a PR adds a new dependency or bumps an existing one, review the upstream release for supply chain risk. Real-world incidents (e.g., LiteLLM 1.82.7-1.82.8 in March 2026, PyTorch Lightning 2.6.2-2.6.3 in April 2026) show that trusted packages can be hijacked through compromised CI/CD pipelines, stolen publishing credentials, or poisoned build artifacts - with malicious code present only in the published package, not in the source repository.
 
-## Risk-Based Scrutiny Tiers
+## Default Approval Rule
 
-Release recency is the primary risk signal - even widely-used, established packages can be compromised (e.g., LiteLLM was a popular package with high download counts when it was hijacked). Check when the target version was published before choosing a tier.
+Use a simple default rule for dependency updates:
 
-**Apply full scrutiny** (all checks below) when:
-- The target version was published less than 7 days ago - regardless of package popularity or age. For PyPI: visit `https://pypi.org/project/<package>/<version>/` and check the "Released" date. For npm: run `npm view <package>@<version> time`. Recent releases have not had time for community vetting, and this is exactly the window supply chain attackers exploit.
-- Adding a dependency not previously used in this project
-- Upgrading a package that was first published less than 6 months ago (check oldest version at `https://pypi.org/project/<package>/#history` or `npm view <package> time | head -3`) or has low weekly downloads (for PyPI: check `https://pypistats.org/packages/<package>` for weekly downloads; for npm: see weekly downloads on the package page at `https://www.npmjs.com/package/<package>`; use <10k on PyPI / <1k on npm as thresholds)
-- The dependency includes native code, install hooks, or system-level access
+- If the target version was published less than 7 days ago, do **NOT** approve the PR. Leave a blocking review comment that cites the 7-day minimum age policy.
+- If the target version is at least 7 days old, continue with the sanity checks below before approving.
+- Apply the same rule to both new dependencies and version bumps. Recent supply-chain attacks often land in the first few days after publication, before the ecosystem has time to notice and react.
 
-**Apply standard scrutiny** (limited checks) when:
-- Upgrading to a version that has been published for at least 7 days, from a widely-used, established package with high adoption (>=10k weekly downloads on PyPI / >=1k on npm; e.g., pytest, requests, react, lodash)
-- Minor or patch version bumps to packages with a history of regular releases, where the target version is at least 7 days old
-- **Check only**: downgrades, yanked versions (target or recent versions), and presence of release notes/source tags. If you find downgrades or high-severity signals (yanked versions), immediately switch to full scrutiny and apply all checklist items below. If you find medium-severity signals (missing release notes) without other signals, note them but remain in standard scrutiny unless combined with additional concerns.
+For PyPI: visit `https://pypi.org/project/<package>/<version>/` and check the "Released" date. For npm: run `npm view <package>@<version> time`.
 
-## Checklist
+## Sanity Checklist
 
-- **Release note and changelog gaps**: Verify a source tag exists for the version. Check `https://github.com/<org>/<repo>/releases/tag/v<version>` or run `gh release view v<version> --repo <org>/<repo>`. If there is no tag, no release notes, or an empty changelog, this is a medium-severity signal - note it in your review and escalate if the package is under full scrutiny or if combined with other signals from this checklist.
-- **Yanked or retracted versions**: Check if the target version or nearby versions have been yanked. For PyPI: `pip index versions <package>` (yanked versions are marked with `[yanked]`). For npm: check the registry page at `https://www.npmjs.com/package/<package>/v/<version>` to see if the version is deprecated, or run `npm view <package>@<version>` (shows `deprecated` field if present). Yanked versions - whether the target or recent neighboring versions - indicate the maintainer or registry identified a problem. Investigate whether it was a security incident or a routine bad release. If any version in the range was yanked for security reasons, treat as a high-severity signal.
-- **Brand-new releases with no adoption signal**: Check when the version was published. For PyPI: visit `https://pypi.org/project/<package>/<version>/` and check the "Released" date. For npm: run `npm view <package>@<version> time`. If published within the last 48 hours and the package is under full scrutiny (or combined with other signals per the escalation guidance below), flag it as elevated risk. Adoption signals include: download counts visible on the registry page, discussion or announcements in the project's issue tracker, mentions in security monitoring feeds (e.g., Snyk, Socket, OSV), or endorsements from maintainers in community channels.
-- **Source-to-package divergence**: If other signals raise concern, compare the published artifact against the source. For PyPI: download the sdist/wheel from `https://pypi.org/project/<package>/<version>/#files`, extract it, clone the tagged source (`git clone --branch v<version> --depth 1 <repo-url>`), and diff: `diff -r <extracted-package>/ <repo-clone>/`. For npm: run `npm pack <package>@<version>`, extract with `tar -xzf <package>-<version>.tgz`, clone source, and compare: `diff -r package/ <repo-clone>/`. Focus your review on source files (.py for Python, .js/.ts for npm) rather than build artifacts or package metadata. Adjust paths to match the package's source layout (commonly `src/`, `lib/`, or root). Divergence in source files is a strong indicator of tampering. Request that the PR author verify and document provenance.
-- **Unusual install-time behavior**: Watch for new post-install scripts, `.pth` files, or import-time side effects introduced by the dependency update. For npm: check for `preinstall`/`postinstall` scripts in the package's `package.json`. For Python: look for `setup.py` with code execution or `.pth` files in the distribution. These are common payload delivery mechanisms in supply chain attacks.
-- **Cascading dependency risk**: If other signals raise concern about a dependency, check whether that dependency's own upstream dependencies have active advisories. For each upstream dependency, search `https://osv.dev/list?q=<upstream-dep-name>` or `https://security.snyk.io/package/pip/<upstream-dep-name>` (or `/npm/<upstream-dep-name>`) for known vulnerabilities. A compromised upstream tool (e.g., a CI/CD scanner or build plugin) can be used to steal publishing credentials for downstream packages.
+Once the version clears the 7-day minimum age rule, do a quick sanity check:
+
+- **Release metadata looks normal**: Verify a source tag or release note exists for the target version. Check `https://github.com/<org>/<repo>/releases/tag/v<version>` or run `gh release view v<version> --repo <org>/<repo>`.
+- **No obvious registry warning**: Check whether the target version or nearby versions are yanked, deprecated, or retracted. For npm: `npm view <package>@<version>` or `https://www.npmjs.com/package/<package>/v/<version>`. For PyPI: `pip index versions <package>` or the package history page.
+- **No suspicious install-time behavior**: For npm, check for new `preinstall`, `install`, `postinstall`, or `prepare` scripts in the package's `package.json`. For Python, look for `.pth` files or setup/install code that executes on install or import.
+- **No active compromise signals**: Search the registry page and a security feed such as Socket, OSV, or Snyk for an active compromise or supply-chain incident affecting the target package or version.
 
 ## Escalation Guidance
 
-Escalate to 🔴 High Risk if any high-severity signal is present: yanked/retracted versions, source-to-package divergence, or new install-time behavior (post-install scripts, `.pth` files). For medium-severity signals (brand-new release with no adoption signal, missing release notes), escalate only when combined with other signals from this checklist (medium or high severity) or when the package is under full scrutiny. For dependencies under standard scrutiny, brand-new publication alone is not sufficient to escalate - established packages with frequent release cycles routinely publish new versions.
+Escalate to 🔴 High Risk, and do **NOT** approve the PR, when any of the following is true:
+
+- the target version is newer than 7 days
+- the version is yanked, deprecated, or retracted for security reasons
+- the published package shows suspicious install-time behavior
+- a security feed reports an active compromise or supply-chain incident
+
+If the update is at least 7 days old and the quick checks look normal, continue the ordinary review flow.

--- a/tests/test_pr_review_prompt.py
+++ b/tests/test_pr_review_prompt.py
@@ -92,6 +92,13 @@ def test_format_prompt_uses_standard_prompt_by_default():
     assert "Analyze the changes and post your review" in prompt
 
 
+def test_format_prompt_includes_dependency_age_guard():
+    prompt = _format_prompt(require_evidence=False)
+
+    assert "published less than 7 days ago" in prompt
+    assert "do **NOT** approve" in prompt
+
+
 def test_format_prompt_appends_delegation_suffix_when_enabled():
     prompt = _format_prompt(require_evidence=False, use_sub_agents=True)
 


### PR DESCRIPTION
## Summary
- make the review skill explicitly block approvals for dependency versions published less than 7 days ago
- simplify the supply-chain checklist into a short sanity-check flow for older dependency updates
- surface the dependency-age rule directly in the generated PR review prompt and cover it with tests

## Testing
- uv run pytest tests/test_pr_review_prompt.py tests/test_code_review_risk_evaluation.py -q

_This PR was created by an AI agent (OpenHands) on behalf of the user._