### PR TITLE
feat: add credential helperText and helperLink to all integration fields

### DIFF
--- a/integrations/catalog/airtable.json
+++ b/integrations/catalog/airtable.json
@@ -30,7 +30,9 @@
             "key": "AIRTABLE_API_KEY",
             "label": "Airtable personal access token",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "Personal access token from your Airtable account.",
+            "helperLink": "https://airtable.com/create/tokens"
           }
         ]
       },

--- a/integrations/catalog/apify.json
+++ b/integrations/catalog/apify.json
@@ -29,7 +29,9 @@
             "key": "APIFY_TOKEN",
             "label": "Apify token",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API token from your Apify account settings.",
+            "helperLink": "https://console.apify.com/account/integrations"
           }
         ]
       },

--- a/integrations/catalog/brave-search.json
+++ b/integrations/catalog/brave-search.json
@@ -31,7 +31,7 @@
             "type": "password",
             "required": true,
             "helperText": "API key from the Brave Search API portal.",
-            "helperLink": "https://api.search.brave.com/app/keys"
+            "helperLink": "https://api-dashboard.search.brave.com/app/keys"
           }
         ]
       },

--- a/integrations/catalog/brave-search.json
+++ b/integrations/catalog/brave-search.json
@@ -29,7 +29,9 @@
             "key": "BRAVE_API_KEY",
             "label": "Brave API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from the Brave Search API portal.",
+            "helperLink": "https://api.search.brave.com/app/keys"
           }
         ]
       },

--- a/integrations/catalog/clickhouse.json
+++ b/integrations/catalog/clickhouse.json
@@ -44,7 +44,7 @@
             "type": "password",
             "required": true,
             "helperText": "Password for your ClickHouse user.",
-            "helperLink": "https://clickhouse.com/docs/en/cloud/manage/users-and-roles"
+            "helperLink": "https://clickhouse.com/docs/cloud/security/manage-database-users"
           }
         ]
       },

--- a/integrations/catalog/clickhouse.json
+++ b/integrations/catalog/clickhouse.json
@@ -44,7 +44,7 @@
             "type": "password",
             "required": true,
             "helperText": "Password for your ClickHouse user.",
-            "helperLink": "https://clickhouse.com/docs/cloud/security/manage-database-users"
+            "helperLink": "https://clickhouse.com/docs/operations/access-rights"
           }
         ]
       },

--- a/integrations/catalog/clickhouse.json
+++ b/integrations/catalog/clickhouse.json
@@ -42,7 +42,9 @@
             "key": "CLICKHOUSE_PASSWORD",
             "label": "Password",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "Password for your ClickHouse user.",
+            "helperLink": "https://clickhouse.com/docs/en/cloud/manage/users-and-roles"
           }
         ]
       },

--- a/integrations/catalog/elevenlabs.json
+++ b/integrations/catalog/elevenlabs.json
@@ -28,7 +28,9 @@
             "key": "ELEVENLABS_API_KEY",
             "label": "ElevenLabs API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your ElevenLabs account settings.",
+            "helperLink": "https://elevenlabs.io/app/settings/api-keys"
           }
         ]
       },

--- a/integrations/catalog/exa.json
+++ b/integrations/catalog/exa.json
@@ -30,7 +30,7 @@
             "label": "Exa API key",
             "type": "password",
             "required": true,
-            "helperText": "API key from your Exa API dashboard; see the getting started docs.",
+            "helperText": "API key from your Exa account; see the getting-started guide for setup instructions.",
             "helperLink": "https://exa.ai/docs/reference/getting-started"
           }
         ]

--- a/integrations/catalog/exa.json
+++ b/integrations/catalog/exa.json
@@ -30,7 +30,7 @@
             "label": "Exa API key",
             "type": "password",
             "required": true,
-            "helperText": "API key from your Exa account; see the getting-started guide for setup instructions.",
+            "helperText": "API key from your Exa account.",
             "helperLink": "https://exa.ai/docs/reference/getting-started"
           }
         ]

--- a/integrations/catalog/exa.json
+++ b/integrations/catalog/exa.json
@@ -29,7 +29,9 @@
             "key": "EXA_API_KEY",
             "label": "Exa API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Exa dashboard.",
+            "helperLink": "https://dashboard.exa.ai/"
           }
         ]
       },

