### PR TITLE
docs: expand openhands-automation skill with architecture overview, no-LLM patterns, and corrected env var names

### DIFF
--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -56,14 +56,14 @@ The agent server typically runs inside a **sandbox** (a Docker or Kubernetes con
 
 ### No-LLM Script Helpers
 
-When building a deterministic custom script, these two stdlib-only functions are required. Copy them verbatim — they handle both local/dev (`OH_INTERNAL_SERVER_URL`, `OH_SESSION_API_KEYS_0`) and cloud (`AGENT_SERVER_URL`, `SESSION_API_KEY`) deployments.
+When building a deterministic custom script, these two stdlib-only functions are required. Copy them verbatim — they use `AGENT_SERVER_URL` and `SESSION_API_KEY` injected by the automation service.
 
 ```python
 import json, os, urllib.request
 
 def get_secret(name):
     """Fetch a named secret stored in the agent server."""
-    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
+    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
     key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
     with urllib.request.urlopen(urllib.request.Request(
         f"{url}/api/settings/secrets/{name}", headers={"X-Session-API-Key": key}

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -34,7 +34,15 @@ The agent server typically runs inside a **sandbox** (a Docker or Kubernetes con
 
 > **⚠️ CRITICAL — Agent behavior rules:**
 >
-> 0. **Does this task need an LLM at all? Check first.** Before picking a preset, ask whether the task actually requires reasoning, judgment, summarization, or open-ended tool use. If it is fully deterministic — fixed data transforms, scheduled HTTP calls, healthcheck pings, file rotation, picking from a known list, posting a templated message — an LLM-driven preset is overkill. Every run will spin up a sandbox and consume LLM tokens, which adds up fast at high frequencies (every 5 min ≈ 288 runs/day). Surface the trade-off to the user and offer the custom-script path (see `references/custom-automation.md`) as the cheaper, more reliable option. Be especially careful for cron schedules tighter than hourly.
+> 0. **Does this task need an LLM at all? Check first.** Before picking a preset, ask whether the task actually requires reasoning, judgment, summarization, or open-ended tool use. If it is fully deterministic — fixed data transforms, scheduled HTTP calls, healthcheck pings, file rotation, picking from a known list, posting a templated message — an LLM-driven preset is overkill. Every run will consume LLM tokens, which adds up fast at high frequencies (every 5 min ≈ 288 runs/day). Surface the trade-off to the user and offer the custom-script path (see `references/custom-automation.md`) as the cheaper, more reliable option. Be especially careful for cron schedules tighter than hourly.
+>
+>    **Instant-recognition patterns — these are always deterministic, never use an LLM preset:**
+>    - "post a quote / message / fact every N minutes" (rotating from a list)
+>    - "send a scheduled reminder / standup / digest"
+>    - "ping a health-check URL on a schedule"
+>    - "post to Slack / webhook every N minutes"
+>    - Any task where the full output could be written as a static template right now
+>
 > 1. **For LLM-appropriate work, default to preset endpoints.** They handle all SDK boilerplate, tarball packaging, and upload automatically:
 >    - **Prompt preset** (`POST /v1/preset/prompt`) — for tasks expressed as a natural language prompt that benefit from agent reasoning
 >    - **Plugin preset** (`POST /v1/preset/plugin`) — when plugins with skills, MCP configs, or commands are needed
@@ -45,6 +53,40 @@ The agent server typically runs inside a **sandbox** (a Docker or Kubernetes con
 >    - **Custom script** — full control over code, with or without LLM; point them to `references/custom-automation.md`
 >    - Let the user choose which approach to use.
 > 4. **Only create custom scripts after the user agrees to that path.** Refer to `references/custom-automation.md` for the full reference.
+
+### No-LLM Script Helpers
+
+When building a deterministic custom script, these two stdlib-only functions are required. Copy them verbatim — they handle both local/dev (`OH_INTERNAL_SERVER_URL`, `OH_SESSION_API_KEYS_0`) and cloud (`AGENT_SERVER_URL`, `SESSION_API_KEY`) deployments.
+
+```python
+import json, os, urllib.request
+
+def get_secret(name):
+    """Fetch a named secret stored in the agent server."""
+    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
+    key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
+    with urllib.request.urlopen(urllib.request.Request(
+        f"{url}/api/settings/secrets/{name}", headers={"X-Session-API-Key": key}
+    )) as r:
+        return r.read().decode().strip()
+
+def fire_callback(status="COMPLETED", error=None):
+    """Signal run completion. MUST be called on every exit path — success AND error."""
+    url = os.environ.get("AUTOMATION_CALLBACK_URL", "")
+    if not url: return
+    body = {"status": status, "run_id": os.environ.get("AUTOMATION_RUN_ID", "")}
+    if error: body["error"] = error
+    try:
+        urllib.request.urlopen(urllib.request.Request(url, data=json.dumps(body).encode(), headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.environ.get('AUTOMATION_CALLBACK_API_KEY', '')}",
+        }))
+    except Exception as e: print(f"Callback error: {e}")
+```
+
+Entrypoint must be `python3 main.py` (no `setup.sh` needed). Wrap your main logic in `try/except` and call `fire_callback("FAILED", str(e))` in the except block.
+
+---
 
 ## Authentication
 

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -18,7 +18,19 @@ triggers:
 
 # OpenHands Automations
 
-Create and manage automations that run in OpenHands Cloud sandboxes — triggered by cron schedules or webhook events (GitHub, custom services).
+Create and manage automations that run inside an OpenHands agent server — triggered by cron schedules or webhook events (GitHub, custom services).
+
+## Architecture
+
+Two components work together to run automations:
+
+**Automation Service** (API at `OPENHANDS_HOST/api/automation/v1`)
+Manages the *when*: holds automation definitions, schedules cron-triggered runs, dispatches webhook-triggered runs, and receives completion callbacks to mark runs as done. This is the API you call to create, update, and manage automations.
+
+**Agent Server** (reachable at `OH_INTERNAL_SERVER_URL` inside a run)
+Manages the *what*: the runtime environment where automation scripts execute and where conversations (AI agent interactions with tools, bash, file editing, etc.) run. When a run is triggered, the automation service uploads the automation's tarball to the agent server, which unpacks and runs the entrypoint script. The script runs inside the agent server and connects back to it using `OH_INTERNAL_SERVER_URL` and a session API key to start, monitor, and stop conversations.
+
+The agent server typically runs inside a **sandbox** (a Docker or Kubernetes container). Some deployments use sandboxless mode, where the agent server runs directly on a host.
 
 > **⚠️ CRITICAL — Agent behavior rules:**
 >
@@ -104,8 +116,8 @@ Use the **preset/prompt endpoint** for simple automations. Provide a natural lan
 #### How It Works
 
 1. Send a prompt describing the task (e.g., "Generate a weekly status report")
-2. The service generates SDK boilerplate that connects to the user's OpenHands Cloud account, fetches their LLM config, secrets, and MCP server configuration, creates an AI agent conversation with the prompt, and reports completion
-3. The service packages the code into a tarball, uploads it, and creates the automation
+2. The automation service generates a Python script that: fetches LLM config and secrets from the agent server, starts an AI agent conversation with your prompt, and sends a completion callback when done
+3. The script is packaged as a tarball and the automation is registered; on each trigger, the automation service uploads the tarball to the agent server, which unpacks and runs the script inside its environment
 
 #### Request
 
@@ -747,9 +759,11 @@ Run status values: `PENDING` (waiting for dispatch), `RUNNING` (in progress), `C
 
 ---
 
