### PR TITLE
fix(pollers): prevent duplicate processing across overlapping cron runs

### DIFF
--- a/skills/github-repo-monitor/SKILL.md
+++ b/skills/github-repo-monitor/SKILL.md
@@ -184,17 +184,25 @@ mkdir -p /tmp/github-monitor-build
 # (write the customised main.py to /tmp/github-monitor-build/main.py)
 ```
 
-Validate syntax before packaging:
+Validate syntax before packaging. Use `ast.parse` (does **not** write a
+`__pycache__/main.cpython-*.pyc` file next to the source — those `.pyc`
+binaries occasionally fail to decompress when the sandbox unpacks the
+tarball and cause runs to fail):
+
 ```bash
-python3 -m py_compile /tmp/github-monitor-build/main.py && echo "Syntax OK"
+python3 -c "import ast,sys; ast.parse(open('/tmp/github-monitor-build/main.py').read()); print('Syntax OK')"
 ```
 
 Fix any syntax errors before proceeding.
 
 ### Step 8  -  Package and upload
 
+Exclude `__pycache__` directories from the tarball as a defensive measure
+even if validation didn't create one:
+
 ```bash
-tar -czf /tmp/github-monitor.tar.gz -C /tmp/github-monitor-build .
+tar --exclude='__pycache__' --exclude='*.pyc' \
+  -czf /tmp/github-monitor.tar.gz -C /tmp/github-monitor-build .
 
 OPENHANDS_HOST="http://localhost:8000"
 

--- a/skills/github-repo-monitor/references/state-schema.md
+++ b/skills/github-repo-monitor/references/state-schema.md
@@ -81,8 +81,18 @@ A rolling list (max `MAX_PROCESSED_IDS = 5000` entries) of integer GitHub
 comment IDs that have already been processed. This prevents:
 
 - Duplicate processing caused by cron boundary overlap (the `last_poll`
-  timestamp is advanced to the start of the current run, so the next run
+  timestamp is captured at the start of the current run, so the next run
   re-scans a small window of time).
+- **Concurrent runs spinning up two conversations for the same comment.**
+  When a poll cycle's network calls take longer than the cron interval
+  (e.g. 60s), the next cron tick starts before the first run has saved
+  state. To prevent the duplicate, the poller uses a *claim-before-process*
+  pattern: it re-reads the state file from disk and atomically appends the
+  comment ID to `processed_comment_ids` **before** creating the OpenHands
+  conversation or posting the GitHub acknowledgement. Atomic writes use
+  `os.replace(tmp, path)` so concurrent runs never observe a half-written
+  file. The runner's final `save_state` at end-of-run also re-reads disk
+  and merges, so claims made by an overlapping run are never clobbered.
 - Accidental re-triggers if the state file is partially reset.
 
 IDs are stored as integers and kept sorted; the oldest entries are pruned

--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -148,8 +148,38 @@ def load_state(path: str) -> dict:
 
 
 def save_state(path: str, state: dict) -> None:
-    with open(path, "w") as f:
+    """Persist state atomically (write to tmp + os.replace) so concurrent
+    runs never observe a half-written file."""
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
         json.dump(state, f, indent=2)
+    os.replace(tmp, path)
+
+
+def claim_comment(path: str, comment_id: int) -> bool:
+    """Reserve ``comment_id`` in ``processed_comment_ids`` on disk.
+
+    Concurrent cron runs can overlap when polling/network calls take longer
+    than the cron interval. To prevent two runs from spinning up two
+    conversations for the same trigger comment we re-read the latest state
+    from disk and atomically append ``comment_id`` *before* doing any
+    side-effects (conversation create, GitHub ack comment).
+
+    Returns True if this run won the claim, False if another concurrent run
+    already claimed ``comment_id``.
+
+    Note: this narrows but does not fully eliminate the race — two runs that
+    read state in the same millisecond can both think they won. For cron
+    schedules of one minute or greater this window is effectively zero.
+    Stronger guarantees would require an OS-level lock (fcntl.flock).
+    """
+    fresh = load_state(path)
+    processed = fresh.setdefault("processed_comment_ids", [])
+    if comment_id in set(processed):
+        return False
+    processed.append(comment_id)
+    save_state(path, fresh)
+    return True
 
 
 # ── GitHub API helpers ─────────────────────────────────────────────────────────
@@ -727,8 +757,9 @@ def main() -> None:
         openhands_url = DEFAULT_OPENHANDS_URL
 
     since = state.get("last_poll") or _default_since()