--- a/integrations/catalog/exa.json
+++ b/integrations/catalog/exa.json
@@ -30,8 +30,8 @@
             "label": "Exa API key",
             "type": "password",
             "required": true,
-            "helperText": "API key from your Exa dashboard.",
-            "helperLink": "https://dashboard.exa.ai/"
+            "helperText": "API key from your Exa API dashboard; see the getting started docs.",
+            "helperLink": "https://exa.ai/docs/reference/getting-started"
           }
         ]
       },

--- a/integrations/catalog/figma.json
+++ b/integrations/catalog/figma.json
@@ -30,7 +30,9 @@
             "key": "FIGMA_API_KEY",
             "label": "Figma personal access token",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "Personal access token from your Figma account settings.",
+            "helperLink": "https://www.figma.com/developers/api#access-tokens"
           }
         ]
       },

--- a/integrations/catalog/figma.json
+++ b/integrations/catalog/figma.json
@@ -32,7 +32,7 @@
             "type": "password",
             "required": true,
             "helperText": "Personal access token from your Figma account settings.",
-            "helperLink": "https://www.figma.com/developers/api#access-tokens"
+            "helperLink": "https://developers.figma.com/docs/rest-api/authentication/#personal-access-tokens"
           }
         ]
       },

--- a/integrations/catalog/firecrawl.json
+++ b/integrations/catalog/firecrawl.json
@@ -29,7 +29,9 @@
             "key": "FIRECRAWL_API_KEY",
             "label": "Firecrawl API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Firecrawl dashboard.",
+            "helperLink": "https://www.firecrawl.dev/app/api-keys"
           }
         ]
       },

--- a/integrations/catalog/github.json
+++ b/integrations/catalog/github.json
@@ -37,7 +37,9 @@
             "label": "Personal access token",
             "type": "password",
             "placeholder": "github_pat_...",
-            "required": true
+            "required": true,
+            "helperText": "Classic or fine-grained personal access token from GitHub settings.",
+            "helperLink": "https://github.com/settings/personal-access-tokens/new"
           }
         ]
       },

--- a/integrations/catalog/github.json
+++ b/integrations/catalog/github.json
@@ -39,7 +39,7 @@
             "placeholder": "github_pat_...",
             "required": true,
             "helperText": "Classic or fine-grained personal access token from GitHub settings.",
-            "helperLink": "https://github.com/settings/personal-access-tokens/new"
+            "helperLink": "https://github.com/settings/tokens"
           }
         ]
       },

--- a/integrations/catalog/kagi.json
+++ b/integrations/catalog/kagi.json
@@ -28,7 +28,9 @@
             "key": "KAGI_API_KEY",
             "label": "Kagi API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Kagi account settings.",
+            "helperLink": "https://kagi.com/settings?p=api"
           }
         ]
       },

--- a/integrations/catalog/mongodb.json
+++ b/integrations/catalog/mongodb.json
@@ -29,7 +29,9 @@
             "label": "MongoDB connection string",
             "type": "password",
             "placeholder": "mongodb+srv://user:pass@cluster.mongodb.net",
-            "required": true
+            "required": true,
+            "helperText": "Connection string from your MongoDB Atlas cluster.",
+            "helperLink": "https://www.mongodb.com/docs/atlas/connect-to-your-cluster/"
           }
         ]
       },

--- a/integrations/catalog/mongodb.json
+++ b/integrations/catalog/mongodb.json
@@ -31,7 +31,7 @@
             "placeholder": "mongodb+srv://user:pass@cluster.mongodb.net",
             "required": true,
             "helperText": "Connection string from your MongoDB Atlas cluster.",
-            "helperLink": "https://www.mongodb.com/docs/atlas/connect-to-your-cluster/"
+            "helperLink": "https://www.mongodb.com/docs/atlas/connect-to-database-deployment/#connect-with-a-connection-string"
           }
         ]
       },

--- a/integrations/catalog/neon.json
+++ b/integrations/catalog/neon.json
@@ -30,7 +30,9 @@
             "key": "NEON_API_KEY",
             "label": "Neon API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Neon account settings.",
+            "helperLink": "https://neon.tech/docs/manage/api-keys"
           }
         ]
       },

--- a/integrations/catalog/notion.json
+++ b/integrations/catalog/notion.json
@@ -32,7 +32,9 @@
             "label": "Internal integration token",
             "type": "password",
             "placeholder": "ntn_...",
