### PR TITLE
fix(github-pr-review): add explicit guidance on when to use APPROVE event

### DIFF
--- a/skills/github-pr-review/SKILL.md
+++ b/skills/github-pr-review/SKILL.md
@@ -56,11 +56,21 @@ gh api -X POST repos/{owner}/{repo}/pulls/{pr_number}/reviews --input /tmp/revie
 | Parameter | Description |
 |-----------|-------------|
 | `commit_id` | Commit SHA to comment on (use `git rev-parse HEAD`) |
-| `event` | `COMMENT`, `APPROVE`, or `REQUEST_CHANGES` |
+| `event` | `APPROVE`, `COMMENT`, or `REQUEST_CHANGES` (see below) |
 | `path` | File path as shown in the diff |
 | `line` | Line number in the NEW version (right side of diff) |
 | `side` | `RIGHT` for new/added lines, `LEFT` for deleted lines |
 | `body` | Comment text with priority label |
+
+### Choosing the `event` Value
+
+| Event | When to use |
+|-------|-------------|
+| `APPROVE` | No issues found, or only 🟡 suggestions that are non-blocking |
+| `COMMENT` | You have 🟠 Important feedback but it's not a hard blocker |
+| `REQUEST_CHANGES` | There are 🔴 Critical issues that **must** be fixed before merge |
+
+**Default to `APPROVE`** when the code is correct and merge-ready. Use `COMMENT` or `REQUEST_CHANGES` only when there are actionable issues that warrant it.
 
 ### Multi-Line Comments
 
@@ -145,4 +155,4 @@ curl -X POST \
 5. Do NOT post comments for code that is acceptable — only comment when action is needed
 6. Use suggestion syntax for concrete code changes
 7. Keep the review body brief (details go in inline comments)
-8. If no issues: post a short approval message with no inline comments
+8. If no issues: use `"event": "APPROVE"` with a short approval message and no inline comments


### PR DESCRIPTION
## Problem

The `github-pr-review` skill's SKILL.md has its example JSON template with `"event": "COMMENT"`, and the summary says "post a short approval message" without specifying which event type to use. Agents follow the template literally and default to `COMMENT` even when the review is fully positive with no issues — the PR never gets an actual `APPROVE`.

Observed on [OpenHands/software-agent-sdk#3393](https://github.com/OpenHands/software-agent-sdk/pull/3393): the bot posted a glowing review ("✅ Worth merging", no concerns) but submitted it as `COMMENTED` instead of `APPROVED`.

## Changes

- **Add "Choosing the `event` Value" section** — a table mapping `APPROVE`/`COMMENT`/`REQUEST_CHANGES` to the corresponding review outcomes (aligned with the existing priority labels)
- **State "Default to `APPROVE`"** when the code is correct and merge-ready
- **Update summary item 8** to explicitly say `"event": "APPROVE"`
- **Reorder event values** in the parameters table to list `APPROVE` first

No changes to the example JSON template itself (it shows the `COMMENT` case with inline comments, which is the common path). The new section makes the decision criteria explicit.

_This PR was created by an AI agent (OpenHands) on behalf of the user._