### PR TITLE
Add show-code step to github-repo-monitor and slack-channel-monitor skills

### DIFF
--- a/skills/github-repo-monitor/SKILL.md
+++ b/skills/github-repo-monitor/SKILL.md
@@ -191,7 +191,15 @@ python3 -m py_compile /tmp/github-monitor-build/main.py && echo "Syntax OK"
 
 Fix any syntax errors before proceeding.
 
-### Step 8  -  Package and upload
+### Step 8  -  Show the customised script
+
+Show `/tmp/github-monitor-build/main.py` to the user with the `canvas_ui` tool
+if available, otherwise display it in a fenced code block. Then ask:
+*"Does this look right? Shall I package and deploy the automation?"*
+
+Wait for confirmation before proceeding.
+
+### Step 9  -  Package and upload
 
 ```bash
 tar -czf /tmp/github-monitor.tar.gz -C /tmp/github-monitor-build .
@@ -208,7 +216,7 @@ TARBALL_PATH=$(curl -s -X POST \
 echo "Uploaded: $TARBALL_PATH"
 ```
 
-### Step 9  -  Create the automation
+### Step 10  -  Create the automation
 
 ```bash
 curl -s -X POST "${OPENHANDS_HOST}/api/automation/v1" \
@@ -225,7 +233,7 @@ curl -s -X POST "${OPENHANDS_HOST}/api/automation/v1" \
 
 Record the returned `id`.
 
-### Step 10  -  Confirm
+### Step 11  -  Confirm
 
 Tell the user:
 

--- a/skills/slack-channel-monitor/SKILL.md
+++ b/skills/slack-channel-monitor/SKILL.md
@@ -139,7 +139,15 @@ python3 -m py_compile /tmp/slack-monitor-build/main.py && echo "Syntax OK"
 
 Fix any syntax errors before proceeding.
 
-### Step 4  -  Package and upload
+### Step 4  -  Show the customised script
+
+Show `/tmp/slack-monitor-build/main.py` to the user with the `canvas_ui` tool
+if available, otherwise display it in a fenced code block. Then ask:
+*"Does this look right? Shall I package and deploy the automation?"*
+
+Wait for confirmation before proceeding.
+
+### Step 5  -  Package and upload
 
 ```bash
 tar -czf /tmp/slack-monitor.tar.gz -C /tmp/slack-monitor-build .
@@ -160,7 +168,7 @@ echo "Uploaded: $TARBALL_PATH"
 If the upload fails with a size error, the tarball must be under 1 MB.
 `main.py` is under 15 KB so this should never trigger.
 
-### Step 5  -  Create the automation
+### Step 6  -  Create the automation
 
 ```bash
 curl -s -X POST "${OPENHANDS_HOST}/api/automation/v1" \
@@ -179,7 +187,7 @@ A 55-second timeout keeps runs well within the 60-second cron window.
 
 Record the returned `id`  -  share it with the user as confirmation.
 
-### Step 6  -  Confirm
+### Step 7  -  Confirm
 
 Tell the user:
 


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The `github-repo-monitor` and `slack-channel-monitor` skills each have standalone step-by-step workflows and do not inherit from the `openhands-automation` skill (which already instructs agents to show the generated code). Without an explicit step, agents following the monitor skills proceed directly to packaging and deploying without first showing the customized script to the user.

## Summary

- Added **Step 8** to `github-repo-monitor`: show the customized `main.py` to the user via `canvas_ui` (or fenced code block) and wait for confirmation before packaging and deploying.
- Added **Step 4** to `slack-channel-monitor`: same behavior, inserted between script generation and packaging.
- Renumbered the subsequent steps in both skills accordingly.

## Issue Number

N/A

##########Test

1. Invoke the `slack-channel-monitor` skill and work through the setup1. Invoke the `slack-channel-monitor` skill and work through the setup1. Invoke theore proceeding to upload/deploy.
2. Do the same for `github-repo-monitor`.
3. Verify `openhands-automation` is unchanged (it already has this behavior in its Automation Creation Process section).

## Video/Screenshots

N/A

## Notes

_This PR was created by an AI agent (OpenHands) on behalf of the user._