+    # Captured at the start of the run so any comments arriving while we work
+    # are still picked up by the next run.
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    state["last_poll"] = now_iso  # advance before processing so next run doesn't miss events
 
     conversations: dict[str, dict] = state.get("conversations", {})
     processed_ids: list[int] = state.get("processed_comment_ids", [])
@@ -790,6 +821,14 @@ def main() -> None:
             processed_set.add(comment_id)
             continue
 
+        # Reserve the comment in shared state BEFORE creating a conversation
+        # or posting the GitHub ack. If a concurrent run already claimed it,
+        # skip — avoids the duplicate-conversation race.
+        if not claim_comment(state_path, comment_id):
+            print(f"  Comment {comment_id} already claimed by another run — skipping")
+            processed_set.add(comment_id)
+            continue
+
         _process_trigger_comment(
             github_token, agent_url, api_key, openhands_url,
             REPO, issue_number, comment, event_type, conversations,
@@ -804,14 +843,22 @@ def main() -> None:
             conv_key, rec, github_token, REPO, agent_url, api_key,
         )
 
-    # Trim processed_ids rolling window.
-    trimmed = sorted(processed_set)
+    # Re-read state from disk and merge in our updates so claims written
+    # by concurrent runs (via claim_comment) aren't clobbered.
+    fresh = load_state(state_path)
+    merged_ids = set(fresh.get("processed_comment_ids", [])) | processed_set
+    trimmed = sorted(merged_ids)
     if len(trimmed) > MAX_PROCESSED_IDS:
         trimmed = trimmed[-MAX_PROCESSED_IDS:]
-    state["processed_comment_ids"] = trimmed
-    state["conversations"] = conversations
 
-    save_state(state_path, state)
+    merged_convs = dict(fresh.get("conversations", {}))
+    merged_convs.update(conversations)
+
+    fresh["last_poll"] = now_iso
+    fresh["processed_comment_ids"] = trimmed
+    fresh["conversations"] = merged_convs
+
+    save_state(state_path, fresh)
     print(f"State saved → {state_path}")
 
 

