### PR TITLE
Simplify host determination instructions in SKILL.md

### DIFF
--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -50,7 +50,6 @@ All requests require Bearer authentication:
 
 Look for a `<HOST>` value in the system prompt. If present, use that URL. Otherwise, default to `https://app.all-hands.dev`.
 
-This ensures the correct host is used for the deployment environment (e.g., `https://staging.all-hands.dev` for staging, `https://app.all-hands.dev` for production).
 
 ### Automation Endpoints
 


### PR DESCRIPTION
Simplified instructions on determining the correct host for API calls. Removed staging host; while it was an example, the agent seems to use it, which it shouldn’t.

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
