### PR TITLE
fix: include conversation_id in fire_callback for monitor scripts

### DIFF
--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -29,7 +29,6 @@ Optional secret:
 import json
 import os
 import sys
-from pathlib import Path
 import time
 import urllib.error
 import urllib.request
@@ -111,23 +110,16 @@ def fire_callback(
 # ── State management ───────────────────────────────────────────────────────────
 
 def _state_file_path() -> str:
-    """Derive a persistent storage path from WORKSPACE_BASE.
+    """Return a writable path for the poller state file.
 
-    WORKSPACE_BASE = {root}/automation-runs/{run_id}
-    State lives two levels up at {root}/automation-state/.
+    Uses /tmp/openhands-automation-state/ which is always writable and shared
+    across cron runs on the same host regardless of WORKSPACE_BASE depth.
     """
-    workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
-
-    if workspace_base:
-        root = Path(workspace_base).resolve().parent.parent
-    else:
-        root = Path.home() / ".openhands" / "workspaces"
-
-    state_dir = root / "automation-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    return str(state_dir / f"github_poller_{automation_id}.json")
+    state_dir = "/tmp/openhands-automation-state"
+    os.makedirs(state_dir, exist_ok=True)
+    return os.path.join(state_dir, f"github_poller_{automation_id}.json")
 
 
 def _default_since() -> str:

--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -29,6 +29,7 @@ Optional secret:
 import json
 import os
 import sys
+from pathlib import Path
 import time
 import urllib.error
 import urllib.request
@@ -110,17 +111,23 @@ def fire_callback(
 # ── State management ───────────────────────────────────────────────────────────
 
 def _state_file_path() -> str:
-    """Return a writable path for the poller state file.
+    """Derive a persistent storage path from WORKSPACE_BASE.
 
-    Uses WORKSPACE_BASE directly when set, falling back to ~/.openhands/workspaces.
+    WORKSPACE_BASE = {root}/automation-runs/{run_id}
+    State lives two levels up at {root}/automation-state/.
     """
     workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
 
-    state_dir = workspace_base if workspace_base else os.path.expanduser("~/.openhands/workspaces")
-    os.makedirs(state_dir, exist_ok=True)
-    return os.path.join(state_dir, f"github_poller_{automation_id}.json")
+    if workspace_base:
+        root = Path(workspace_base).resolve().parent.parent
+    else:
+        root = Path.home() / ".openhands" / "workspaces"
+
+    state_dir = root / "automation-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return str(state_dir / f"github_poller_{automation_id}.json")
 
 
 def _default_since() -> str:

--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -80,7 +80,11 @@ def get_secret(name: str) -> str:
         return r.read().decode().strip()
 
 
-def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
+def fire_callback(
+    status: str = "COMPLETED",
+    error: str | None = None,
+    conversation_id: str | None = None,
+) -> None:
     """Signal run completion to the automation service."""
     url = os.environ.get("AUTOMATION_CALLBACK_URL", "")
     if not url:
@@ -88,6 +92,8 @@ def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
     body: dict = {"status": status, "run_id": os.environ.get("AUTOMATION_RUN_ID", "")}
     if error:
         body["error"] = error
+    if conversation_id:
+        body["conversation_id"] = conversation_id
     req = urllib.request.Request(
         url,
         data=json.dumps(body).encode(),
@@ -607,8 +613,12 @@ def _process_trigger_comment(
     comment: dict,
     event_type: str,
     conversations: dict[str, dict],
-) -> None:
-    """Handle a new trigger comment: create or resume a conversation."""
+) -> str | None:
+    """Handle a new trigger comment: create or resume a conversation.
+
+    Returns the conversation ID when a new or re-opened conversation is
+    created, or None when the comment is forwarded to an existing one.
+    """
     conv_key = str(issue_number)
     print(f"  Trigger detected on #{issue_number} (comment {comment.get('id')})")
 
@@ -617,7 +627,7 @@ def _process_trigger_comment(
         ctx = _get_issue_context(github_token, repo, issue_number)
     except Exception as exc:
         print(f"  Error fetching context for #{issue_number}: {exc}")
-        return
+        return None
 
     is_pr = ctx["is_pr"]
     item_type = "pull request" if is_pr else "issue"
@@ -637,7 +647,7 @@ def _process_trigger_comment(
                 f"New comment on GitHub {item_type} #{issue_number} by @{author}:\n\n{body}",
             )
             existing["last_activity"] = time.time()
-            return
+            return None
         except Exception as exc:
             print(f"  Warning: could not forward to conversation {conv_id}: {exc} — creating new")
             # Fall through to create a new conversation.
@@ -651,10 +661,11 @@ def _process_trigger_comment(
         )
     except Exception as exc:
         print(f"  Error creating conversation for #{issue_number}: {exc}")
-        return
+        return None
 
     conv_url = f"{openhands_url}/conversations/{conv_id}"
     _post_acknowledgement(github_token, repo, issue_number, item_type, conv_url, resumed)
+    return conv_id
 
 
 def _check_conversation_completion(
@@ -711,7 +722,8 @@ def _check_conversation_completion(
 
 # ── Main ───────────────────────────────────────────────────────────────────────
 
-def main() -> None:
+def main() -> str | None:
+    """Run one polling cycle. Returns the last conversation ID created, if any."""
     state_path = _state_file_path()
     state = load_state(state_path)
 
@@ -761,6 +773,7 @@ def main() -> None:
     all_events.sort(key=lambda x: x[1].get("created_at", ""))
 
     # ── Process trigger events ─────────────────────────────────────────────────
+    last_conversation_id: str | None = None
     for event_type, comment in all_events:
         comment_id: int = comment.get("id", 0)
         if comment_id in processed_set:
@@ -790,10 +803,12 @@ def main() -> None:
             processed_set.add(comment_id)
             continue
 
-        _process_trigger_comment(
+        conv_id = _process_trigger_comment(
             github_token, agent_url, api_key, openhands_url,
             REPO, issue_number, comment, event_type, conversations,
         )
+        if conv_id:
+            last_conversation_id = conv_id
         processed_set.add(comment_id)
 
     # ── Check active conversations for completion ──────────────────────────────
@@ -813,12 +828,13 @@ def main() -> None:
 
     save_state(state_path, state)
     print(f"State saved → {state_path}")
+    return last_conversation_id
 
 
 if __name__ == "__main__":
     try:
-        main()
-        fire_callback("COMPLETED")
+        conversation_id = main()
+        fire_callback("COMPLETED", conversation_id=conversation_id)
     except Exception as exc:
         import traceback
         traceback.print_exc()

--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -112,12 +112,13 @@ def fire_callback(
 def _state_file_path() -> str:
     """Return a writable path for the poller state file.
 
-    Uses /tmp/openhands-automation-state/ which is always writable and shared
-    across cron runs on the same host regardless of WORKSPACE_BASE depth.
+    Uses WORKSPACE_BASE directly when set, falling back to ~/.openhands/workspaces.
     """
+    workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
-    state_dir = "/tmp/openhands-automation-state"
+
+    state_dir = workspace_base if workspace_base else os.path.expanduser("~/.openhands/workspaces")
     os.makedirs(state_dir, exist_ok=True)
     return os.path.join(state_dir, f"github_poller_{automation_id}.json")
 

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -116,15 +116,21 @@ def fire_callback(
 # ── State management ───────────────────────────────────────────────────────────
 
 def _state_file_path() -> str:
-    """Return a writable path for the poller state file.
+    """Derive a persistent storage path from WORKSPACE_BASE.
 
-    Uses WORKSPACE_BASE directly when set, falling back to ~/.openhands/workspaces.
+    WORKSPACE_BASE = {root}/automation-runs/{run_id}
+    State lives two levels up at {root}/automation-state/.
     """
     workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
 
-    state_dir = workspace_base if workspace_base else os.path.expanduser("~/.openhands/workspaces")
+    if workspace_base:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(workspace_base)))
+    else:
+        root = os.path.expanduser("~/.openhands/workspaces")
+
+    state_dir = os.path.join(root, "automation-state")
     os.makedirs(state_dir, exist_ok=True)
     return os.path.join(state_dir, f"slack_poller_{automation_id}.json")
 

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -118,12 +118,13 @@ def fire_callback(
 def _state_file_path() -> str:
     """Return a writable path for the poller state file.
 
-    Uses /tmp/openhands-automation-state/ which is always writable and shared
-    across cron runs on the same host regardless of WORKSPACE_BASE depth.
+    Uses WORKSPACE_BASE directly when set, falling back to ~/.openhands/workspaces.
     """
+    workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
-    state_dir = "/tmp/openhands-automation-state"
+
+    state_dir = workspace_base if workspace_base else os.path.expanduser("~/.openhands/workspaces")
     os.makedirs(state_dir, exist_ok=True)
     return os.path.join(state_dir, f"slack_poller_{automation_id}.json")
 

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -116,21 +116,14 @@ def fire_callback(
 # ── State management ───────────────────────────────────────────────────────────
 
 def _state_file_path() -> str:
-    """Derive a persistent storage path from WORKSPACE_BASE.
+    """Return a writable path for the poller state file.
 
-    WORKSPACE_BASE = {root}/automation-runs/{run_id}
-    State lives two levels up at {root}/automation-state/.
+    Uses /tmp/openhands-automation-state/ which is always writable and shared
+    across cron runs on the same host regardless of WORKSPACE_BASE depth.
     """
-    workspace_base = os.environ.get("WORKSPACE_BASE", "")
     event_payload = json.loads(os.environ.get("AUTOMATION_EVENT_PAYLOAD", "{}"))
     automation_id = event_payload.get("automation_id", "default")
-
-    if workspace_base:
-        root = os.path.dirname(os.path.dirname(os.path.abspath(workspace_base)))
-    else:
-        root = os.path.expanduser("~/.openhands/workspaces")
-
-    state_dir = os.path.join(root, "automation-state")
+    state_dir = "/tmp/openhands-automation-state"
     os.makedirs(state_dir, exist_ok=True)
     return os.path.join(state_dir, f"slack_poller_{automation_id}.json")
 

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -85,7 +85,11 @@ def get_secret(name: str) -> str:
         return r.read().decode().strip()
 
 
-def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
+def fire_callback(
+    status: str = "COMPLETED",
+    error: str | None = None,
+    conversation_id: str | None = None,
+) -> None:
     """Signal run completion to the automation service."""
     url = os.environ.get("AUTOMATION_CALLBACK_URL", "")
     if not url:
@@ -93,6 +97,8 @@ def fire_callback(status: str = "COMPLETED", error: str | None = None) -> None:
     body: dict = {"status": status, "run_id": os.environ.get("AUTOMATION_RUN_ID", "")}
     if error:
         body["error"] = error
+    if conversation_id:
+        body["conversation_id"] = conversation_id
     req = urllib.request.Request(
         url,
         data=json.dumps(body).encode(),
@@ -513,8 +519,11 @@ def _process_trigger_message(
     bot_message_ts: list[str],
     bot_user_id: str,
     can_react: bool,
-) -> None:
-    """React to a trigger message, create an OpenHands conversation, and post a link."""
+) -> str | None:
+    """React to a trigger message, create an OpenHands conversation, and post a link.
+
+    Returns the new conversation ID on success, or None on error.
+    """
     print(f"  Trigger detected in {channel_id} at {msg_ts}: {text[:80]}")
     if can_react:
         add_reaction(slack_token, channel_id, msg_ts)
@@ -554,8 +563,10 @@ def _process_trigger_message(
             bot_message_ts.append(ts_back)
 
         print(f"  Created conversation {conv_id} ({conv_url})")
+        return conv_id
     except Exception as exc:
         print(f"  Error creating conversation for {conv_key}: {exc}")
+        return None
 
 
 def _check_conversation_completion(
@@ -607,7 +618,8 @@ def _check_conversation_completion(
 
 # ── Main ───────────────────────────────────────────────────────────────────────
 
-def main() -> None:
+def main() -> str | None:
+    """Run one polling cycle. Returns the last conversation ID created, if any."""
     state_path = _state_file_path()
     state = load_state(state_path)
 
@@ -654,6 +666,7 @@ def main() -> None:
     for cid in CHANNEL_IDS:
         state["last_poll"][cid] = now_ts
 
+    last_conversation_id: str | None = None
     for channel_id, msg in all_incoming:
         if not _is_human_message(msg, bot_user_id, bot_message_ts):
             continue
@@ -692,11 +705,13 @@ def main() -> None:
 
         # ── Case B: message contains trigger phrase → create a new conversation ─
         if has_trigger:
-            _process_trigger_message(
+            conv_id = _process_trigger_message(
                 slack_token, agent_url, api_key, openhands_url,
                 channel_id, msg_ts, text, thread_root, conv_key,
                 active_convs, bot_message_ts, bot_user_id, can_react,
             )
+            if conv_id:
+                last_conversation_id = conv_id
 
     for conv_key, rec in list(active_convs.items()):
         if rec.get("status") != "closed":
@@ -712,11 +727,12 @@ def main() -> None:
     state["conversations"] = active_convs
     save_state(state_path, state)
     print(f"State saved to {state_path}")
+    return last_conversation_id
 
 
 try:
-    main()
-    fire_callback("COMPLETED")
+    conversation_id = main()
+    fire_callback("COMPLETED", conversation_id=conversation_id)
 except Exception as exc:
     import traceback
     traceback.print_exc()


### PR DESCRIPTION
## Problem

Both `github-repo-monitor` and `slack-channel-monitor` create OpenHands conversations as part of their polling loop, but never reported those conversation IDs back to the automation service. The `AutomationRun.conversation_id` field is populated exclusively from the completion callback payload — since `fire_callback()` only sent `status` and `run_id`, all runs from these custom scripts ended up with `conversation_id: null` in the run record.

For example, a `github-repo-monitor` run logs `Created conversation 424295c8-a8bf-4fa9-97e1-2414cc878219` but the corresponding `AutomationRun` has `conversation_id: null` because that ID was never sent back.

## Changes

Applied identically to both `github-repo-monitor/scripts/main.py` and `slack-channel-monitor/sApplied identically to both `github-re)`**: add optional `conversationApplied identically to both `github-repo-monitor/scripts/main.py` and `slac **`_process_trigApplied identically to both `github-repoage()`**: change returnApplied identically to both `github-repo-monitor/scripts/main.py` and `slack-channel-monitor/sApplied identically to both `github-re)`**: add optional `conversationApplied identically to both `github-repo-monitor/scripts/main.py` and `slac **`_process_trigApplied identically to both `github-repoage()`**: change returnApplied identically to both `github-repo-monitor/scripts/main.py` and `slack-channel-monitor/sApplied identically to both `gMPLETED")`.

## Notes

- When a run creates multiple conversations (multiple triggers in one poll cycle), the _last_ conversation ID created is reported. This is the best we can do since the `conversation_id` field is a single string.
- Forwarding a message to an already-active conversation (Case A in both scripts) does not update `last_conversation_id` — only freshly created conversations are reported.
- The `FAILED` path is unchanged: if `main()` raises before reaching `return last_conversation_id`, the exception handler calls `fire_callback("FAILED", str(exc))` without a `conversation_id`, which is correct.

_This PR was created by an AI agent (OpenHands) on behalf of the user._