-            "required": true
+            "required": true,
+            "helperText": "Internal integration token from your Notion integrations page.",
+            "helperLink": "https://www.notion.so/profile/integrations"
           }
         ]
       },

--- a/integrations/catalog/obsidian.json
+++ b/integrations/catalog/obsidian.json
@@ -30,7 +30,8 @@
             "label": "Local REST API key",
             "type": "password",
             "required": true,
-            "helperText": "From the Obsidian 'Local REST API' community plugin."
+            "helperText": "From the Obsidian 'Local REST API' community plugin.",
+            "helperLink": "https://github.com/coddingtonbear/obsidian-local-rest-api"
           }
         ]
       },

--- a/integrations/catalog/redis.json
+++ b/integrations/catalog/redis.json
@@ -33,7 +33,8 @@
             "type": "password",
             "placeholder": "redis://localhost:6379",
             "required": true,
-            "helperText": "Appended as --url <redis_url>."
+            "helperText": "Connection URL for your Redis instance. Appended as --url <redis_url>.",
+            "helperLink": "https://redis.io/docs/latest/operate/rs/references/client_references/client_reference_redis-py/#connectionpool"
           }
         ]
       },

--- a/integrations/catalog/redis.json
+++ b/integrations/catalog/redis.json
@@ -34,7 +34,7 @@
             "placeholder": "redis://localhost:6379",
             "required": true,
             "helperText": "Connection URL for your Redis instance. Appended as --url <redis_url>.",
-            "helperLink": "https://redis.io/docs/latest/operate/rs/references/client_references/client_reference_redis-py/#connectionpool"
+            "helperLink": "https://redis.io/docs/latest/develop/clients/redis-py/connect/#connect-to-a-redis-database"
           }
         ]
       },

--- a/integrations/catalog/redis.json
+++ b/integrations/catalog/redis.json
@@ -34,7 +34,7 @@
             "placeholder": "redis://localhost:6379",
             "required": true,
             "helperText": "Connection URL for your Redis instance. Appended as --url <redis_url>.",
-            "helperLink": "https://redis.io/docs/latest/develop/clients/redis-py/connect/#connect-to-a-redis-database"
+            "helperLink": "https://redis.io/docs/latest/operate/rc/databases/connect/"
           }
         ]
       },

--- a/integrations/catalog/resend.json
+++ b/integrations/catalog/resend.json
@@ -28,7 +28,9 @@
             "key": "RESEND_API_KEY",
             "label": "Resend API key",
             "type": "password",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Resend dashboard.",
+            "helperLink": "https://resend.com/api-keys"
           },
           {
             "key": "SENDER_EMAIL_ADDRESS",

--- a/integrations/catalog/slack.json
+++ b/integrations/catalog/slack.json
@@ -31,7 +31,9 @@
             "label": "Bot token",
             "type": "password",
             "placeholder": "xoxb-...",
-            "required": true
+            "required": true,
+            "helperText": "Bot token from your Slack app's OAuth & Permissions page.",
+            "helperLink": "https://api.slack.com/apps"
           },
           {
             "key": "SLACK_TEAM_ID",

--- a/integrations/catalog/supabase.json
+++ b/integrations/catalog/supabase.json
@@ -30,7 +30,8 @@
             "label": "Supabase access token",
             "type": "password",
             "required": true,
-            "helperText": "Personal access token from your Supabase dashboard."
+            "helperText": "Personal access token from your Supabase dashboard.",
+            "helperLink": "https://supabase.com/dashboard/account/tokens"
           }
         ]
       },

--- a/integrations/catalog/tavily.json
+++ b/integrations/catalog/tavily.json
@@ -32,7 +32,9 @@
             "label": "Tavily API key",
             "type": "password",
             "placeholder": "tvly-...",
-            "required": true
+            "required": true,
+            "helperText": "API key from your Tavily dashboard.",
+            "helperLink": "https://app.tavily.com/home"
           }
         ]
       },

--- a/integrations/catalog/tavily.json
+++ b/integrations/catalog/tavily.json
@@ -11,7 +11,7 @@
     "research"
   ],
   "popularityRank": 90,
-  "installHint": "Paste your Tavily API key — the official tavily-mcp package runs via npx.",
+  "installHint": "Paste your Tavily API key - the official tavily-mcp package runs via npx.",
   "kind": "mcp",
   "defaultConnectionOptionId": "api",
   "connectionOptions": [
@@ -34,7 +34,7 @@
             "placeholder": "tvly-...",
             "required": true,
             "helperText": "API key from your Tavily dashboard.",
-            "helperLink": "https://app.tavily.com/home"
+            "helperLink": "https://app.tavily.com/home?tab=keys"
           }
         ]
       },