--- a/skills/github-repo-monitor/tests/test_main.py
+++ b/skills/github-repo-monitor/tests/test_main.py
@@ -88,6 +88,71 @@ class TestSaveAndLoadRoundtrip(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_save_state_is_atomic_no_partial_file_left_behind(self):
+        """A successful save_state must leave no `.tmp.*` sidecar behind."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {"version": 1, "processed_comment_ids": [7]})
+            files = os.listdir(d)
+            self.assertEqual(files, ["state.json"], f"unexpected files: {files}")
+
+
+# ── Claim/dedup tests ─────────────────────────────────────────────────────────
+
+class TestClaimComment(unittest.TestCase):
+    """The processed_comment_ids strategy prevents concurrent cron runs from
+    spinning up two conversations for the same trigger comment."""
+
+    def test_first_claim_wins_second_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            self.assertTrue(main.claim_comment(path, 12345))
+            self.assertFalse(main.claim_comment(path, 12345))
+
+    def test_claim_persists_id_on_disk(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.claim_comment(path, 999)
+            loaded = main.load_state(path)
+            self.assertIn(999, loaded["processed_comment_ids"])
+
+    def test_claim_respects_existing_ids(self):
+        """A comment already in processed_comment_ids cannot be re-claimed,
+        simulating: Run A wrote state, Run B reads disk and tries to claim."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {
+                "version": 1,
+                "conversations": {},
+                "processed_comment_ids": [42],
+            })
+            self.assertFalse(main.claim_comment(path, 42))
+
+    def test_distinct_comments_both_succeed(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            self.assertTrue(main.claim_comment(path, 1))
+            self.assertTrue(main.claim_comment(path, 2))
+            loaded = main.load_state(path)
+            self.assertEqual(sorted(loaded["processed_comment_ids"]), [1, 2])
+
+    def test_claim_preserves_other_state_fields(self):
+        """claim_comment must not clobber conversations or last_poll written
+        by an earlier run."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {
+                "version": 1,
+                "last_poll": "2025-01-01T00:00:00Z",
+                "conversations": {"7": {"conversation_id": "x", "status": "active"}},
+                "processed_comment_ids": [10],
+            })
+            main.claim_comment(path, 11)
+            loaded = main.load_state(path)
+            self.assertEqual(loaded["last_poll"], "2025-01-01T00:00:00Z")
+            self.assertEqual(loaded["conversations"]["7"]["conversation_id"], "x")
+            self.assertEqual(sorted(loaded["processed_comment_ids"]), [10, 11])
+
 
 # ── Bot detection tests ────────────────────────────────────────────────────────
 

--- a/skills/slack-channel-monitor/SKILL.md
+++ b/skills/slack-channel-monitor/SKILL.md
@@ -132,17 +132,25 @@ mkdir -p /tmp/slack-monitor-build
 # (write the customised main.py to /tmp/slack-monitor-build/main.py)
 ```
 
-Validate syntax before packaging:
+Validate syntax before packaging. Use `ast.parse` (does **not** write a
+`__pycache__/main.cpython-*.pyc` file next to the source — those `.pyc`
+binaries occasionally fail to decompress when the sandbox unpacks the
+tarball and cause runs to fail):
+
 ```bash
-python3 -m py_compile /tmp/slack-monitor-build/main.py && echo "Syntax OK"
+python3 -c "import ast,sys; ast.parse(open('/tmp/slack-monitor-build/main.py').read()); print('Syntax OK')"
 ```
 
 Fix any syntax errors before proceeding.
 
 ### Step 4  -  Package and upload
 
+Exclude `__pycache__` directories from the tarball as a defensive measure
+even if validation didn't create one:
+
 ```bash
-tar -czf /tmp/slack-monitor.tar.gz -C /tmp/slack-monitor-build .
+tar --exclude='__pycache__' --exclude='*.pyc' \
+  -czf /tmp/slack-monitor.tar.gz -C /tmp/slack-monitor-build .
 
 # Determine the API host (use <HOST> from the system prompt, else localhost:8000)
 OPENHANDS_HOST="http://localhost:8000"

--- a/skills/slack-channel-monitor/references/state-schema.md
+++ b/skills/slack-channel-monitor/references/state-schema.md
@@ -41,7 +41,10 @@ variable (field `automation_id`).
   "conversations": { ... },            // see ConversationRecord below
   "bot_message_ts": [                  // rolling list of Slack 'ts' values for
     "1716576100.000200"                // messages THIS bot posted; used to skip
-  ]                                    // self-messages during processing
+  ],                                   // self-messages during processing
+  "processed_message_keys": [          // rolling list (max 5000) of
+    "C0123456789:1716576000.123456"    // "{channel_id}:{msg_ts}" reserved by
+  ]                                    // claim_message before side effects
 }
 ```
 
@@ -92,6 +95,28 @@ replies as user messages.
 Entries are added when:
 - The bot posts a conversation link (on trigger detection)
 - The bot posts a summary (on conversation completion)
+
+---
+
+## `processed_message_keys` List
+
+A rolling list (max `MAX_PROCESSED_KEYS = 5000` entries) of
+`"{channel_id}:{msg_ts}"` strings claimed by `claim_message`. This prevents
+**concurrent runs from spinning up two conversations for the same trigger
+message (or double-forwarding the same thread reply).**
+
+When a poll cycle's network calls take longer than the cron interval (e.g.
+60s), the next cron tick starts before the first run has saved state. To
+prevent the duplicate, the poller uses a *claim-before-process* pattern: it
+re-reads the state file from disk and atomically appends the key **before**
+any side effects (creating an OpenHands conversation, posting a Slack
+reaction, forwarding a thread reply).
+
+Atomic writes use `os.replace(tmp, path)` so concurrent runs never observe a
+half-written file. The runner's final `save_state` at end-of-run also
+re-reads disk and merges, so claims made by an overlapping run are never
+clobbered. The key is namespaced by `channel_id` because Slack `ts` values
+are unique within a channel but not necessarily globally.
 
 ---
 
@@ -151,6 +176,10 @@ Entries are added when:
   "bot_message_ts": [
     "1716575903.000200",
     "1716572105.000100"
+  ],
+  "processed_message_keys": [
+    "C0123456789:1716575900.000100",
+    "C0123456789:1716572100.000100"
   ]
 }
 ```

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -56,6 +56,9 @@ DONE_DEBOUNCE = 15
 # ~1 week of continuous operation at high message rates.
 MAX_BOT_TS = 2000
 
+# Rolling window size for processed-message dedup (see claim_message).
+MAX_PROCESSED_KEYS = 5000
+
 # Limit context to avoid overwhelming the agent with too much history.
 CONTEXT_MESSAGE_LIMIT = 15
 
@@ -139,12 +142,48 @@ def load_state(path: str) -> dict:
         "last_poll": {},           # channel_id → float timestamp string
         "conversations": {},       # conv_key → ConversationRecord (see schema docs)
         "bot_message_ts": [],      # ts strings of messages posted by this bot
+        "processed_message_keys": [],  # "{channel_id}:{msg_ts}" claimed by past runs
     }
 
 
 def save_state(path: str, state: dict) -> None:
-    with open(path, "w") as f:
+    """Persist state atomically (write to tmp + os.replace) so concurrent
+    runs never observe a half-written file."""
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
         json.dump(state, f, indent=2)
+    os.replace(tmp, path)
+
+
+def claim_message(path: str, channel_id: str, msg_ts: str) -> bool:
+    """Reserve ``{channel_id}:{msg_ts}`` in ``processed_message_keys`` on disk.
+
+    Concurrent cron runs can overlap when polling/network calls take longer
+    than the cron interval. To prevent two runs from spinning up two
+    conversations for the same trigger message (or double-forwarding the same
+    thread reply), this re-reads the latest state from disk and atomically
+    appends the message key *before* doing any side-effects (conversation
+    create, Slack ack, reaction).
+
+    Slack ``ts`` values are unique within a channel but not necessarily
+    globally, so the key is namespaced by ``channel_id``.
+
+    Returns True if this run won the claim, False if another concurrent run
+    already claimed the message.
+
+    Note: this narrows but does not fully eliminate the race — two runs that
+    read state in the same millisecond can both think they won. For cron
+    schedules of one minute or greater this window is effectively zero.
+    Stronger guarantees would require an OS-level lock (fcntl.flock).
+    """
+    key = f"{channel_id}:{msg_ts}"
+    fresh = load_state(path)
+    keys = fresh.setdefault("processed_message_keys", [])
+    if key in set(keys):
+        return False
+    keys.append(key)
+    save_state(path, fresh)
+    return True
 
 
 # ── Slack API helpers ──────────────────────────────────────────────────────────
@@ -677,6 +716,11 @@ def main() -> None:
 
         # ── Case A: reply in a thread that has an active conversation ──────────
         if is_reply_in_tracked:
+            # Claim BEFORE forwarding to prevent two overlapping runs from
+            # double-forwarding the same reply (and double-reacting).
+            if not claim_message(state_path, channel_id, msg_ts):
+                print(f"  Reply {channel_id}:{msg_ts} already claimed — skipping")
+                continue
             rec = active_convs[conv_key]
             print(f"  Forwarding reply {msg_ts} → conversation {rec['conversation_id']}")
             try:
@@ -692,6 +736,11 @@ def main() -> None:
 
         # ── Case B: message contains trigger phrase → create a new conversation ─
         if has_trigger:
+            # Claim BEFORE creating the conversation / posting the link, so
+            # an overlapping cron run doesn't spin up a duplicate conversation.
+            if not claim_message(state_path, channel_id, msg_ts):
+                print(f"  Trigger {channel_id}:{msg_ts} already claimed — skipping")
+                continue
             _process_trigger_message(
                 slack_token, agent_url, api_key, openhands_url,
                 channel_id, msg_ts, text, thread_root, conv_key,
@@ -710,15 +759,33 @@ def main() -> None:
         state["bot_message_ts"] = bot_message_ts
 
     state["conversations"] = active_convs
+
+    # Re-read state from disk and merge in our updates so claims written by
+    # concurrent runs (via claim_message) aren't clobbered.
+    fresh = load_state(state_path)
+    merged_keys = list(dict.fromkeys(
+        fresh.get("processed_message_keys", []) + state.get("processed_message_keys", [])
+    ))
+    if len(merged_keys) > MAX_PROCESSED_KEYS:
+        merged_keys = merged_keys[-MAX_PROCESSED_KEYS:]
+    state["processed_message_keys"] = merged_keys
+
+    # Conversations dict: our in-memory state has the latest local updates;
+    # merge with any entries that disk had but we didn't see.
+    merged_convs = dict(fresh.get("conversations", {}))
+    merged_convs.update(active_convs)
+    state["conversations"] = merged_convs
+
     save_state(state_path, state)
     print(f"State saved to {state_path}")
 
 
-try:
-    main()
-    fire_callback("COMPLETED")
-except Exception as exc:
-    import traceback
-    traceback.print_exc()
-    fire_callback("FAILED", str(exc))
-    sys.exit(1)
+if __name__ == "__main__":
+    try:
+        main()
+        fire_callback("COMPLETED")
+    except Exception as exc:
+        import traceback
+        traceback.print_exc()
+        fire_callback("FAILED", str(exc))
+        sys.exit(1)

--- a/skills/slack-channel-monitor/tests/test_main.py
+++ b/skills/slack-channel-monitor/tests/test_main.py
@@ -1,0 +1,125 @@
+"""Unit tests for slack-channel-monitor main.py.
+
+Focused on the atomic save_state + claim_message behavior that prevents
+concurrent cron runs from spinning up duplicate conversations for the same
+trigger message.
+
+Run from the skill root:
+    python -m unittest discover tests
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Allow importing main.py from the sibling scripts/ directory.
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import main  # noqa: E402
+
+
+class TestLoadStateDefault(unittest.TestCase):
+
+    def test_missing_file_returns_default(self):
+        state = main.load_state("/nonexistent/path/state.json")
+        self.assertEqual(state["version"], 1)
+        self.assertIn("conversations", state)
+        self.assertIn("processed_message_keys", state)
+        self.assertEqual(state["processed_message_keys"], [])
+
+
+class TestSaveStateAtomic(unittest.TestCase):
+
+    def test_roundtrip(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            data = {
+                "version": 1,
+                "bot_user_id": "UBOT",
+                "last_poll": {"C1": "1234567890.0"},
+                "conversations": {"C1:1": {"conversation_id": "x", "status": "active"}},
+                "bot_message_ts": ["1.1"],
+                "processed_message_keys": ["C1:1234567890.111"],
+            }
+            main.save_state(path, data)
+            loaded = main.load_state(path)
+            self.assertEqual(loaded, data)
+
+    def test_no_tmp_sidecar_remains(self):
+        """A successful save_state must not leave a `.tmp.*` file behind."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {"version": 1, "processed_message_keys": []})
+            files = os.listdir(d)
+            self.assertEqual(files, ["state.json"], f"unexpected files: {files}")
+
+
+class TestClaimMessage(unittest.TestCase):
+    """The processed_message_keys strategy prevents concurrent cron runs from
+    creating two conversations for the same Slack trigger message."""
+
+    def test_first_claim_wins_second_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            self.assertTrue(main.claim_message(path, "C1", "1716576000.000100"))
+            self.assertFalse(main.claim_message(path, "C1", "1716576000.000100"))
+
+    def test_claim_persists_key_on_disk(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.claim_message(path, "C1", "1716576000.000100")
+            loaded = main.load_state(path)
+            self.assertIn("C1:1716576000.000100", loaded["processed_message_keys"])
+
+    def test_claim_is_namespaced_by_channel(self):
+        """Same ts in different channels must both succeed (Slack ts is unique
+        per-channel, not globally)."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            self.assertTrue(main.claim_message(path, "C1", "1716576000.000100"))
+            self.assertTrue(main.claim_message(path, "C2", "1716576000.000100"))
+            loaded = main.load_state(path)
+            self.assertEqual(
+                sorted(loaded["processed_message_keys"]),
+                ["C1:1716576000.000100", "C2:1716576000.000100"],
+            )
+
+    def test_claim_respects_existing_key(self):
+        """Simulates: Run A wrote state, Run B reads disk and tries to claim."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {
+                "version": 1,
+                "conversations": {},
+                "processed_message_keys": ["C1:1716576000.000100"],
+            })
+            self.assertFalse(main.claim_message(path, "C1", "1716576000.000100"))
+
+    def test_claim_preserves_other_state_fields(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "state.json")
+            main.save_state(path, {
+                "version": 1,
+                "bot_user_id": "UBOT",
+                "last_poll": {"C1": "1234567890.0"},
+                "conversations": {
+                    "C1:1": {"conversation_id": "x", "status": "active"},
+                },
+                "bot_message_ts": ["1.1"],
+                "processed_message_keys": ["C1:1716576000.000100"],
+            })
+            main.claim_message(path, "C1", "1716576999.999999")
+            loaded = main.load_state(path)
+            self.assertEqual(loaded["bot_user_id"], "UBOT")
+            self.assertEqual(loaded["last_poll"], {"C1": "1234567890.0"})
+            self.assertEqual(loaded["conversations"]["C1:1"]["conversation_id"], "x")
+            self.assertEqual(loaded["bot_message_ts"], ["1.1"])
+            self.assertEqual(
+                sorted(loaded["processed_message_keys"]),
+                ["C1:1716576000.000100", "C1:1716576999.999999"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Fixes a race condition in **both** the `github-repo-monitor` and `slack-channel-monitor` cron-based polling skills where a single trigger comment / message could spin up two OpenHands conversations (and post two acknowledgements) when the previous poll run hadn't finished saving state before the next cron tick fired.

Also fixes a packaging bug that caused intermittent `gzip decompression failed` run failures.

> _This PR was authored by an AI agent (OpenHands) on behalf of @rbren._

## How I found it

Set up the github-repo-monitor locally on `OpenHands/extensions` with a 1-minute cron. A single trigger comment on PR #288 produced two `🤖 OpenHands is on it!` acks, two distinct conversation IDs, and two completion summaries. Run timeline:

| Time (UTC) | Run status | Side effects |
|---|---|---|
| 15:13:22 | (user comment posted) | — |
| 15:14:07 | FAILED | tar error on stray `__pycache__/main.cpython-312.pyc` |
| 15:15:07 | FAILED | same tar error |
| 15:16:07 | COMPLETED | created conv `7823f1…`, posted ack #1 at 15:17:16 (run took ~1m9s) |
| 15:17:07 | COMPLETED | created conv `4376b5…`, posted ack #2 at 15:17:17 |

The 15:16 run was still in flight when 15:17 fired. Both reads of `processed_comment_ids` showed the comment as unprocessed, so both created conversations. The slack-channel-monitor has the identical pattern.

## The race

Original flow in both pollers:

```python
state = load_state(path)                  # ① read processed IDs
# ... poll API, for each new trigger:
#     create_conversation(...)            # side effect, slow network call
#     post_ack_comment(...)               # side effect
save_state(path, state)                   # ② persist at the end
```

When step ① to ② took longer than the cron interval (60s), two runs would race on identical state.

## The fix (same pattern in both skills)

1. **Atomic `save_state`** — write to `{path}.tmp.{pid}` and `os.replace()` so readers never see a half-written file.
2. **New `claim_comment` / `claim_message` helper** — re-reads disk, atomically appends the ID to `processed_comment_ids` / `processed_message_keys`, returns `True` only if this run won the claim. Called **before** any side effect.
3. **End-of-run `save_state` re-reads & merges** the processed-ID set and conversations dict so claims written by an overlapping run aren't clobbered by a stale in-memory write.

Slack message keys are namespaced `{channel_id}:{msg_ts}` because Slack `ts` is unique per-channel, not globally.

### Residual race window
The claim helper is read-then-write without an OS lock, so two runs hitting the same millisecond can both think they won. For 1-minute (or larger) cron schedules this window is effectively zero. The docstrings flag `fcntl.flock` as the upgrade path if a stronger guarantee is ever needed.

## Packaging fix (root cause of those two FAILED runs above)

- `SKILL.md` syntax validation switched from `python3 -m py_compile` (which writes `__pycache__/main.cpython-*.pyc`) to `python3 -c "import ast; ast.parse(…)"`. No more stray pyc.
- Tarball commands now use `tar --exclude='__pycache__' --exclude='*.pyc'` as defense in depth.

## Misc

- Slack `scripts/main.py` wrapped its bottom `main()` call in `if __name__ == "__main__":` so the module can be imported by tests. Runtime behavior when invoked as `python3 main.py` is unchanged.
- New `slack-channel-monitor/tests/test_main.py` (8 tests) — slack had no test suite before.
- Extended `github-repo-monitor/tests/test_main.py` with 5 new tests.

## Test results

```
github-repo-monitor: 44 tests pass (5 new)
slack-channel-monitor: 8 tests pass (new file)
```

## Files

- `skills/github-repo-monitor/scripts/main.py` — atomic save, claim_comment, end-of-run merge
- `skills/github-repo-monitor/SKILL.md` — ast.parse validation + `--exclude` tarball
- `skills/github-repo-monitor/references/state-schema.md` — documents the claim-before-process pattern
- `skills/github-repo-monitor/tests/test_main.py` — 5 new tests
- `skills/slack-channel-monitor/scripts/main.py` — same fixes + `__main__` guard
- `skills/slack-channel-monitor/SKILL.md` — same packaging fixes
- `skills/slack-channel-monitor/references/state-schema.md` — same docs
- `skills/slack-channel-monitor/tests/test_main.py` — new file (8 tests)
