### PR TITLE
Update Slack MCP catalog entry

### DIFF
--- a/mcps/catalog/slack.json
+++ b/mcps/catalog/slack.json
@@ -2,7 +2,7 @@
   "id": "slack",
   "name": "Slack",
   "description": "Read channels, post messages, and search workspace history from your agent.",
-  "docsUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+  "docsUrl": "https://github.com/zencoderai/slack-mcp-server",
   "iconBg": "#4A154B",
   "keywords": [
     "chat",
@@ -17,7 +17,7 @@
     "command": "npx",
     "args": [
       "-y",
-      "@modelcontextprotocol/server-slack"
+      "@zencoderai/slack-mcp-server"
     ],
     "envFields": [
       {


### PR DESCRIPTION
## Why

The Slack MCP catalog entry still points to the archived Model Context Protocol Slack server docs and deprecated npm package. Users should be sent to the maintained Zencoder repository and install command instead.

## Summary

- update the Slack MCP docs URL to `https://github.com/zencoderai/slack-mcp-server`
- switch the stdio install package from `@modelcontextprotocol/server-slack` to `@zencoderai/slack-mcp-server`

## Testing

- inspected the generated catalog diff for `mcps/catalog/slack.json`

## Notes

- This PR was created by an AI agent (OpenHands) on behalf of the user.