--- a/integrations/index.d.ts
+++ b/integrations/index.d.ts
@@ -6,6 +6,7 @@ export interface MarketplaceField {
   type?: MarketplaceFieldType;
   placeholder?: string;
   helperText?: string;
+  helperLink?: string;
   required?: boolean;
 }
 

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -71,6 +71,28 @@ def test_catalog_entries_have_required_fields():
         assert isinstance(entry["estimatedSetupMinutes"], int)
 
 
+def test_credential_fields_have_helper_text_and_link():
+    """All password fields must have helperText and helperLink so users know how to get credentials."""
+    for entry in load_catalog_entries("integrations/catalog"):
+        for option in entry["connectionOptions"]:
+            transport = option.get("transport", {})
+            for field_group in ("envFields", "argFields"):
+                for field in transport.get(field_group, []):
+                    if field.get("type") == "password":
+                        assert "helperText" in field, (
+                            f"{entry['id']}: password field '{field['key']}' is missing helperText"
+                        )
+                        assert "helperLink" in field, (
+                            f"{entry['id']}: password field '{field['key']}' is missing helperLink"
+                        )
+                        assert field["helperText"], (
+                            f"{entry['id']}: password field '{field['key']}' has empty helperText"
+                        )
+                        assert field["helperLink"].startswith("https://"), (
+                            f"{entry['id']}: password field '{field['key']}' helperLink must start with https://"
+                        )
+
+
 def test_node_package_exports_catalogs():
     script = """
       import { INTEGRATION_CATALOG, AUTOMATION_CATALOG } from './index.js';

--- a/tests/test_catalogs.py
+++ b/tests/test_catalogs.py
@@ -79,17 +79,18 @@ def test_credential_fields_have_helper_text_and_link():
             for field_group in ("envFields", "argFields"):
                 for field in transport.get(field_group, []):
                     if field.get("type") == "password":
+                        field_key = field.get("key", "<unknown>")
                         assert "helperText" in field, (
-                            f"{entry['id']}: password field '{field['key']}' is missing helperText"
+                            f"{entry['id']}: password field '{field_key}' is missing helperText"
                         )
                         assert "helperLink" in field, (
-                            f"{entry['id']}: password field '{field['key']}' is missing helperLink"
+                            f"{entry['id']}: password field '{field_key}' is missing helperLink"
                         )
                         assert field["helperText"], (
-                            f"{entry['id']}: password field '{field['key']}' has empty helperText"
+                            f"{entry['id']}: password field '{field_key}' has empty helperText"
                         )
                         assert field["helperLink"].startswith("https://"), (
-                            f"{entry['id']}: password field '{field['key']}' helperLink must start with https://"
+                            f"{entry['id']}: password field '{field_key}' helperLink must start with https://"
                         )
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

When users set up integrations in the OpenHands agent-canvas UI (e.g. Slack), they are prompted for tokens/API keys with no guidance on how to obtain them. This makes onboarding unnecessarily difficult.

## Summary

- Added `helperText` and `helperLink` to every `password`-type field in all 19 affected integration catalog entries (airtable, apify, brave-search, clickhouse, elevenlabs, exa, figma, firecrawl, github, kagi, mongodb, neon, notion, obsidian, redis, resend, slack, supabase, tavily)
- Added `helperLink?: string` to the `MarketplaceField` TypeScript interface in `integrations/index.d.ts` so UIs can render a clickable link alongside the helper text
- Added `test_credential_fields_have_helper_text_and_link` test that enforces every `password` field has both `helperText` and `helperLink`

## Issue Number

Fixes #279

## How to Test

```bash
uv sync --group test
uv run pytest tests/test_catalogs.py -v
```

All 4 tests pass, including the new `test_credential_fields_have_helper_text_and_link` test.

## Notes

- `helperText` provides a short human-readable description (e.g. "Bot token from your Slack app's OAuth & Permissions page.")
- `helperLink` provides a direct URL to the credential creation/management page so the UI can render it as a clickable link
- The new test will catch any future integrations that add `password` fields without documentation

_This PR was created by an AI agent (OpenHands) on behalf of the user._