### PR TITLE
Add maintainer feedback collection to PR reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,8 @@ When editing or adding skills in this repo, follow these rules (and add new skil
 - `plugins/pr-review` exposes an `enable-uv-cache` input (default `'false'`) that toggles `setup-uv`'s GitHub Actions cache. Default stays off because a prompt-injected reviewer could poison a shared cache that higher-privilege workflows later consume; opt in only on single-tenant self-hosted runners. The README's "Caching and Security" section documents the threat model and recommends a host-level uv cache volume as the preferred alternative for self-hosted setups.
 - GitHub review suggestions that only delete lines can look empty in `PullRequestReviewComment.body`; the rendered content is available via `bodyText`/`bodyHTML`, so review-context formatting should fall back there before treating a suggestion as empty.
 - Prompt coverage for this behavior lives in `tests/test_pr_review_prompt.py`.
+- `plugins/pr-review`'s `collect-feedback` input should append a short thumbs up/down footer to the main GitHub review body via `agent_script.py` / `prompt.py`, rather than posting a separate PR comment. `evaluate_review.py` should read feedback from review-body reactions while still tolerating legacy issue-comment markers.
+
 
 ## When uncertain
 

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -217,6 +217,7 @@ PR reviews are automatically triggered when:
 | `review-style` | No | `roasted` | **[DEPRECATED]** Previously chose between `standard` and `roasted` review styles. Now ignored — the styles have been merged into a single unified skill. |
 | `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with end-to-end proof: screenshots/videos for frontend work, commands and runtime output for backend or scripts, and an agent conversation link when applicable. Test output alone does not qualify. |
 | `use-sub-agents` | No | `'false'` | Enable sub-agent delegation for file-level reviews in `openhands` mode. The main agent acts as a coordinator that delegates per-file review work to `file_reviewer` sub-agents via the SDK TaskToolSet, then consolidates findings into a single PR review. Useful for large PRs with many changed files. **Disabled by default** due to high token costs and potential timeouts (see [#208](https://github.com/OpenHands/extensions/issues/208)). Set to `'true'` to opt in. Ignored in ACP mode. |
+| `collect-feedback` | No | `'true'` | Post a short PR comment after the automated review asking maintainers to rate the review with thumbs up/down reactions. The evaluation workflow records these reaction counts for analysis. |
 | `extensions-repo` | No | `OpenHands/extensions` | Extensions repository |
 | `extensions-version` | No | `main` | Git ref (tag, branch, or SHA) |
 | `openhands-sdk-package` | No | `openhands-sdk` | Package spec passed to `uv --with`; override only when pinning a specific SDK build for testing or rollout control |
@@ -271,6 +272,7 @@ One model is randomly selected for each review. When Laminar observability is en
 
 - **Review Trace**: Full agent execution including diff analysis, review generation, and comment posting
 - **Metadata**: PR number, repository, review style, model used
+- **Feedback**: Optional thumbs up/down reactions on the generated PR feedback prompt
 - **Evaluation Trace**: (Optional) Created when PR is closed/merged to measure review effectiveness
 
 ### Review Evaluation

--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -217,7 +217,7 @@ PR reviews are automatically triggered when:
 | `review-style` | No | `roasted` | **[DEPRECATED]** Previously chose between `standard` and `roasted` review styles. Now ignored — the styles have been merged into a single unified skill. |
 | `require-evidence` | No | `'false'` | Require the reviewer to enforce an `Evidence` section in the PR description with end-to-end proof: screenshots/videos for frontend work, commands and runtime output for backend or scripts, and an agent conversation link when applicable. Test output alone does not qualify. |
 | `use-sub-agents` | No | `'false'` | Enable sub-agent delegation for file-level reviews in `openhands` mode. The main agent acts as a coordinator that delegates per-file review work to `file_reviewer` sub-agents via the SDK TaskToolSet, then consolidates findings into a single PR review. Useful for large PRs with many changed files. **Disabled by default** due to high token costs and potential timeouts (see [#208](https://github.com/OpenHands/extensions/issues/208)). Set to `'true'` to opt in. Ignored in ACP mode. |
-| `collect-feedback` | No | `'true'` | Post a short PR comment after the automated review asking maintainers to rate the review with thumbs up/down reactions. The evaluation workflow records these reaction counts for analysis. |
+| `collect-feedback` | No | `'true'` | Append a short feedback footer to the main automated review body asking maintainers to react with thumbs up/down. The evaluation workflow records these reaction counts for analysis. |
 | `extensions-repo` | No | `OpenHands/extensions` | Extensions repository |
 | `extensions-version` | No | `main` | Git ref (tag, branch, or SHA) |
 | `openhands-sdk-package` | No | `openhands-sdk` | Package spec passed to `uv --with`; override only when pinning a specific SDK build for testing or rollout control |
@@ -272,7 +272,7 @@ One model is randomly selected for each review. When Laminar observability is en
 
 - **Review Trace**: Full agent execution including diff analysis, review generation, and comment posting
 - **Metadata**: PR number, repository, review style, model used
-- **Feedback**: Optional thumbs up/down reactions on the generated PR feedback prompt
+- **Feedback**: Optional thumbs up/down reactions on the footer appended to the generated PR review body
 - **Evaluation Trace**: (Optional) Created when PR is closed/merged to measure review effectiveness
 
 ### Review Evaluation

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -65,6 +65,13 @@ inputs:
             and the pr-review plugin skills.
         required: false
         default: 'true'
+    collect-feedback:
+        description: >
+            Post a short PR comment after the automated review asking
+            maintainers to rate the review with thumbs up/down reactions.
+            This does not change the review prompt or model output.
+        required: false
+        default: 'true'
     extensions-repo:
         description: GitHub repository for extensions (owner/repo)
         required: false
@@ -261,6 +268,39 @@ runs:
               cd pr-repo
               uv run --no-project --with "$OPENHANDS_SDK_PACKAGE" --with openhands-tools --with lmnr \
                 python ../extensions/plugins/pr-review/scripts/agent_script.py
+
+        - name: Post PR review feedback prompt
+          if: success() && inputs.collect-feedback == 'true'
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              REPO_NAME: ${{ github.repository }}
+              PR_NUMBER: ${{ github.event.pull_request.number }}
+              RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          run: |
+              REVIEW_URL="$(gh api "repos/${REPO_NAME}/pulls/${PR_NUMBER}/reviews" --jq '.[-1].html_url // ""' 2>/dev/null || true)"
+              REVIEW_LINK="${REVIEW_URL:-the automated review above}"
+
+              BODY="$(printf '%s\n\n%s\n\n%s\n%s\n\n%s\n' \
+                '## OpenHands PR review feedback' \
+                'Was this automated review useful? React to this comment with 👍 or 👎 so we can analyze review quality.' \
+                "- Review: ${REVIEW_LINK}" \
+                "- Workflow run: ${RUN_URL}" \
+                '<!-- openhands-pr-review-feedback -->')"
+
+              if ! COMMENT_ID="$(
+                gh api \
+                  -X POST \
+                  "repos/${REPO_NAME}/issues/${PR_NUMBER}/comments" \
+                  -f body="$BODY" \
+                  --jq '.id'
+              )"; then
+                echo "Warning: failed to post PR review feedback prompt."
+                echo "If using GITHUB_TOKEN, add 'permissions: { issues: write }' to the workflow job."
+                exit 0
+              fi
+
+              echo "Posted PR review feedback prompt: ${COMMENT_ID}"
 
         - name: Upload logs as artifact
           uses: actions/upload-artifact@v4

--- a/plugins/pr-review/action.yml
+++ b/plugins/pr-review/action.yml
@@ -67,9 +67,8 @@ inputs:
         default: 'true'
     collect-feedback:
         description: >
-            Post a short PR comment after the automated review asking
-            maintainers to rate the review with thumbs up/down reactions.
-            This does not change the review prompt or model output.
+            Ask maintainers to rate the automated review with thumbs up/down
+            reactions by appending a short footer to the main review body.
         required: false
         default: 'true'
     extensions-repo:
@@ -253,6 +252,8 @@ runs:
               LLM_BASE_URL: ${{ inputs.llm-base-url }}
               REVIEW_STYLE: ${{ inputs.review-style }}
               REQUIRE_EVIDENCE: ${{ inputs.require-evidence }}
+              COLLECT_FEEDBACK: ${{ inputs.collect-feedback }}
+              REVIEW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               USE_SUB_AGENTS: ${{ inputs.use-sub-agents }}
               LOAD_PUBLIC_SKILLS: ${{ inputs.load-public-skills }}
               LLM_API_KEY: ${{ inputs.llm-api-key }}
@@ -268,39 +269,6 @@ runs:
               cd pr-repo
               uv run --no-project --with "$OPENHANDS_SDK_PACKAGE" --with openhands-tools --with lmnr \
                 python ../extensions/plugins/pr-review/scripts/agent_script.py
-
-        - name: Post PR review feedback prompt
-          if: success() && inputs.collect-feedback == 'true'
-          shell: bash
-          env:
-              GITHUB_TOKEN: ${{ inputs.github-token }}
-              REPO_NAME: ${{ github.repository }}
-              PR_NUMBER: ${{ github.event.pull_request.number }}
-              RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          run: |
-              REVIEW_URL="$(gh api "repos/${REPO_NAME}/pulls/${PR_NUMBER}/reviews" --jq '.[-1].html_url // ""' 2>/dev/null || true)"
-              REVIEW_LINK="${REVIEW_URL:-the automated review above}"
-
-              BODY="$(printf '%s\n\n%s\n\n%s\n%s\n\n%s\n' \
-                '## OpenHands PR review feedback' \
-                'Was this automated review useful? React to this comment with 👍 or 👎 so we can analyze review quality.' \
-                "- Review: ${REVIEW_LINK}" \
-                "- Workflow run: ${RUN_URL}" \
-                '<!-- openhands-pr-review-feedback -->')"
-
-              if ! COMMENT_ID="$(
-                gh api \
-                  -X POST \
-                  "repos/${REPO_NAME}/issues/${PR_NUMBER}/comments" \
-                  -f body="$BODY" \
-                  --jq '.id'
-              )"; then
-                echo "Warning: failed to post PR review feedback prompt."
-                echo "If using GITHUB_TOKEN, add 'permissions: { issues: write }' to the workflow job."
-                exit 0
-              fi
-
-              echo "Posted PR review feedback prompt: ${COMMENT_ID}"
 
         - name: Upload logs as artifact
           uses: actions/upload-artifact@v4

--- a/plugins/pr-review/scripts/agent_script.py
+++ b/plugins/pr-review/scripts/agent_script.py
@@ -36,6 +36,11 @@ Environment Variables:
     REPO_NAME: Repository name in format owner/repo (required)
     REQUIRE_EVIDENCE: Whether to require PR description evidence showing the code
         works ('true'/'false', default: 'false')
+    COLLECT_FEEDBACK: Whether to ask maintainers for thumbs up/down feedback by
+        appending a short footer to the main review body ('true'/'false',
+        default: 'false')
+    REVIEW_RUN_URL: Optional GitHub Actions run URL to include in the feedback
+        footer when COLLECT_FEEDBACK is enabled
     USE_SUB_AGENTS: Enable sub-agent delegation for file-level reviews
         ('true'/'false', default: 'false'). When enabled, the main agent acts
         as a coordinator that delegates per-file review work to
@@ -921,6 +926,8 @@ def validate_environment() -> dict[str, Any]:
         "model": os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
         "base_url": os.getenv("LLM_BASE_URL"),
         "require_evidence": _get_bool_env("REQUIRE_EVIDENCE"),
+        "collect_feedback": _get_bool_env("COLLECT_FEEDBACK"),
+        "review_run_url": os.getenv("REVIEW_RUN_URL", ""),
         "use_sub_agents": use_sub_agents,
         "load_public_skills": _get_bool_env("LOAD_PUBLIC_SKILLS", default=True),
         "pr_info": {
@@ -1217,10 +1224,12 @@ def main():
     config = validate_environment()
     pr_info = config["pr_info"]
     require_evidence = config["require_evidence"]
+    collect_feedback = config["collect_feedback"]
     use_sub_agents = config["use_sub_agents"]
 
     logger.info(f"Reviewing PR #{pr_info['number']}: {pr_info['title']}")
     logger.info(f"Require PR evidence: {require_evidence}")
+    logger.info(f"Collect review feedback: {collect_feedback}")
     logger.info(f"Sub-agent delegation: {use_sub_agents}")
     logger.info(f"Agent kind: {config['agent_kind']}")
 
@@ -1245,6 +1254,8 @@ def main():
             files_manifest=manifest,
             review_context=review_context,
             require_evidence=require_evidence,
+            collect_feedback=collect_feedback,
+            review_run_url=config["review_run_url"],
             use_sub_agents=use_sub_agents,
         )
 

--- a/plugins/pr-review/scripts/evaluate_review.py
+++ b/plugins/pr-review/scripts/evaluate_review.py
@@ -39,6 +39,35 @@ logger = logging.getLogger(__name__)
 
 FEEDBACK_COMMENT_MARKER = "<!-- openhands-pr-review-feedback -->"
 
+REVIEWS_QUERY = """
+query($owner: String!, $repo: String!, $pr_number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr_number) {
+      reviews(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          body
+          state
+          submittedAt
+          author { login }
+          reactionGroups {
+            content
+            users {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
 
 def _get_required_env(name: str) -> str:
     """Get a required environment variable or raise an error."""
@@ -106,16 +135,95 @@ def fetch_pr_issue_comments(repo: str, pr_number: str) -> list[dict]:
         return []
 
 
-def fetch_pr_reviews(repo: str, pr_number: str) -> list[dict]:
-    """Fetch all reviews on a PR (approve, request changes, comment)."""
-    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
-    request = urllib.request.Request(url, headers=_get_github_headers())
+def _call_github_graphql(query: str, variables: dict) -> dict:
+    """Execute a GitHub GraphQL query and return the `data` payload."""
+    request = urllib.request.Request(
+        "https://api.github.com/graphql",
+        headers=_get_github_headers(),
+        method="POST",
+        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+    )
+    request.add_header("Content-Type", "application/json")
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
-            return json.loads(response.read().decode("utf-8"))
+            payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
-        _handle_github_api_error(e, "fetch reviews")
-        return []
+        _handle_github_api_error(e, "fetch GraphQL data")
+        return {}
+
+    if payload.get("errors"):
+        logger.error("GitHub GraphQL returned errors: %s", payload["errors"])
+        return {}
+
+    return payload.get("data") or {}
+
+
+def _normalize_review_reactions(reaction_groups: list[dict] | None) -> dict[str, int]:
+    """Map GraphQL reaction groups to GitHub-style thumbs-up/down counters."""
+    thumbs_up = 0
+    thumbs_down = 0
+
+    for group in reaction_groups or []:
+        total_count = ((group.get("users") or {}).get("totalCount")) or 0
+        content = group.get("content")
+        if content == "THUMBS_UP":
+            thumbs_up = total_count
+        elif content == "THUMBS_DOWN":
+            thumbs_down = total_count
+
+    return {
+        "+1": thumbs_up,
+        "-1": thumbs_down,
+        "total_count": thumbs_up + thumbs_down,
+    }
+
+
+def fetch_pr_reviews(repo: str, pr_number: str) -> list[dict]:
+    """Fetch all reviews on a PR, including thumbs-up/down reaction counts."""
+    owner, repo_name = repo.split("/", 1)
+    reviews = []
+    cursor = None
+
+    while True:
+        data = _call_github_graphql(
+            REVIEWS_QUERY,
+            {
+                "owner": owner,
+                "repo": repo_name,
+                "pr_number": int(pr_number),
+                "cursor": cursor,
+            },
+        )
+        reviews_data = (
+            data.get("repository", {})
+            .get("pullRequest", {})
+            .get("reviews", {})
+        )
+        nodes = reviews_data.get("nodes") or []
+
+        for review in nodes:
+            author = review.get("author") or {}
+            reviews.append(
+                {
+                    "id": review.get("id"),
+                    "user": {"login": author.get("login")},
+                    "body": review.get("body") or "",
+                    "state": review.get("state"),
+                    "submitted_at": review.get("submittedAt"),
+                    "reactions": _normalize_review_reactions(
+                        review.get("reactionGroups")
+                    ),
+                }
+            )
+
+        page_info = reviews_data.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+
+    return reviews
 
 
 def fetch_pr_diff(repo: str, pr_number: str) -> str:
@@ -236,12 +344,14 @@ def extract_human_responses(
     return human_responses
 
 
-def extract_review_feedback(issue_comments: list[dict]) -> list[dict]:
-    """Extract thumbs-up/down feedback from OpenHands feedback comments."""
+def extract_review_feedback(
+    issue_comments: list[dict], reviews: list[dict] | None = None
+) -> list[dict]:
+    """Extract thumbs-up/down feedback from review bodies or legacy comments."""
     agent_users = _get_agent_usernames()
     feedback = []
 
-    for comment in issue_comments:
+    for comment in [*issue_comments, *(reviews or [])]:
         if FEEDBACK_COMMENT_MARKER not in (comment.get("body") or ""):
             continue
         if comment.get("user", {}).get("login") not in agent_users:
@@ -253,7 +363,8 @@ def extract_review_feedback(issue_comments: list[dict]) -> list[dict]:
         feedback.append(
             {
                 "comment_id": comment.get("id"),
-                "created_at": comment.get("created_at"),
+                "created_at": comment.get("created_at")
+                or comment.get("submitted_at"),
                 "thumbs_up": thumbs_up,
                 "thumbs_down": thumbs_down,
                 "total": thumbs_up + thumbs_down,
@@ -330,7 +441,7 @@ def fetch_pr_data(repo: str, pr_number: str) -> dict:
 
     agent_comments = extract_agent_comments(review_comments, issue_comments, reviews)
     human_responses = extract_human_responses(review_comments, issue_comments)
-    review_feedback = extract_review_feedback(issue_comments)
+    review_feedback = extract_review_feedback(issue_comments, reviews)
 
     logger.info(f"Agent made {len(agent_comments)} comments")
     logger.info(f"Humans made {len(human_responses)} responses")

--- a/plugins/pr-review/scripts/evaluate_review.py
+++ b/plugins/pr-review/scripts/evaluate_review.py
@@ -37,6 +37,8 @@ from lmnr import Laminar, LaminarClient
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
+FEEDBACK_COMMENT_MARKER = "<!-- openhands-pr-review-feedback -->"
+
 
 def _get_required_env(name: str) -> str:
     """Get a required environment variable or raise an error."""
@@ -60,9 +62,12 @@ def _get_agent_usernames() -> set[str]:
     """Get the set of agent usernames to identify agent comments.
 
     Configurable via AGENT_USERNAMES environment variable (comma-separated).
-    Defaults to 'openhands-agent,all-hands-bot'.
+    Defaults to 'openhands-agent,all-hands-bot,github-actions[bot]'.
     """
-    usernames = os.getenv("AGENT_USERNAMES", "openhands-agent,all-hands-bot")
+    usernames = os.getenv(
+        "AGENT_USERNAMES",
+        "openhands-agent,all-hands-bot,github-actions[bot]",
+    )
     return set(name.strip() for name in usernames.split(",") if name.strip())
 
 
@@ -231,6 +236,33 @@ def extract_human_responses(
     return human_responses
 
 
+def extract_review_feedback(issue_comments: list[dict]) -> list[dict]:
+    """Extract thumbs-up/down feedback from OpenHands feedback comments."""
+    agent_users = _get_agent_usernames()
+    feedback = []
+
+    for comment in issue_comments:
+        if FEEDBACK_COMMENT_MARKER not in (comment.get("body") or ""):
+            continue
+        if comment.get("user", {}).get("login") not in agent_users:
+            continue
+
+        reactions = comment.get("reactions") or {}
+        thumbs_up = reactions.get("+1", 0) or 0
+        thumbs_down = reactions.get("-1", 0) or 0
+        feedback.append(
+            {
+                "comment_id": comment.get("id"),
+                "created_at": comment.get("created_at"),
+                "thumbs_up": thumbs_up,
+                "thumbs_down": thumbs_down,
+                "total": thumbs_up + thumbs_down,
+            }
+        )
+
+    return feedback
+
+
 def truncate_text(text: str, max_chars: int = 50000) -> str:
     """Truncate text to stay within reasonable API payload limits.
 
@@ -298,9 +330,11 @@ def fetch_pr_data(repo: str, pr_number: str) -> dict:
 
     agent_comments = extract_agent_comments(review_comments, issue_comments, reviews)
     human_responses = extract_human_responses(review_comments, issue_comments)
+    review_feedback = extract_review_feedback(issue_comments)
 
     logger.info(f"Agent made {len(agent_comments)} comments")
     logger.info(f"Humans made {len(human_responses)} responses")
+    logger.info(f"Found {len(review_feedback)} review feedback prompts")
 
     return {
         "review_comments": review_comments,
@@ -310,6 +344,7 @@ def fetch_pr_data(repo: str, pr_number: str) -> dict:
         "pr_info": pr_info,
         "agent_comments": agent_comments,
         "human_responses": human_responses,
+        "review_feedback": review_feedback,
     }
 
 
@@ -372,6 +407,7 @@ def create_evaluation_span(
         "original_trace_id": trace_info.get("trace_id"),
         "agent_comments": pr_data["agent_comments"],
         "human_responses": pr_data["human_responses"],
+        "review_feedback": pr_data["review_feedback"],
         "final_diff": truncate_text(pr_data["final_diff"]),
         "total_review_comments": len(pr_data["review_comments"]),
         "total_issue_comments": len(pr_data["issue_comments"]),
@@ -398,6 +434,7 @@ def create_evaluation_span(
             "merged": pr_merged,
             "agent_comments_count": len(pr_data["agent_comments"]),
             "human_responses_count": len(pr_data["human_responses"]),
+            "review_feedback": pr_data["review_feedback"],
             "diff_length": len(pr_data["final_diff"]),
         }
         logger.info(f"Evaluation summary: {json.dumps(summary)}")
@@ -439,6 +476,7 @@ def main(trace_file_path: str | None = None):
     original_trace_id = trace_info.get("trace_id")
     agent_comments = pr_data["agent_comments"]
     human_responses = pr_data["human_responses"]
+    review_feedback = pr_data["review_feedback"]
 
     # Score engagement on the original trace for immediate feedback
     if original_trace_id:
@@ -456,6 +494,7 @@ def main(trace_file_path: str | None = None):
                     "agent_comments": len(agent_comments),
                     "human_responses": len(human_responses),
                     "pr_merged": pr_merged,
+                    "review_feedback": review_feedback,
                     "score_type": "engagement",
                 },
             )
@@ -476,6 +515,10 @@ def main(trace_file_path: str | None = None):
     print(f"Merged: {pr_merged}")
     print(f"Agent Comments: {len(agent_comments)}")
     print(f"Human Responses: {len(human_responses)}")
+    if review_feedback:
+        thumbs_up = sum(item["thumbs_up"] for item in review_feedback)
+        thumbs_down = sum(item["thumbs_down"] for item in review_feedback)
+        print(f"Review Feedback: 👍 {thumbs_up} / 👎 {thumbs_down}")
     if original_trace_id:
         print(f"Original Review Trace: {original_trace_id}")
     if eval_trace_id:

--- a/plugins/pr-review/scripts/prompt.py
+++ b/plugins/pr-review/scripts/prompt.py
@@ -51,6 +51,26 @@ When checking the PR description:
 If the change is substantive and this evidence is missing or weak, call it out as a must-fix issue in your review. Do not invent evidence that is not present in the PR description.
 """
 
+FEEDBACK_COMMENT_MARKER = "<!-- openhands-pr-review-feedback -->"
+
+_FEEDBACK_FOOTER_SECTION = """
+## Review Feedback Footer
+
+When you submit the top-level GitHub review body, append this exact footer at the end of that same review body so maintainers can react without creating a separate PR comment:
+
+```md
+---
+Was this automated review useful? React with 👍 or 👎 to this review to help us measure review quality.
+Workflow run: {review_run_url}
+{feedback_comment_marker}
+```
+
+Requirements:
+- Put this footer in the main review body, not in a separate issue comment.
+- Keep the rest of the review body concise.
+- If you would otherwise post only inline comments, still include a short top-level review body so this footer has somewhere to live.
+"""
+
 PROMPT = """{skill_trigger}
 /github-pr-review
 
@@ -70,7 +90,7 @@ Review the PR changes below and identify issues that need to be addressed.
 - **PR Number**: {pr_number}
 - **Commit ID**: {commit_id}
 
-{review_context_section}{evidence_requirements_section}
+{review_context_section}{evidence_requirements_section}{feedback_footer_section}
 {files_manifest}
 ## Patches
 
@@ -169,6 +189,8 @@ def format_prompt(
     files_manifest: str = "",
     review_context: str = "",
     require_evidence: bool = False,
+    collect_feedback: bool = False,
+    review_run_url: str = "",
     use_sub_agents: bool = False,
 ) -> str:
     """Format the PR review prompt with all parameters.
@@ -187,6 +209,9 @@ def format_prompt(
                         the review context section is omitted from the prompt.
         require_evidence: Whether to instruct the reviewer to enforce PR description
                           evidence showing the code works.
+        collect_feedback: Whether to instruct the reviewer to append the feedback
+                          footer to the main review body.
+        review_run_url: Workflow run URL to embed in the feedback footer.
         use_sub_agents: When True, the agent gets the TaskToolSet and decides
                         at runtime whether to delegate file-level reviews to
                         sub-agents based on diff size and complexity.
@@ -206,6 +231,13 @@ def format_prompt(
         _EVIDENCE_REQUIREMENT_SECTION if require_evidence else ""
     )
 
+    feedback_footer_section = ""
+    if collect_feedback:
+        feedback_footer_section = _FEEDBACK_FOOTER_SECTION.format(
+            review_run_url=review_run_url or "unavailable",
+            feedback_comment_marker=FEEDBACK_COMMENT_MARKER,
+        )
+
     prompt = PROMPT.format(
         skill_trigger=skill_trigger,
         title=title,
@@ -217,6 +249,7 @@ def format_prompt(
         commit_id=commit_id,
         review_context_section=review_context_section,
         evidence_requirements_section=evidence_requirements_section,
+        feedback_footer_section=feedback_footer_section,
         files_manifest=files_manifest,
         diff=diff,
     )

--- a/tests/test_pr_review_feedback.py
+++ b/tests/test_pr_review_feedback.py
@@ -8,6 +8,20 @@ from pathlib import Path
 import yaml
 
 
+_ROOT = Path(__file__).parent.parent
+_PR_REVIEW_SCRIPTS = _ROOT / "plugins" / "pr-review" / "scripts"
+
+
+def _load_prompt_module():
+    path = _PR_REVIEW_SCRIPTS / "prompt.py"
+    spec = importlib.util.spec_from_file_location("pr_review_prompt_feedback", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+
 def _load_eval_module():
     """Load evaluate_review.py with Laminar stubbed."""
     lmnr_mod = types.ModuleType("lmnr")
@@ -60,13 +74,7 @@ def _load_eval_module():
     saved = sys.modules.get("lmnr")
     sys.modules["lmnr"] = lmnr_mod
     try:
-        path = (
-            Path(__file__).parent.parent
-            / "plugins"
-            / "pr-review"
-            / "scripts"
-            / "evaluate_review.py"
-        )
+        path = _PR_REVIEW_SCRIPTS / "evaluate_review.py"
         spec = importlib.util.spec_from_file_location("pr_review_evaluate", path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = module
@@ -79,35 +87,82 @@ def _load_eval_module():
             sys.modules["lmnr"] = saved
 
 
-def test_action_collect_feedback_defaults_to_true():
-    action_yml = (
-        Path(__file__).parent.parent / "plugins" / "pr-review" / "action.yml"
+
+def _format_prompt(*, collect_feedback: bool, review_run_url: str = "") -> str:
+    module = _load_prompt_module()
+    return module.format_prompt(
+        skill_trigger="/codereview",
+        title="Add review feedback footer",
+        body="## Summary\nCapture review reactions without extra PR spam.",
+        repo_name="OpenHands/extensions",
+        base_branch="main",
+        head_branch="feature/feedback-footer",
+        pr_number="249",
+        commit_id="abc123",
+        diff="diff --git a/file b/file",
+        review_context="",
+        require_evidence=False,
+        collect_feedback=collect_feedback,
+        review_run_url=review_run_url,
+        use_sub_agents=False,
     )
+
+
+
+def test_action_collect_feedback_defaults_to_true_and_uses_agent_prompt():
+    action_yml = _ROOT / "plugins" / "pr-review" / "action.yml"
     with open(action_yml) as f:
         action = yaml.safe_load(f)
 
     collect_feedback = action["inputs"]["collect-feedback"]
     assert collect_feedback["default"] == "true"
 
-    feedback_step = next(
-        step
-        for step in action["runs"]["steps"]
-        if step["name"] == "Post PR review feedback prompt"
+    run_step = next(
+        step for step in action["runs"]["steps"] if step["name"] == "Run PR review"
     )
-    assert "inputs.collect-feedback == 'true'" in feedback_step["if"]
-    assert "openhands-pr-review-feedback" in feedback_step["run"]
-    assert "React to this comment with 👍 or 👎" in feedback_step["run"]
+    assert run_step["env"]["COLLECT_FEEDBACK"] == "${{ inputs.collect-feedback }}"
+    assert run_step["env"]["REVIEW_RUN_URL"] == (
+        "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    )
+    assert all(
+        step["name"] != "Post PR review feedback prompt"
+        for step in action["runs"]["steps"]
+    )
 
 
-def test_extract_review_feedback_counts_thumbs_reactions():
+
+def test_prompt_omits_feedback_footer_by_default():
+    prompt = _format_prompt(collect_feedback=False)
+
+    assert "## Review Feedback Footer" not in prompt
+    assert "React with 👍 or 👎 to this review" not in prompt
+    assert "<!-- openhands-pr-review-feedback -->" not in prompt
+
+
+
+def test_prompt_includes_feedback_footer_when_enabled():
+    prompt = _format_prompt(
+        collect_feedback=True,
+        review_run_url="https://github.com/OpenHands/extensions/actions/runs/123",
+    )
+
+    assert "## Review Feedback Footer" in prompt
+    assert "main review body, not in a separate issue comment" in prompt
+    assert "React with 👍 or 👎 to this review" in prompt
+    assert "https://github.com/OpenHands/extensions/actions/runs/123" in prompt
+    assert "<!-- openhands-pr-review-feedback -->" in prompt
+
+
+
+def test_extract_review_feedback_counts_thumbs_reactions_from_reviews():
     module = _load_eval_module()
 
-    comments = [
+    reviews = [
         {
             "id": 101,
             "user": {"login": "openhands-agent"},
-            "body": "## OpenHands PR review feedback\n<!-- openhands-pr-review-feedback -->",
-            "created_at": "2026-05-19T12:00:00Z",
+            "body": "Automated review\n<!-- openhands-pr-review-feedback -->",
+            "submitted_at": "2026-05-19T12:00:00Z",
             "reactions": {"+1": 3, "-1": 1, "total_count": 4},
         },
         {
@@ -124,7 +179,7 @@ def test_extract_review_feedback_counts_thumbs_reactions():
         },
     ]
 
-    assert module.extract_review_feedback(comments) == [
+    assert module.extract_review_feedback([], reviews) == [
         {
             "comment_id": 101,
             "created_at": "2026-05-19T12:00:00Z",
@@ -135,7 +190,8 @@ def test_extract_review_feedback_counts_thumbs_reactions():
     ]
 
 
-def test_extract_review_feedback_handles_missing_reactions():
+
+def test_extract_review_feedback_keeps_legacy_issue_comment_support():
     module = _load_eval_module()
 
     result = module.extract_review_feedback(
@@ -144,6 +200,8 @@ def test_extract_review_feedback_handles_missing_reactions():
                 "id": 201,
                 "user": {"login": "all-hands-bot"},
                 "body": "<!-- openhands-pr-review-feedback -->",
+                "created_at": "2026-05-19T12:00:00Z",
+                "reactions": {"+1": 2, "-1": 0},
             }
         ]
     )
@@ -151,6 +209,32 @@ def test_extract_review_feedback_handles_missing_reactions():
     assert result == [
         {
             "comment_id": 201,
+            "created_at": "2026-05-19T12:00:00Z",
+            "thumbs_up": 2,
+            "thumbs_down": 0,
+            "total": 2,
+        }
+    ]
+
+
+
+def test_extract_review_feedback_handles_missing_reactions():
+    module = _load_eval_module()
+
+    result = module.extract_review_feedback(
+        [],
+        [
+            {
+                "id": 301,
+                "user": {"login": "all-hands-bot"},
+                "body": "<!-- openhands-pr-review-feedback -->",
+            }
+        ],
+    )
+
+    assert result == [
+        {
+            "comment_id": 301,
             "created_at": None,
             "thumbs_up": 0,
             "thumbs_down": 0,
@@ -159,18 +243,20 @@ def test_extract_review_feedback_handles_missing_reactions():
     ]
 
 
+
 def test_extract_review_feedback_accepts_github_actions_bot():
     module = _load_eval_module()
 
     result = module.extract_review_feedback(
+        [],
         [
             {
-                "id": 301,
+                "id": 401,
                 "user": {"login": "github-actions[bot]"},
                 "body": "<!-- openhands-pr-review-feedback -->",
                 "reactions": {"+1": 1, "-1": 2},
             }
-        ]
+        ],
     )
 
     assert result[0]["thumbs_up"] == 1

--- a/tests/test_pr_review_feedback.py
+++ b/tests/test_pr_review_feedback.py
@@ -1,0 +1,177 @@
+"""Tests for PR review feedback collection."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import yaml
+
+
+def _load_eval_module():
+    """Load evaluate_review.py with Laminar stubbed."""
+    lmnr_mod = types.ModuleType("lmnr")
+
+    class _FakeLaminar:
+        @staticmethod
+        def initialize():
+            return None
+
+        @staticmethod
+        def get_trace_id():
+            return None
+
+        @staticmethod
+        def get_laminar_span_context():
+            return None
+
+        @staticmethod
+        def set_trace_metadata(metadata):
+            return None
+
+        @staticmethod
+        def set_span_output(output):
+            return None
+
+        @staticmethod
+        def flush():
+            return None
+
+        @staticmethod
+        def start_as_current_span(**kwargs):
+            import contextlib
+
+            return contextlib.nullcontext()
+
+    class _FakeClient:
+        class evaluators:
+            @staticmethod
+            def score(**kwargs):
+                return None
+
+        class tags:
+            @staticmethod
+            def tag(trace_id, tags):
+                return None
+
+    lmnr_mod.Laminar = _FakeLaminar
+    lmnr_mod.LaminarClient = _FakeClient
+
+    saved = sys.modules.get("lmnr")
+    sys.modules["lmnr"] = lmnr_mod
+    try:
+        path = (
+            Path(__file__).parent.parent
+            / "plugins"
+            / "pr-review"
+            / "scripts"
+            / "evaluate_review.py"
+        )
+        spec = importlib.util.spec_from_file_location("pr_review_evaluate", path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if saved is None:
+            sys.modules.pop("lmnr", None)
+        else:
+            sys.modules["lmnr"] = saved
+
+
+def test_action_collect_feedback_defaults_to_true():
+    action_yml = (
+        Path(__file__).parent.parent / "plugins" / "pr-review" / "action.yml"
+    )
+    with open(action_yml) as f:
+        action = yaml.safe_load(f)
+
+    collect_feedback = action["inputs"]["collect-feedback"]
+    assert collect_feedback["default"] == "true"
+
+    feedback_step = next(
+        step
+        for step in action["runs"]["steps"]
+        if step["name"] == "Post PR review feedback prompt"
+    )
+    assert "inputs.collect-feedback == 'true'" in feedback_step["if"]
+    assert "openhands-pr-review-feedback" in feedback_step["run"]
+    assert "React to this comment with 👍 or 👎" in feedback_step["run"]
+
+
+def test_extract_review_feedback_counts_thumbs_reactions():
+    module = _load_eval_module()
+
+    comments = [
+        {
+            "id": 101,
+            "user": {"login": "openhands-agent"},
+            "body": "## OpenHands PR review feedback\n<!-- openhands-pr-review-feedback -->",
+            "created_at": "2026-05-19T12:00:00Z",
+            "reactions": {"+1": 3, "-1": 1, "total_count": 4},
+        },
+        {
+            "id": 102,
+            "user": {"login": "openhands-agent"},
+            "body": "Regular review comment",
+            "reactions": {"+1": 100, "-1": 100},
+        },
+        {
+            "id": 103,
+            "user": {"login": "human-dev"},
+            "body": "<!-- openhands-pr-review-feedback -->",
+            "reactions": {"+1": 5, "-1": 0},
+        },
+    ]
+
+    assert module.extract_review_feedback(comments) == [
+        {
+            "comment_id": 101,
+            "created_at": "2026-05-19T12:00:00Z",
+            "thumbs_up": 3,
+            "thumbs_down": 1,
+            "total": 4,
+        }
+    ]
+
+
+def test_extract_review_feedback_handles_missing_reactions():
+    module = _load_eval_module()
+
+    result = module.extract_review_feedback(
+        [
+            {
+                "id": 201,
+                "user": {"login": "all-hands-bot"},
+                "body": "<!-- openhands-pr-review-feedback -->",
+            }
+        ]
+    )
+
+    assert result == [
+        {
+            "comment_id": 201,
+            "created_at": None,
+            "thumbs_up": 0,
+            "thumbs_down": 0,
+            "total": 0,
+        }
+    ]
+
+
+def test_extract_review_feedback_accepts_github_actions_bot():
+    module = _load_eval_module()
+
+    result = module.extract_review_feedback(
+        [
+            {
+                "id": 301,
+                "user": {"login": "github-actions[bot]"},
+                "body": "<!-- openhands-pr-review-feedback -->",
+                "reactions": {"+1": 1, "-1": 2},
+            }
+        ]
+    )
+
+    assert result[0]["thumbs_up"] == 1
+    assert result[0]["thumbs_down"] == 2


### PR DESCRIPTION
## Summary
- append the maintainer feedback request to the main GitHub review body instead of posting a separate PR comment
- pass `collect-feedback` and the workflow run URL into `agent_script.py` / `prompt.py` so the agent can add the inline footer itself
- collect thumbs-up/down feedback from review-body reactions during evaluation while keeping legacy issue-comment markers supported
- update the plugin README and focused tests for the new flow

## Testing
- `uv run --group test --with pyyaml pytest -q tests/test_pr_review_feedback.py tests/test_pr_review_prompt.py`

_This PR description was created by an AI agent (OpenHands) on behalf of the user._