-## Sandbox Lifecycle
+## Run Lifecycle
 
-After a run completes, the sandbox is **kept alive** by default — users can view the conversation history in the OpenHands UI and continue interacting. The sandbox persists until it times out or is manually deleted.
+When a run completes, the automation service receives a callback and marks the run done. Any conversations started during the run remain accessible in the OpenHands UI — users can view the history and continue interacting. The agent server persists until it times out or is manually deleted.
+
+The automation script itself controls when the callback fires (signalling completion). For simple synchronous scripts this happens naturally on exit. For scripts that start asynchronous conversations, the callback should be deferred until the conversation reaches an idle state (see `references/custom-automation.md` for patterns).
 
 ---
 

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -38,13 +38,13 @@ The agent server typically runs inside a **sandbox** (a Docker or Kubernetes con
 > 1. **For LLM-appropriate work, default to preset endpoints.** They handle all SDK boilerplate, tarball packaging, and upload automatically:
 >    - **Prompt preset** (`POST /v1/preset/prompt`) — for tasks expressed as a natural language prompt that benefit from agent reasoning
 >    - **Plugin preset** (`POST /v1/preset/plugin`) — when plugins with skills, MCP configs, or commands are needed
-> 2. **Do not silently create custom SDK scripts.** Do not generate Python SDK code, `setup.sh` files, or tarball uploads without user consent. But *do* proactively recommend the custom path (per rule 0) when the task is deterministic or high-frequency — surface the option and let the user choose.
+> 2. **Do not silently create custom scripts.** Do not generate Python code, `setup.sh` files, or tarball uploads without user consent. But *do* proactively recommend the custom path (per rule 0) when the task is deterministic or high-frequency — surface the option and let the user choose.
 > 3. **If neither preset is the right fit**, do NOT silently fall back to custom automation. Instead, explain the available options to the user:
 >    - **Prompt preset** — natural language prompt execution (LLM-driven)
 >    - **Plugin preset** — load plugins with extended capabilities (skills, MCP, hooks, commands)
->    - **Custom SDK script** — full control over code, no LLM required; point them to `references/custom-automation.md`
+>    - **Custom script** — full control over code, with or without LLM; point them to `references/custom-automation.md`
 >    - Let the user choose which approach to use.
-> 4. **Only create custom SDK scripts after the user agrees to that path.** Refer to `references/custom-automation.md` for the full reference.
+> 4. **Only create custom scripts after the user agrees to that path.** Refer to `references/custom-automation.md` for the full reference.
 
 ## Authentication
 
@@ -775,8 +775,8 @@ Pick based on **what the task needs**, not just **what is technically possible**
 |----------|-------------|
 | Reasoning, summarization, triage, code review, or open-ended tool use | **Prompt Preset** |
 | Needs plugin commands / skills / MCP configs / hooks | **Plugin Preset** |
-| **Deterministic task** (fixed data + scheduled action, e.g. healthcheck, templated notification, rotating from a known list) — especially if it runs frequently | **Custom SDK script** (no LLM) — see `references/custom-automation.md` |
-| Custom Python dependencies, non-Python entrypoint, multi-file project structure, direct SDK lifecycle control | **Custom Automation** (see below) |
+| **Deterministic task** (fixed data + scheduled action, e.g. healthcheck, Slack notification, rotating from a known list) — especially if it runs frequently | **Custom script, no LLM** — see `references/custom-automation.md#deterministic-script-no-llm` |
+| Custom Python dependencies, multi-file project, or direct SDK lifecycle control | **Custom script with SDK** — see `references/custom-automation.md#sdk-based-scripts` |
 
 The **prompt preset** is the right default for genuinely agent-shaped work — anything that benefits from reasoning over context, calling tools dynamically, or producing a non-templated output. Use the **plugin preset** when you need extended capabilities from plugins (skills, MCP configurations, hooks, commands).
 
@@ -786,4 +786,4 @@ The **prompt preset** is the right default for genuinely agent-shaped work — a
 
 ## Reference Files
 
-- **`references/custom-automation.md`** — Detailed guide for custom automations: tarball uploads, SDK code structure, environment variables, validation rules, and complete examples. Consult this whenever you need to evaluate or recommend the custom path (including for deterministic / cost-sensitive tasks per rule 0). Only *implement* a custom automation after the user agrees to that path.
+- **`references/custom-automation.md`** — Detailed guide for custom automations: tarball uploads, code structure (SDK and no-LLM), environment variables, validation rules, and complete examples. Consult this whenever you need to evaluate or recommend the custom path (including for deterministic / cost-sensitive tasks per rule 0). Only *implement* a custom automation after the user agrees to that path.

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -27,8 +27,8 @@ Two components work together to run automations:
 **Automation Service** (API at `OPENHANDS_HOST/api/automation/v1`)
 Manages the *when*: holds automation definitions, schedules cron-triggered runs, dispatches webhook-triggered runs, and receives completion callbacks to mark runs as done. This is the API you call to create, update, and manage automations.
 
-**Agent Server** (reachable at `OH_INTERNAL_SERVER_URL` inside a run)
-Manages the *what*: the runtime environment where automation scripts execute and where conversations (AI agent interactions with tools, bash, file editing, etc.) run. When a run is triggered, the automation service uploads the automation's tarball to the agent server, which unpacks and runs the entrypoint script. The script runs inside the agent server and connects back to it using `OH_INTERNAL_SERVER_URL` and a session API key to start, monitor, and stop conversations.
+**Agent Server** (reachable at `AGENT_SERVER_URL` inside a run)
+Manages the *what*: the runtime environment where automation scripts execute and where conversations (AI agent interactions with tools, bash, file editing, etc.) run. When a run is triggered, the automation service uploads the automation's tarball to the agent server, which unpacks and runs the entrypoint script. The script runs inside the agent server and connects back to it using `AGENT_SERVER_URL` and a session API key to start, monitor, and stop conversations.
 
 The agent server typically runs inside a **sandbox** (a Docker or Kubernetes container). Some deployments use sandboxless mode, where the agent server runs directly on a host.
 

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -405,7 +405,7 @@ For tasks that don't need AI reasoning — sending a Slack message, calling an A
 import os, urllib.request
 
 def get_secret(name: str) -> str:
-    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
+    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
     key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
     req = urllib.request.Request(
         f"{url}/api/settings/secrets/{name}",
@@ -483,7 +483,7 @@ QUOTES = ["Stay hungry, stay foolish.", "Done is better than perfect."]
 CHANNEL = "C12345678"
 
 def get_secret(name):
-    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
+    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
     key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
     req = urllib.request.Request(f"{url}/api/settings/secrets/{name}",
         headers={"X-Session-API-Key": key})

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -42,6 +42,17 @@ automation.tar.gz
 
 **Note:** The `setup.sh` script is critical - it must install `uv` and the OpenHands SDK packages before your entrypoint runs.
 
+### Validate Before Packaging
+
+**Always validate syntax before creating the tarball.** This catches errors immediately and avoids uploading broken code that fails silently at runtime.
+
+```bash
+python3 -m py_compile main.py   # fails with a clear error on any syntax problem
+bash -n setup.sh                 # validates shell syntax without executing
+```
+
+Fix any errors reported before proceeding to the next step.
+
 ### Upload the Tarball
 
 First, determine the API host. Look for a `<HOST>` value in the system prompt. If present, use that URL. Otherwise, default to `https://app.all-hands.dev`.
@@ -473,10 +484,14 @@ with OpenHandsCloudWorkspace(
 print("Automation completed!")
 EOF
 
-# 2. Create the tarball
+# 2. Validate syntax before packaging
+python3 -m py_compile main.py
+bash -n setup.sh
+
+# 3. Create the tarball
 tar -czf ../my-automation.tar.gz .
 
-# 3. Upload the tarball
+# 4. Upload the tarball
 UPLOAD_RESPONSE=$(curl -s -X POST \
   "${OPENHANDS_HOST}/api/automation/v1/uploads?name=my-automation" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
@@ -485,7 +500,7 @@ UPLOAD_RESPONSE=$(curl -s -X POST \
 
 TARBALL_PATH=$(echo "$UPLOAD_RESPONSE" | jq -r '.tarball_path')
 
-# 4. Create the automation
+# 5. Create the automation
 curl -X POST "${OPENHANDS_HOST}/api/automation/v1" \
   -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
   -H "Content-Type: application/json" \

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -405,7 +405,7 @@ For tasks that don't need AI reasoning — sending a Slack message, calling an A
 import os, urllib.request
 
 def get_secret(name: str) -> str:
-    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
+    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
     key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
     req = urllib.request.Request(
         f"{url}/api/settings/secrets/{name}",
@@ -483,7 +483,7 @@ QUOTES = ["Stay hungry, stay foolish.", "Done is better than perfect."]
 CHANNEL = "C12345678"
 
 def get_secret(name):
-    url = (os.environ.get("OH_INTERNAL_SERVER_URL") or os.environ.get("AGENT_SERVER_URL", "")).rstrip("/")
+    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
     key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
     req = urllib.request.Request(f"{url}/api/settings/secrets/{name}",
         headers={"X-Session-API-Key": key})

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -229,20 +229,20 @@ uv pip install -q openhands-sdk openhands-workspace openhands-tools
 import os
 
 from openhands.sdk import Conversation
+from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
-from openhands.workspace import OpenHandsCloudWorkspace
 
-# The API key and server URL each have two names depending on the deployment.
+# Session API key and agent server URL are injected by the automation runtime.
 api_key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
-api_url = os.environ.get("RUNTIME_URL") or os.environ.get("OH_INTERNAL_SERVER_URL", "")
+host = os.environ.get("OH_INTERNAL_SERVER_URL", "http://localhost:60000")
 
-# Use OpenHandsCloudWorkspace to connect to your OpenHands Cloud account
-with OpenHandsCloudWorkspace(
-    local_agent_server_mode=True,
-    cloud_api_url=api_url,
-    cloud_api_key=api_key,
+# Use RemoteWorkspace to connect to the sandbox's local agent server
+with RemoteWorkspace(
+    host=host,
+    api_key=api_key,
+    working_dir="/workspace",
 ) as workspace:
-    # Get your configured LLM from OpenHands Cloud
+    # Get your configured LLM from the agent server's persisted settings
     llm = workspace.get_llm()
     
     # Optionally get your stored secrets
@@ -282,7 +282,7 @@ conversation = Conversation(agent=agent, workspace=workspace, delete_on_close=Fa
 conversation = Conversation(agent=agent, workspace=workspace, delete_on_close=True)
 ```
 
-The `OpenHandsCloudWorkspace` also has a `keep_alive` parameter, but in `local_agent_server_mode=True` (used by automations), sandbox lifecycle is managed by the automation service — not the workspace. The automation service defaults to keeping sandboxes alive.
+Sandbox lifecycle in automations is managed entirely by the automation service — not the workspace. The automation service defaults to keeping sandboxes alive.
 
 ---
 
@@ -292,11 +292,11 @@ Your automation script receives these environment variables:
 
 | Variable | Cloud alias | Description |
 |----------|-------------|-------------|
-| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for sandbox-scoped settings calls |
-| `OH_INTERNAL_SERVER_URL` | `RUNTIME_URL` | Internal server URL — used as `cloud_api_url` for the workspace |
+| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key — passed as `api_key` to `RemoteWorkspace` |
+| `OH_INTERNAL_SERVER_URL` | — | Agent server URL — passed as `host` to `RemoteWorkspace` (fallback: `http://localhost:60000`) |
 | `AUTOMATION_EVENT_PAYLOAD` | — | JSON with trigger info, automation ID, and name |
 
-> **Note:** `OH_*` names are used in local/dev deployments; `SESSION_API_KEY` and `RUNTIME_URL` are used in cloud deployments. Always read both with `.get()` — see the code examples above.
+> **Note:** `OH_SESSION_API_KEYS_0` is used in local/dev deployments; `SESSION_API_KEY` is used in cloud deployments. Always read both with `.get()` — see the code examples above.
 
 **Note:** The automation framework automatically handles run completion callbacks.
 
@@ -341,19 +341,19 @@ import os
 import json
 
 from openhands.sdk import Conversation
+from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
-from openhands.workspace import OpenHandsCloudWorkspace
 
 payload = json.loads(os.environ.get('AUTOMATION_EVENT_PAYLOAD', '{}'))
 print(f"Running: {payload.get('automation_name')}")
 
 api_key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
-api_url = os.environ.get("RUNTIME_URL") or os.environ.get("OH_INTERNAL_SERVER_URL", "")
+host = os.environ.get("OH_INTERNAL_SERVER_URL", "http://localhost:60000")
 
-with OpenHandsCloudWorkspace(
-    local_agent_server_mode=True,
-    cloud_api_url=api_url,
-    cloud_api_key=api_key,
+with RemoteWorkspace(
+    host=host,
+    api_key=api_key,
+    working_dir="/workspace",
 ) as workspace:
     llm = workspace.get_llm()
     agent = get_default_agent(llm=llm, cli_mode=True)

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -322,25 +322,74 @@ else:
         conversation.close()
 ```
 
-#### Pattern 3: Fire and continue (asynchronous)
+#### Pattern 3: Wait for conversation completion (polling)
 
-Start one or more conversations without blocking, then do other work. The completion callback fires when the `with` block exits — **not** when the conversations finish. Use this only when you don't need to wait for conversation results.
+Start a conversation without blocking, do other work, then poll until the conversation reaches a terminal state before exiting. The callback fires only after the conversation is done.
+
+`ConversationExecutionStatus.is_terminal()` returns `True` for `FINISHED`, `ERROR`, and `STUCK`. Call `refresh_from_server()` before checking status — `execution_status` uses a cached value and won't update automatically.
 
 ```python
+import time
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+
 with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
     llm = workspace.get_llm()
     agent = get_default_agent(llm=llm, cli_mode=True)
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("Run a long analysis task")
+    # Conversation is now running asynchronously in the agent server.
 
-    # Start conversations without blocking
-    conv1 = Conversation(agent=agent, workspace=workspace)
-    conv1.send_message("Run the weekly security scan on repo-A")
+    # Do other work here while conversation runs...
 
-    conv2 = Conversation(agent=agent, workspace=workspace)
-    conv2.send_message("Run the weekly security scan on repo-B")
+    # Wait until the conversation reaches a terminal state.
+    while True:
+        time.sleep(5)
+        conversation.refresh_from_server()
+        if conversation.execution_status.is_terminal():
+            break
 
-    # Exit immediately — conversations continue running in the agent server.
-    # The completion callback fires now (run marked done before conversations finish).
+    conversation.close()
+# Callback fires here — after the conversation has finished.
 ```
+
+#### Pattern 4: Deferred callback via stop hook
+
+For cases where the automation script needs to exit while a conversation is still running, use a `stop` hook to fire the completion callback from within the agent server when the conversation finishes.
+
+The `stop` hook runs a shell command when the agent stops. The agent server's environment includes `AUTOMATION_CALLBACK_URL`, `AUTOMATION_CALLBACK_API_KEY`, and `AUTOMATION_RUN_ID`, so the hook can call the automation service directly.
+
+```python
+from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher
+
+# Shell command that fires the completion callback when the agent stops.
+# Runs inside the agent server — env vars are available at hook execution time.
+stop_hook = HookConfig(
+    stop=[
+        HookMatcher(hooks=[
+            HookDefinition(
+                command=(
+                    'curl -sf -X POST "$AUTOMATION_CALLBACK_URL" '
+                    '-H "Authorization: Bearer $AUTOMATION_CALLBACK_API_KEY" '
+                    '-H "Content-Type: application/json" '
+                    '-d \'{"status":"COMPLETED","run_id":"$AUTOMATION_RUN_ID"}\' || true'
+                )
+            )
+        ])
+    ]
+)
+
+with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+    llm = workspace.get_llm()
+    agent = get_default_agent(llm=llm, cli_mode=True)
+    conversation = Conversation(agent=agent, workspace=workspace, hook_config=stop_hook)
+    conversation.send_message("Do some long-running work")
+    # Don't call run() — the conversation runs asynchronously.
+    # When the agent stops, the stop hook will fire the callback.
+# RemoteWorkspace.__exit__ also fires a callback here (on script exit).
+# The automation service should handle receiving two callbacks for the same run.
+```
+
+> **Note:** When using the stop hook pattern, the automation service receives two completion callbacks — one from `RemoteWorkspace.__exit__` when the script exits, and one from the stop hook when the conversation finishes. Ensure your automation service handles duplicate callbacks gracefully.
 
 ---
 
@@ -353,7 +402,8 @@ The automation service injects these environment variables into every run:
 | `OH_INTERNAL_SERVER_URL` | — | URL of the agent server the script is running inside. Use as `host` for `RemoteWorkspace` (fallback: `http://localhost:60000`) |
 | `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for authenticating with the agent server. Use as `api_key` for `RemoteWorkspace` |
 | `AUTOMATION_EVENT_PAYLOAD` | — | JSON object with trigger context: `automation_id`, `automation_name`, `trigger` type, and (for webhook runs) the raw event payload |
-| `AUTOMATION_CALLBACK_URL` | — | URL that `RemoteWorkspace.__exit__` POSTs to, marking the run complete. Set automatically — do not call manually unless you bypass `RemoteWorkspace` |
+| `AUTOMATION_CALLBACK_URL` | — | URL that `RemoteWorkspace.__exit__` POSTs to, marking the run complete. Also available to stop hooks for deferred callbacks |
+| `AUTOMATION_CALLBACK_API_KEY` | — | Bearer token for authenticating the completion callback POST |
 | `AUTOMATION_RUN_ID` | — | Unique ID for this run, included in the completion callback payload |
 
 > **Note:** `OH_*` variable names are used in local/dev deployments; the plain aliases (`SESSION_API_KEY`) are used in cloud deployments. Always read both with `.get()` — see the code examples above.

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -203,12 +203,12 @@ curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/runs?limit=20" \
 
 When a run is triggered, the automation service uploads your tarball to the agent server, which unpacks it, runs `setup.sh` to install dependencies, then executes your entrypoint. Your script therefore runs **inside the agent server** — not in a separate process.
 
-The agent server exposes an HTTP API (at `OH_INTERNAL_SERVER_URL`) for managing conversations. A **conversation** is an AI agent interaction that can use tools: bash commands, file editing, web browsing, and so on. Your script uses the SDK's `RemoteWorkspace` (pointing to `OH_INTERNAL_SERVER_URL`) to start, monitor, and stop conversations running in that same agent server.
+The agent server exposes an HTTP API (at `AGENT_SERVER_URL`) for managing conversations. A **conversation** is an AI agent interaction that can use tools: bash commands, file editing, web browsing, and so on. Your script uses the SDK's `OpenHandsCloudWorkspace` (pointing to `AGENT_SERVER_URL`) to start, monitor, and stop conversations running in that same agent server.
 
 Key points:
 - **Your script and its conversations share the same agent server.** There is no network hop to a remote service.
 - **Conversations are asynchronous.** You can fire one and continue, fire several concurrently, or start none at all (e.g. if your script fetches external data and decides no action is needed).
-- **The completion callback** is sent by `RemoteWorkspace.__exit__` when the `with` block exits, telling the automation service the run is done. For async patterns, defer exiting until the conversation is in the desired state.
+- **The completion callback** is sent by `OpenHandsCloudWorkspace.__exit__` when the `with` block exits, telling the automation service the run is done. For async patterns, defer exiting until the conversation is in the desired state.
 - **LLM config and secrets** are fetched from the agent server (`workspace.get_llm()`, `workspace.get_secrets()`), so your script does not need to supply its own credentials.
 
 **SDK Documentation:** https://docs.openhands.dev/sdk
@@ -236,20 +236,20 @@ uv pip install -q openhands-sdk openhands-workspace openhands-tools
 import os
 
 from openhands.sdk import Conversation
-from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
+from openhands.workspace import OpenHandsCloudWorkspace
 
-# OH_INTERNAL_SERVER_URL points to the agent server this script is running inside.
+# AGENT_SERVER_URL is set by the automation service for the agent server URL.
 # SESSION_API_KEY / OH_SESSION_API_KEYS_0 authenticate against that server.
 api_key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
-host = os.environ.get("OH_INTERNAL_SERVER_URL", "http://localhost:60000")
+api_url = os.environ.get("AGENT_SERVER_URL", "")
 
-# RemoteWorkspace connects back to the agent server to manage conversations.
+# OpenHandsCloudWorkspace connects back to the agent server to manage conversations.
 # __exit__ sends the completion callback to the automation service.
-with RemoteWorkspace(
-    host=host,
-    api_key=api_key,
-    working_dir="/workspace",
+with OpenHandsCloudWorkspace(
+    local_agent_server_mode=True,
+    cloud_api_url=api_url,
+    cloud_api_key=api_key,
 ) as workspace:
     # LLM config and secrets come from the agent server's persisted settings —
     # no credentials need to be embedded in the script.
@@ -267,7 +267,7 @@ with RemoteWorkspace(
     conversation.send_message("Your automation prompt here")
     conversation.run()
     conversation.close()
-# RemoteWorkspace.__exit__ fires the completion callback here.
+# OpenHandsCloudWorkspace.__exit__ fires the completion callback here.
 ```
 
 ### Conversation Persistence
@@ -313,7 +313,7 @@ if not alerts:
     print("No alerts — nothing to do.")
 else:
     # Only now do we spin up an agent conversation
-    with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+    with OpenHandsCloudWorkspace(local_agent_server_mode=True, cloud_api_url=api_url, cloud_api_key=api_key) as workspace:
         llm = workspace.get_llm()
         agent = get_default_agent(llm=llm, cli_mode=True)
         conversation = Conversation(agent=agent, workspace=workspace)
@@ -332,7 +332,7 @@ Start a conversation without blocking, do other work, then poll until the conver
 import time
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 
-with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+with OpenHandsCloudWorkspace(local_agent_server_mode=True, cloud_api_url=api_url, cloud_api_key=api_key) as workspace:
     llm = workspace.get_llm()
     agent = get_default_agent(llm=llm, cli_mode=True)
     conversation = Conversation(agent=agent, workspace=workspace)
@@ -378,18 +378,18 @@ stop_hook = HookConfig(
     ]
 )
 
-with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+with OpenHandsCloudWorkspace(local_agent_server_mode=True, cloud_api_url=api_url, cloud_api_key=api_key) as workspace:
     llm = workspace.get_llm()
     agent = get_default_agent(llm=llm, cli_mode=True)
     conversation = Conversation(agent=agent, workspace=workspace, hook_config=stop_hook)
     conversation.send_message("Do some long-running work")
     # Don't call run() — the conversation runs asynchronously.
     # When the agent stops, the stop hook will fire the callback.
-# RemoteWorkspace.__exit__ also fires a callback here (on script exit).
+# OpenHandsCloudWorkspace.__exit__ also fires a callback here (on script exit).
 # The automation service should handle receiving two callbacks for the same run.
 ```
 
-> **Note:** When using the stop hook pattern, the automation service receives two completion callbacks — one from `RemoteWorkspace.__exit__` when the script exits, and one from the stop hook when the conversation finishes. Ensure your automation service handles duplicate callbacks gracefully.
+> **Note:** When using the stop hook pattern, the automation service receives two completion callbacks — one from `OpenHandsCloudWorkspace.__exit__` when the script exits, and one from the stop hook when the conversation finishes. Ensure your automation service handles duplicate callbacks gracefully.
 
 ---
 
@@ -399,14 +399,14 @@ The automation service injects these environment variables into every run:
 
 | Variable | Alt name | Description |
 |----------|----------|-------------|
-| `OH_INTERNAL_SERVER_URL` | — | URL of the agent server the script is running inside. Use as `host` for `RemoteWorkspace` (fallback: `http://localhost:60000`) |
-| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for authenticating with the agent server. Use as `api_key` for `RemoteWorkspace` |
+| `AGENT_SERVER_URL` | — | URL of the agent server the script is running inside. Use as `cloud_api_url` for `OpenHandsCloudWorkspace` |
+| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for authenticating with the agent server. Use as `cloud_api_key` for `OpenHandsCloudWorkspace` |
 | `AUTOMATION_EVENT_PAYLOAD` | — | JSON object with trigger context: `automation_id`, `automation_name`, `trigger` type, and (for webhook runs) the raw event payload |
-| `AUTOMATION_CALLBACK_URL` | — | URL that `RemoteWorkspace.__exit__` POSTs to, marking the run complete. Also available to stop hooks for deferred callbacks |
+| `AUTOMATION_CALLBACK_URL` | — | URL that `OpenHandsCloudWorkspace.__exit__` POSTs to, marking the run complete. Also available to stop hooks for deferred callbacks |
 | `AUTOMATION_CALLBACK_API_KEY` | — | Bearer token for authenticating the completion callback POST |
 | `AUTOMATION_RUN_ID` | — | Unique ID for this run, included in the completion callback payload |
 
-> **Note:** `OH_*` variable names are used in local/dev deployments; the plain aliases (`SESSION_API_KEY`) are used in cloud deployments. Always read both with `.get()` — see the code examples above.
+> **Note:** The session API key has two names depending on the deployment: `SESSION_API_KEY` (cloud) and `OH_SESSION_API_KEYS_0` (local/dev). Always read both with `.get()` — see the code examples above.
 
 ---
 
@@ -449,19 +449,19 @@ import os
 import json
 
 from openhands.sdk import Conversation
-from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
+from openhands.workspace import OpenHandsCloudWorkspace
 
 payload = json.loads(os.environ.get('AUTOMATION_EVENT_PAYLOAD', '{}'))
 print(f"Running: {payload.get('automation_name')}")
 
 api_key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
-host = os.environ.get("OH_INTERNAL_SERVER_URL", "http://localhost:60000")
+api_url = os.environ.get("AGENT_SERVER_URL", "")
 
-with RemoteWorkspace(
-    host=host,
-    api_key=api_key,
-    working_dir="/workspace",
+with OpenHandsCloudWorkspace(
+    local_agent_server_mode=True,
+    cloud_api_url=api_url,
+    cloud_api_key=api_key,
 ) as workspace:
     llm = workspace.get_llm()
     agent = get_default_agent(llm=llm, cli_mode=True)

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -15,8 +15,11 @@ This file contains detailed documentation for creating custom automations with u
 2. [Creating Custom Automations](#creating-an-automation)
 3. [Managing Automations](#managing-automations)
 4. [Writing Automation Code](#writing-automation-code)
+   - [SDK-based Scripts](#sdk-based-scripts) — AI agent conversations
+   - [Deterministic Script (No LLM)](#deterministic-script-no-llm) — pure Python stdlib
 5. [Environment Variables](#environment-variables)
 6. [Validation Rules](#validation-rules)
+7. [Complete Examples](#complete-examples)
 
 ---
 
@@ -34,13 +37,10 @@ tar -czf automation.tar.gz -C /path/to/your/code .
 
 ```
 automation.tar.gz
-├── main.py           # Your entrypoint script (uses SDK)
-├── setup.sh          # Setup script (REQUIRED: installs uv + SDK)
-├── pyproject.toml    # Optional: for uv/poetry dependency management
+├── main.py           # Your entrypoint script
+├── setup.sh          # Optional: install dependencies before entrypoint runs
 └── requirements.txt  # Optional: additional dependencies
 ```
-
-**Note:** The `setup.sh` script is critical - it must install `uv` and the OpenHands SDK packages before your entrypoint runs.
 
 ### Validate Before Packaging
 
@@ -52,6 +52,7 @@ bash -n setup.sh                 # validates shell syntax without executing
 ```
 
 Fix any errors reported before proceeding to the next step.
+
 
 ### Upload the Tarball
 
@@ -220,13 +221,13 @@ Key points:
 - **Your script and its conversations share the same agent server.** There is no network hop to a remote service.
 - **Conversations are asynchronous.** You can fire one and continue, fire several concurrently, or start none at all (e.g. if your script fetches external data and decides no action is needed).
 - **The completion callback** is sent by `OpenHandsCloudWorkspace.__exit__` when the `with` block exits, telling the automation service the run is done. For async patterns, defer exiting until the conversation is in the desired state.
-- **LLM config and secrets** are fetched from the agent server (`workspace.get_llm()`, `workspace.get_secrets()`), so your script does not need to supply its own credentials.
+- **Secrets** stored in the agent server are accessed via its REST API: `GET {AGENT_SERVER_URL}/api/settings/secrets/{name}` with `X-Session-API-Key: {SESSION_API_KEY}`. SDK scripts can also call `workspace.get_llm()` to get the configured LLM.
 
 **SDK Documentation:** https://docs.openhands.dev/sdk
 
-### Required Dependencies
+### SDK-based Scripts
 
-Your automation must install the OpenHands SDK packages. Use a `setup.sh` script:
+For scripts that start AI agent conversations, install the SDK packages in `setup.sh`:
 
 ```bash
 #!/bin/bash
@@ -262,19 +263,9 @@ with OpenHandsCloudWorkspace(
     cloud_api_url=api_url,
     cloud_api_key=api_key,
 ) as workspace:
-    # LLM config and secrets come from the agent server's persisted settings —
-    # no credentials need to be embedded in the script.
     llm = workspace.get_llm()
-    secrets = workspace.get_secrets()
-
-    # Start a conversation (AI agent with tool access) in the agent server.
     agent = get_default_agent(llm=llm, cli_mode=True)
     conversation = Conversation(agent=agent, workspace=workspace)
-
-    if secrets:
-        conversation.update_secrets(secrets)
-
-    # Run the conversation synchronously and wait for it to finish.
     conversation.send_message("Your automation prompt here")
     conversation.run()
     conversation.close()
@@ -404,20 +395,64 @@ with OpenHandsCloudWorkspace(local_agent_server_mode=True, cloud_api_url=api_url
 
 ---
 
+### Deterministic Script (No LLM)
+
+For tasks that don't need AI reasoning — sending a Slack message, calling an API, rotating from a fixed list — skip the SDK entirely. Use pure Python stdlib with `python3 main.py` as the entrypoint and no `setup.sh`.
+
+**Accessing secrets** — custom secrets are not injected into the subprocess environment automatically. Fetch them via the agent server's REST API:
+
+```python
+import os, urllib.request
+
+def get_secret(name: str) -> str:
+    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
+    key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
+    req = urllib.request.Request(
+        f"{url}/api/settings/secrets/{name}",
+        headers={"X-Session-API-Key": key},
+    )
+    with urllib.request.urlopen(req) as r:
+        return r.read().decode().strip()
+```
+
+**Firing the callback** — without the SDK, POST to `AUTOMATION_CALLBACK_URL` before exiting. If you never fire the callback the run stays `RUNNING` until the watchdog marks it `FAILED`.
+
+```python
+import json, os, urllib.request
+
+def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
+    url = os.environ.get("AUTOMATION_CALLBACK_URL", "")
+    if not url:
+        return
+    body = {"status": status, "run_id": os.environ.get("AUTOMATION_RUN_ID", "")}
+    if error:
+        body["error"] = error
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {os.environ.get('AUTOMATION_CALLBACK_API_KEY', '')}",
+    })
+    try:
+        urllib.request.urlopen(req)
+    except Exception as e:
+        print(f"Callback error (non-fatal): {e}")
+```
+
+---
+
 ## Environment Variables
 
 The automation service injects these environment variables into every run:
 
 | Variable | Alt name | Description |
 |----------|----------|-------------|
-| `AGENT_SERVER_URL` | — | URL of the agent server the script is running inside. Use as `cloud_api_url` for `OpenHandsCloudWorkspace` |
-| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for authenticating with the agent server. Use as `cloud_api_key` for `OpenHandsCloudWorkspace` |
-| `AUTOMATION_EVENT_PAYLOAD` | — | JSON object with trigger context: `automation_id`, `automation_name`, `trigger` type, and (for webhook runs) the raw event payload |
-| `AUTOMATION_CALLBACK_URL` | — | URL that `OpenHandsCloudWorkspace.__exit__` POSTs to, marking the run complete. Also available to stop hooks for deferred callbacks |
-| `AUTOMATION_CALLBACK_API_KEY` | — | Bearer token for authenticating the completion callback POST |
-| `AUTOMATION_RUN_ID` | — | Unique ID for this run, included in the completion callback payload |
+| `AGENT_SERVER_URL` | — | Agent server URL. Used as `cloud_api_url` for `OpenHandsCloudWorkspace`, and as the base URL for secret lookups |
+| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key. Used as `cloud_api_key` for `OpenHandsCloudWorkspace`, and as `X-Session-API-Key` for REST API calls |
+| `AUTOMATION_CALLBACK_URL` | — | POST here to mark the run complete (done automatically by `OpenHandsCloudWorkspace.__exit__`, or manually in no-LLM scripts) |
+| `AUTOMATION_CALLBACK_API_KEY` | — | Bearer token for the completion callback POST |
+| `AUTOMATION_RUN_ID` | — | Run ID to include in the completion callback payload |
+| `AUTOMATION_EVENT_PAYLOAD` | — | JSON with trigger context: `automation_id`, `automation_name`, `trigger` type, and (for webhook runs) the raw event payload |
 
-> **Note:** The session API key has two names depending on the deployment: `SESSION_API_KEY` (cloud) and `OH_SESSION_API_KEYS_0` (local/dev). Always read both with `.get()` — see the code examples above.
+> **Note:** The session API key has two names: `SESSION_API_KEY` (cloud) and `OH_SESSION_API_KEYS_0` (local/dev). Always read both — see the code examples above.
 
 ---
 
@@ -432,7 +467,76 @@ The automation service injects these environment variables into every run:
 
 ---
 
-## Complete Example
+## Complete Examples
+
+### No LLM (deterministic)
+
+```bash
+OPENHANDS_HOST="https://app.all-hands.dev"
+mkdir my-automation && cd my-automation
+
+cat > main.py << 'PYEOF'
+"""Post a random quote to Slack — no LLM, no SDK."""
+import json, os, random, sys, urllib.request
+
+QUOTES = ["Stay hungry, stay foolish.", "Done is better than perfect."]
+CHANNEL = "C12345678"
+
+def get_secret(name):
+    url = os.environ.get("AGENT_SERVER_URL", "").rstrip("/")
+    key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
+    req = urllib.request.Request(f"{url}/api/settings/secrets/{name}",
+        headers={"X-Session-API-Key": key})
+    with urllib.request.urlopen(req) as r:
+        return r.read().decode().strip()
+
+def fire_callback(status="COMPLETED", error=None):
+    url = os.environ.get("AUTOMATION_CALLBACK_URL", "")
+    if not url: return
+    body = {"status": status, "run_id": os.environ.get("AUTOMATION_RUN_ID", "")}
+    if error: body["error"] = error
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {os.environ.get('AUTOMATION_CALLBACK_API_KEY', '')}",
+    })
+    try: urllib.request.urlopen(req)
+    except Exception as e: print(f"Callback error: {e}")
+
+try:
+    token = get_secret("SLACK_BOT_TOKEN")
+    msg = random.choice(QUOTES)
+    req = urllib.request.Request("https://slack.com/api/chat.postMessage",
+        data=json.dumps({"channel": CHANNEL, "text": msg}).encode(),
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {token}"})
+    result = json.loads(urllib.request.urlopen(req).read())
+    if not result.get("ok"): raise RuntimeError(result.get("error"))
+    print(f"Posted: {msg}")
+    fire_callback("COMPLETED")
+except Exception as e:
+    print(f"ERROR: {e}", file=sys.stderr)
+    fire_callback("FAILED", str(e))
+    sys.exit(1)
+PYEOF
+
+tar -czf ../my-automation.tar.gz .
+
+TARBALL_PATH=$(curl -s -X POST "${OPENHANDS_HOST}/api/automation/v1/uploads?name=my-automation" \
+  -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
+  -H "Content-Type: application/gzip" \
+  --data-binary @../my-automation.tar.gz | jq -r '.tarball_path')
+
+curl -X POST "${OPENHANDS_HOST}/api/automation/v1" \
+  -H "Authorization: Bearer ${OPENHANDS_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"name\": \"Daily Quote\",
+    \"trigger\": {\"type\": \"cron\", \"schedule\": \"0 9 * * *\", \"timezone\": \"UTC\"},
+    \"tarball_path\": \"$TARBALL_PATH\",
+    \"entrypoint\": \"python3 main.py\"
+  }"
+```
+
+### SDK Script (AI conversations)
 
 ```bash
 # 0. Set the API host (use value from <HOST> in system prompt, or default)
@@ -527,3 +631,14 @@ The upload limit is 1MB. Reduce your tarball size by:
 1. Check if the automation is enabled (`enabled: true`)
 2. Verify the cron schedule is correct
 3. Check for validation errors in the response
+
+### Run fails instantly with `error_detail: null`
+The script sent `fire_callback("FAILED")` immediately — before doing meaningful work. Common causes:
+- A required secret was empty: the `get_secret()` call failed or returned nothing
+- A missing/wrong `AGENT_SERVER_URL` or `SESSION_API_KEY`
+- An import error in the entrypoint
+
+Add `"error": str(exc)` to your `fire_callback("FAILED", ...)` call so `error_detail` is populated.
+
+### Run stays `RUNNING` indefinitely, then fails
+The completion callback was never fired. Every code path in your script must call `fire_callback()` — including exception handlers.

--- a/skills/openhands-automation/references/custom-automation.md
+++ b/skills/openhands-automation/references/custom-automation.md
@@ -199,10 +199,17 @@ curl "${OPENHANDS_HOST}/api/automation/v1/{automation_id}/runs?limit=20" \
 
 ## Writing Automation Code
 
-Automations run inside OpenHands Cloud sandboxes and use the **Software Agent SDK** to:
-- Create and run AI agent conversations
-- Access your configured LLM settings
-- Use your stored secrets
+### How Execution Works
+
+When a run is triggered, the automation service uploads your tarball to the agent server, which unpacks it, runs `setup.sh` to install dependencies, then executes your entrypoint. Your script therefore runs **inside the agent server** — not in a separate process.
+
+The agent server exposes an HTTP API (at `OH_INTERNAL_SERVER_URL`) for managing conversations. A **conversation** is an AI agent interaction that can use tools: bash commands, file editing, web browsing, and so on. Your script uses the SDK's `RemoteWorkspace` (pointing to `OH_INTERNAL_SERVER_URL`) to start, monitor, and stop conversations running in that same agent server.
+
+Key points:
+- **Your script and its conversations share the same agent server.** There is no network hop to a remote service.
+- **Conversations are asynchronous.** You can fire one and continue, fire several concurrently, or start none at all (e.g. if your script fetches external data and decides no action is needed).
+- **The completion callback** is sent by `RemoteWorkspace.__exit__` when the `with` block exits, telling the automation service the run is done. For async patterns, defer exiting until the conversation is in the desired state.
+- **LLM config and secrets** are fetched from the agent server (`workspace.get_llm()`, `workspace.get_secrets()`), so your script does not need to supply its own credentials.
 
 **SDK Documentation:** https://docs.openhands.dev/sdk
 
@@ -232,73 +239,124 @@ from openhands.sdk import Conversation
 from openhands.sdk.workspace import RemoteWorkspace
 from openhands.tools.preset.default import get_default_agent
 
-# Session API key and agent server URL are injected by the automation runtime.
+# OH_INTERNAL_SERVER_URL points to the agent server this script is running inside.
+# SESSION_API_KEY / OH_SESSION_API_KEYS_0 authenticate against that server.
 api_key = os.environ.get("SESSION_API_KEY") or os.environ.get("OH_SESSION_API_KEYS_0", "")
 host = os.environ.get("OH_INTERNAL_SERVER_URL", "http://localhost:60000")
 
-# Use RemoteWorkspace to connect to the sandbox's local agent server
+# RemoteWorkspace connects back to the agent server to manage conversations.
+# __exit__ sends the completion callback to the automation service.
 with RemoteWorkspace(
     host=host,
     api_key=api_key,
     working_dir="/workspace",
 ) as workspace:
-    # Get your configured LLM from the agent server's persisted settings
+    # LLM config and secrets come from the agent server's persisted settings —
+    # no credentials need to be embedded in the script.
     llm = workspace.get_llm()
-    
-    # Optionally get your stored secrets
     secrets = workspace.get_secrets()
-    
-    # Create an agent and conversation
+
+    # Start a conversation (AI agent with tool access) in the agent server.
     agent = get_default_agent(llm=llm, cli_mode=True)
     conversation = Conversation(agent=agent, workspace=workspace)
-    
-    # Inject secrets if available
+
     if secrets:
         conversation.update_secrets(secrets)
-    
-    # Send a prompt and run the conversation
+
+    # Run the conversation synchronously and wait for it to finish.
     conversation.send_message("Your automation prompt here")
     conversation.run()
     conversation.close()
+# RemoteWorkspace.__exit__ fires the completion callback here.
 ```
 
-### Sandbox Lifecycle & Conversation Persistence
+### Conversation Persistence
 
-By default, the sandbox is **kept alive** after the automation run completes. This means:
-- Users can view the conversation history in the OpenHands UI after the run
-- Users can "continue" or "log into" the conversation to interact further
-- The sandbox and its state persist until it times out or is manually deleted
-
-The `Conversation` constructor accepts a `delete_on_close` parameter that controls whether the conversation resources are cleaned up when `close()` is called:
+Conversations started during a run remain accessible in the OpenHands UI after the run completes — users can view the history and continue interacting. By default, `Conversation` does not delete the conversation on close:
 
 ```python
-# Default: delete_on_close=False for remote conversations (sandbox kept alive)
+# Default: conversation persists after close (users can view/continue it)
 conversation = Conversation(agent=agent, workspace=workspace)
 
-# Explicitly keep the conversation alive (same as default for remote)
+# Explicitly persist (same as default)
 conversation = Conversation(agent=agent, workspace=workspace, delete_on_close=False)
 
-# Clean up conversation resources on close (sandbox still persists)
+# Delete conversation resources on close
 conversation = Conversation(agent=agent, workspace=workspace, delete_on_close=True)
 ```
 
-Sandbox lifecycle in automations is managed entirely by the automation service — not the workspace. The automation service defaults to keeping sandboxes alive.
+The agent server itself persists until it times out or is manually deleted; this is managed by the automation service, not by the workspace.
+
+### Conversation Patterns
+
+#### Pattern 1: Synchronous (run and wait)
+
+The simplest pattern — start a conversation, block until it finishes, then exit (firing the callback).
+
+```python
+conversation.send_message("Analyze the latest deployment logs and summarise any errors")
+conversation.run()   # blocks until the agent finishes or times out
+conversation.close()
+```
+
+#### Pattern 2: Conditional (fetch data first, then decide)
+
+A common pattern where the script queries an external source and only starts a conversation if needed.
+
+```python
+import httpx
+
+response = httpx.get("https://api.example.com/alerts", headers={"Authorization": f"Bearer {token}"})
+alerts = response.json().get("alerts", [])
+
+if not alerts:
+    print("No alerts — nothing to do.")
+else:
+    # Only now do we spin up an agent conversation
+    with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+        llm = workspace.get_llm()
+        agent = get_default_agent(llm=llm, cli_mode=True)
+        conversation = Conversation(agent=agent, workspace=workspace)
+        conversation.send_message(f"Investigate these alerts and open GitHub issues: {alerts}")
+        conversation.run()
+        conversation.close()
+```
+
+#### Pattern 3: Fire and continue (asynchronous)
+
+Start one or more conversations without blocking, then do other work. The completion callback fires when the `with` block exits — **not** when the conversations finish. Use this only when you don't need to wait for conversation results.
+
+```python
+with RemoteWorkspace(host=host, api_key=api_key, working_dir="/workspace") as workspace:
+    llm = workspace.get_llm()
+    agent = get_default_agent(llm=llm, cli_mode=True)
+
+    # Start conversations without blocking
+    conv1 = Conversation(agent=agent, workspace=workspace)
+    conv1.send_message("Run the weekly security scan on repo-A")
+
+    conv2 = Conversation(agent=agent, workspace=workspace)
+    conv2.send_message("Run the weekly security scan on repo-B")
+
+    # Exit immediately — conversations continue running in the agent server.
+    # The completion callback fires now (run marked done before conversations finish).
+```
 
 ---
 
 ## Environment Variables
 
-Your automation script receives these environment variables:
+The automation service injects these environment variables into every run:
 
-| Variable | Cloud alias | Description |
-|----------|-------------|-------------|
-| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key — passed as `api_key` to `RemoteWorkspace` |
-| `OH_INTERNAL_SERVER_URL` | — | Agent server URL — passed as `host` to `RemoteWorkspace` (fallback: `http://localhost:60000`) |
-| `AUTOMATION_EVENT_PAYLOAD` | — | JSON with trigger info, automation ID, and name |
+| Variable | Alt name | Description |
+|----------|----------|-------------|
+| `OH_INTERNAL_SERVER_URL` | — | URL of the agent server the script is running inside. Use as `host` for `RemoteWorkspace` (fallback: `http://localhost:60000`) |
+| `OH_SESSION_API_KEYS_0` | `SESSION_API_KEY` | Session API key for authenticating with the agent server. Use as `api_key` for `RemoteWorkspace` |
+| `AUTOMATION_EVENT_PAYLOAD` | — | JSON object with trigger context: `automation_id`, `automation_name`, `trigger` type, and (for webhook runs) the raw event payload |
+| `AUTOMATION_CALLBACK_URL` | — | URL that `RemoteWorkspace.__exit__` POSTs to, marking the run complete. Set automatically — do not call manually unless you bypass `RemoteWorkspace` |
+| `AUTOMATION_RUN_ID` | — | Unique ID for this run, included in the completion callback payload |
 
-> **Note:** `OH_SESSION_API_KEYS_0` is used in local/dev deployments; `SESSION_API_KEY` is used in cloud deployments. Always read both with `.get()` — see the code examples above.
-
-**Note:** The automation framework automatically handles run completion callbacks.
+> **Note:** `OH_*` variable names are used in local/dev deployments; the plain aliases (`SESSION_API_KEY`) are used in cloud deployments. Always read both with `.get()` — see the code examples above.
 
 ---
 

--- a/skills/openhands-sdk/SKILL.md
+++ b/skills/openhands-sdk/SKILL.md
@@ -187,6 +187,7 @@ Source: [`examples/`](https://github.com/OpenHands/software-agent-sdk/tree/main/
 - [`47_defense_in_depth_security.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/47_defense_in_depth_security.py)
 - [`48_conversation_fork.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/48_conversation_fork.py)
 - [`49_switch_llm_tool.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/49_switch_llm_tool.py)
+- [`50_async_cancellation.py`](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/50_async_cancellation.py)
 
 ### [`02_remote_agent_server/`](https://github.com/OpenHands/software-agent-sdk/tree/main/examples/02_remote_agent_server)
 


### PR DESCRIPTION
## Summary

Three related improvements to the OpenHands Automations skill and a minor SDK skill update.

### 1. New: Architecture section in SKILL.md

Added a two-component model explanation that was previously missing:
- **Automation Service** — manages scheduling, webhook dispatch, and completion callbacks
- **Agent Server** — the runtime where scripts and conversations execute; receives tarballs from the automation service on each trigger

This context is essential for understanding how custom scripts interact with their environment.

### 2. New: No-LLM Script Helpers in SKILL.md

Added two copy-paste-ready stdlib-only functions (`get_secret` and `fire_callback`) for deterministic scripts that skip the SDK entirely. These handle both local/dev (`OH_INTERNAL_SERVER_URL`, `OH_SESSION_API_KEYS_0`) and cloud (`AGENT_SERVER_URL`, `SESSION_API_KEY`) deployments.

Also added instant-recognition patterns so the agent can reliably identify tasks that are always deterministic (Slack messages, healthcheck pings, rotating from a fixed list) and route them to the no-LLM path.

### 3. Expanded `custom-automation.md`

- **How Execution Works** — new section explaining that the script runs inside the agent server and connects back to it; conversations are asynchronous
- **Four Conversation Patterns**: synchr- **Four Conversation Patterns**: synchr- **Four Conversation Patterns**: synchr- **Four Conversation Patterns**: synchr- **Four Convhook
- **Deterministic Script (No LLM)** — full section with `get_secret` and `fire_callback` helpers and usage guidance
- **Updated Environment Variables table** — added `AUTOMATION_CALLBACK_URL`, `AUTOMATION_CALLBACK_API_KEY`, `AUTOMATION_RUN_ID`; renamed `RUNTIME_URL` → `AGENT_SERVER_URL` to match the actual injected variable name
- **Validate Before Packaging** — added `py_compile` and `bash -n` pre-packaging checks
- **New no-LLM complete example** — end-to-end Slack quote poster using only stdlib
- **New troubleshooting entries** — `Run fails instantly` and `Run stays RUNNING indefinitely`
- Renamed "Sandbo- Renamed "Sandbo- Renamed "Sandbo- Rh accurate callback description

### 4. Minor: openhands-sdk/SKILL.md

Added link to SDK example `50_async_cancellation.py`.

---

_This PR was updated by an AI agent (OpenHands) on behalf of the user._