### PR TITLE
Add automation creation process to SKILL.md

### DIFF
--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -113,7 +113,7 @@ Entrypoint must be `python3 main.py` (no `setup.sh` needed). Wrap your main logi
 All requests require Bearer authentication:
 
 ```bash
--H "X-API-Key: ${OPENHANDS_API_KEY}"
+-H "Authorization: Bearer ${OPENHANDS_API_KEY}"
 ```
 
 ## API Endpoints

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -23,7 +23,7 @@ Create and manage automations that run inside an OpenHands agent server — trig
 ## Automation Creation Process
 The agent must follow these steps when creating an automation:
 * Quickly check that you can access the correct automations backend using the auth mechanism below
-* Quickly check that you can access any necessary integrations (e.g. GitHub, Slack)
+* Quickly check that you can access any necessary integrations (e.g. GitHub, Slack); if access fails, inform the user and stop
 * Ask the user for any necessary information, e.g. if you need the name of a Slack channel or GitHub repo to proceed
 * Write the code or prompt that will be sent to the automations backend _inside the current workspace_
 * Show the code to the user with the `canvas_ui` tool if available

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -26,7 +26,7 @@ The agent must follow these steps when creating an automation:
 * Quickly check that you can access any necessary integrations (e.g. GitHub, Slack); if access fails, inform the user and stop
 * Ask the user for any necessary information, e.g. if you need the name of a Slack channel or GitHub repo to proceed
 * Write the code or prompt that will be sent to the automations backend _inside the current workspace_
-* Show the code to the user with the `canvas_ui` tool if available
+* Show the code to the user with the `canvas_ui` tool if available, otherwise present it in a fenced code block in your reply
 * Message the user with a concise summary of how the automation will behave, and ask if they are ready to deploy it
 
 ## Architecture

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -20,6 +20,14 @@ triggers:
 
 Create and manage automations that run inside an OpenHands agent server — triggered by cron schedules or webhook events (GitHub, custom services).
 
+## Automation Creation Process
+The agent must follow these steps when creating an automation:
+* Quickly check that you can access the correct automations backend using the auth mechanism below
+* Ask the user for any necessary information, e.g. if you need the name of a Slack channel or GitHub repo to proceed
+* Write the code or prompt that will be sent to the automations backend _inside the current workspace_
+* Show the code to the user with the `canvas_ui` tool if available
+* Message the user with a concise summary of how the automation will behave, and ask if they are ready to deploy it
+
 ## Architecture
 
 Two components work together to run automations:
@@ -104,7 +112,7 @@ Entrypoint must be `python3 main.py` (no `setup.sh` needed). Wrap your main logi
 All requests require Bearer authentication:
 
 ```bash
--H "Authorization: Bearer ${OPENHANDS_API_KEY}"
+-H "X-API-Key: ${OPENHANDS_API_KEY}"
 ```
 
 ## API Endpoints

--- a/skills/openhands-automation/SKILL.md
+++ b/skills/openhands-automation/SKILL.md
@@ -23,6 +23,7 @@ Create and manage automations that run inside an OpenHands agent server — trig
 ## Automation Creation Process
 The agent must follow these steps when creating an automation:
 * Quickly check that you can access the correct automations backend using the auth mechanism below
+* Quickly check that you can access any necessary integrations (e.g. GitHub, Slack)
 * Ask the user for any necessary information, e.g. if you need the name of a Slack channel or GitHub repo to proceed
 * Write the code or prompt that will be sent to the automations backend _inside the current workspace_
 * Show the code to the user with the `canvas_ui` tool if available


### PR DESCRIPTION
This gives the agent clearer instructions on how exactly to create an automation requested by the user. In particular, it tells the agent to ask the user before deploying the automation, and gives the user the chance to review the code/prompt

I tested this by pointing the agent directly to this live version of the skill instead of using the built-in one. Works well! Agent showed me the code and asked before deploying

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Notes

<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
