### PR TITLE
fix: use uv instead of pip in Python script examples

### DIFF
--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -326,7 +326,11 @@ mkdir my-automation && cd my-automation
 cat > setup.sh << 'EOF'
 #!/bin/bash
 set -e
-pip install -q openhands-sdk openhands-workspace openhands-tools
+uv venv .venv --quiet
+uv pip install --quiet \
+  openhands-sdk \
+  openhands-workspace \
+  openhands-tools
 EOF
 chmod +x setup.sh
 
@@ -381,7 +385,7 @@ curl -X POST "${OPENHANDS_HOST}/api/automation/v1" \
     \"name\": \"Weekly Report Generator\",
     \"trigger\": {\"type\": \"cron\", \"schedule\": \"0 9 * * 1\", \"timezone\": \"UTC\"},
     \"tarball_path\": \"$TARBALL_PATH\",
-    \"entrypoint\": \"python main.py\",
+    \"entrypoint\": \".venv/bin/python main.py\",
     \"setup_script_path\": \"setup.sh\",
     \"timeout\": 300
   }"

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -54,6 +54,7 @@ Executable code (Python/Bash/etc.) for tasks that require deterministic reliabil
 - **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
 - **Benefits**: Token efficient, deterministic, may be executed without loading into context
 - **Note**: Scripts may still need to be read by OpenHands for patching or environment-specific adjustments
+- **Python dependencies**: Use `uv` instead of `pip` or `pip3` for all Python dependency installs. `uv` is cross-platform, faster, and avoids the `pip`/`pip3` naming inconsistency across environments. Example: `uv venv .venv --quiet && uv pip install --quiet <package>`
 
 ##### References (`references/`)
 
@@ -505,6 +506,7 @@ Good for: Complex domains with validation utilities
 - Reference supporting files clearly
 - Provide working examples
 - Create utility scripts for common operations
+- Use `uv` for Python dependency installs in scripts (`uv venv .venv --quiet && uv pip install --quiet <pkg>`)
 
 ❌ **DON'T:**
 - Use second person anywhere
@@ -514,6 +516,7 @@ Good for: Complex domains with validation utilities
 - Leave resources unreferenced
 - Include broken or incomplete examples
 - Skip validation
+- Use `pip` or `pip3` directly — `uv` is the cross-platform standard
 
 ## Additional Resources
 


### PR DESCRIPTION
## Problem

The `openhands-automation` skill's **Complete Example** section had a bare `pip install` in its generated `setup.sh`:

```bash
pip install -q openhands-sdk openhands-workspace openhands-tools
```

This breaks on macOS (where only `pip3` is on the PATH, not `pip`) and contradicted the **Required Dependencies** section just above it, which already correctly used `uv`. When an agent follows the Complete Example to create a custom automation, it generates a broken `setup.sh` that fails immediately with `pip: command not found`.

## Changes

### `skills/openhands-automation/references/custom-automation.md`
- Replace `pip install` with `uv venv .venv --quiet && uv pip install --quiet` in the Complete Example `setup.sh` — consistent with the preset `setup.sh` files which already use `uv`
- Update the matching entrypoint from `python main.py` to `.venv/bin/python main.py` so it uses the venv that `setup.sh` creates (matching the preset router's `VENV_ENTRYPOINT`)

### `skills/skill-creator/SKILL.md`
- Add an explicit `uv` rule in the **Scripts** section: always use `uv` instead of `pip`/`pip3` for Python dependency installs in skill scripts
- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Add the same rule to the *- Ad an AI agent (OpenHands) on behalf of the repository owner._