### PR TITLE
fix: forward user secrets and MCP config to dispatched conversations

### DIFF
--- a/skills/github-repo-monitor/scripts/main.py
+++ b/skills/github-repo-monitor/scripts/main.py
@@ -370,16 +370,25 @@ def _oh_request(
         raise RuntimeError(f"Agent API {method} {path} → {exc.code}: {body_text}") from exc
 
 
-def _get_agent_dict(agent_url: str, api_key: str) -> dict:
-    """Fetch configured agent settings for conversation creation."""
+def _fetch_settings(agent_url: str, api_key: str) -> dict:
+    """Fetch the full user settings from the agent server.
+
+    Uses X-Expose-Secrets: plaintext so the LLM api_key is a real string
+    rather than a masked placeholder.
+    """
     url = f"{agent_url}/api/settings"
     headers = {"X-Session-API-Key": api_key, "X-Expose-Secrets": "plaintext"}
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req) as r:
-            data = json.loads(r.read())
+            return json.loads(r.read())
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"GET /api/settings failed: {exc.code}") from exc
+
+
+def _get_agent_dict(agent_url: str, api_key: str) -> dict:
+    """Fetch configured agent settings for conversation creation."""
+    data = _fetch_settings(agent_url, api_key)
     agent_settings = data.get("agent_settings", {})
     llm = agent_settings.get("llm", {})
     # settings["agent_settings"]["agent"] reflects the full-app agent registry
@@ -394,15 +403,79 @@ def _get_agent_dict(agent_url: str, api_key: str) -> dict:
     }
 
 
+def _get_mcp_config(agent_url: str, api_key: str) -> dict | None:
+    """Extract MCP server configuration from user settings, if any."""
+    try:
+        data = _fetch_settings(agent_url, api_key)
+        agent_settings = data.get("agent_settings", {})
+        mcp_config = agent_settings.get("mcp_config")
+        if isinstance(mcp_config, dict) and mcp_config.get("mcpServers"):
+            return mcp_config
+    except Exception as exc:
+        print(f"Warning: could not fetch MCP config: {exc}")
+    return None
+
+
+def _list_secret_names(agent_url: str, api_key: str) -> list[dict]:
+    """Fetch user secret names and descriptions from the agent server."""
+    try:
+        result = _oh_request(agent_url, api_key, "GET", "/api/settings/secrets")
+        return result.get("secrets", [])
+    except Exception as exc:
+        print(f"Warning: could not list secrets: {exc}")
+        return []
+
+
+def _build_secrets_payload(agent_url: str, api_key: str) -> dict:
+    """Build LookupSecret references so spawned conversations can access
+    the user's secrets via the agent server's per-secret endpoint.
+    """
+    secrets_list = _list_secret_names(agent_url, api_key)
+    if not secrets_list:
+        return {}
+    secrets: dict = {}
+    for secret in secrets_list:
+        name = secret.get("name", "")
+        if not name:
+            continue
+        lookup: dict = {
+            "kind": "LookupSecret",
+            "url": f"/api/settings/secrets/{name}",
+        }
+        if api_key:
+            lookup["headers"] = {"X-Session-API-Key": api_key}
+        desc = secret.get("description")
+        if desc:
+            lookup["description"] = desc
+        secrets[name] = lookup
+    return secrets
+
+
 def create_conversation(agent_url: str, api_key: str, initial_message: str) -> str:
-    """Create an OpenHands conversation and return its ID."""
+    """Create an OpenHands conversation and return its ID.
+
+    Inherits the user's secrets (as LookupSecret references) and MCP
+    server configuration so the spawned agent has the same capabilities.
+    """
     workspace_dir = os.environ.get("WORKSPACE_BASE", "/workspace")
     agent = _get_agent_dict(agent_url, api_key)
-    result = _oh_request(agent_url, api_key, "POST", "/api/conversations", {
+    payload: dict = {
         "workspace": {"working_dir": workspace_dir},
         "agent": agent,
         "initial_message": {"content": [{"text": initial_message}]},
-    })
+    }
+
+    # Forward user secrets so the spawned conversation can access them.
+    secrets = _build_secrets_payload(agent_url, api_key)
+    if secrets:
+        payload["secrets"] = secrets
+
+    # Forward MCP server configuration so MCP tools are available.
+    mcp_config = _get_mcp_config(agent_url, api_key)
+    if mcp_config:
+        payload["mcp_config"] = mcp_config
+
+    result = _oh_request(agent_url, api_key, "POST", "/api/conversations", payload)
     return result["id"]
 
 

--- a/skills/slack-channel-monitor/scripts/main.py
+++ b/skills/slack-channel-monitor/scripts/main.py
@@ -334,24 +334,32 @@ def _oh_request(
         raise RuntimeError(f"Agent API {method} {path} → {exc.code}: {body_text}") from exc
 
 
-def _get_agent_dict(agent_url: str, api_key: str) -> dict:
-    """Fetch configured agent settings and return a serialised Agent dict.
+def _fetch_settings(agent_url: str, api_key: str) -> dict:
+    """Fetch the full user settings from the agent server.
 
     Uses X-Expose-Secrets: plaintext so the LLM api_key is a real string
-    rather than a masked placeholder.  The result is passed as the 'agent'
-    field (not 'agent_settings') to avoid a double-registration bug: the
-    agent_settings code path calls create_agent() during request validation
-    AND again during StoredConversation construction, both of which try to
-    register the same usage_id in the LLM registry.
+    rather than a masked placeholder.
     """
     url = f"{agent_url}/api/settings"
     headers = {"X-Session-API-Key": api_key, "X-Expose-Secrets": "plaintext"}
     req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req) as r:
-            data = json.loads(r.read())
+            return json.loads(r.read())
     except urllib.error.HTTPError as exc:
         raise RuntimeError(f"GET /api/settings failed: {exc.code}") from exc
+
+
+def _get_agent_dict(agent_url: str, api_key: str) -> dict:
+    """Fetch configured agent settings and return a serialised Agent dict.
+
+    The result is passed as the 'agent' field (not 'agent_settings') to
+    avoid a double-registration bug: the agent_settings code path calls
+    create_agent() during request validation AND again during
+    StoredConversation construction, both of which try to register the
+    same usage_id in the LLM registry.
+    """
+    data = _fetch_settings(agent_url, api_key)
     agent_settings = data.get("agent_settings", {})
     llm = agent_settings.get("llm", {})
     # settings["agent_settings"]["agent"] reflects the full-app agent registry
@@ -366,12 +374,63 @@ def _get_agent_dict(agent_url: str, api_key: str) -> dict:
     }
 
 
+def _get_mcp_config(agent_url: str, api_key: str) -> dict | None:
+    """Extract MCP server configuration from user settings, if any."""
+    try:
+        data = _fetch_settings(agent_url, api_key)
+        agent_settings = data.get("agent_settings", {})
+        mcp_config = agent_settings.get("mcp_config")
+        if isinstance(mcp_config, dict) and mcp_config.get("mcpServers"):
+            return mcp_config
+    except Exception as exc:
+        print(f"Warning: could not fetch MCP config: {exc}")
+    return None
+
+
+def _list_secret_names(agent_url: str, api_key: str) -> list[dict]:
+    """Fetch user secret names and descriptions from the agent server."""
+    try:
+        result = _oh_request(agent_url, api_key, "GET", "/api/settings/secrets")
+        return result.get("secrets", [])
+    except Exception as exc:
+        print(f"Warning: could not list secrets: {exc}")
+        return []
+
+
+def _build_secrets_payload(agent_url: str, api_key: str) -> dict:
+    """Build LookupSecret references so spawned conversations can access
+    the user's secrets via the agent server's per-secret endpoint.
+    """
+    secrets_list = _list_secret_names(agent_url, api_key)
+    if not secrets_list:
+        return {}
+    secrets: dict = {}
+    for secret in secrets_list:
+        name = secret.get("name", "")
+        if not name:
+            continue
+        lookup: dict = {
+            "kind": "LookupSecret",
+            "url": f"/api/settings/secrets/{name}",
+        }
+        if api_key:
+            lookup["headers"] = {"X-Session-API-Key": api_key}
+        desc = secret.get("description")
+        if desc:
+            lookup["description"] = desc
+        secrets[name] = lookup
+    return secrets
+
+
 def create_conversation(agent_url: str, api_key: str, initial_message: str) -> str:
     """Create a conversation and return its ID.
 
     The server auto-starts the agent when initial_message is provided
     (conversation_service calls send_message(..., run=True)), so no
     separate POST to /run is needed or wanted — it would 409.
+
+    Inherits the user's secrets (as LookupSecret references) and MCP
+    server configuration so the spawned agent has the same capabilities.
     """
     # Use a dedicated directory for spawned conversations rather than the
     # automation run's WORKSPACE_BASE, which may be cleaned up between runs.
@@ -384,11 +443,23 @@ def create_conversation(agent_url: str, api_key: str, initial_message: str) -> s
     os.makedirs(workspace_dir, exist_ok=True)
 
     agent = _get_agent_dict(agent_url, api_key)
-    result = _oh_request(agent_url, api_key, "POST", "/api/conversations", {
+    payload: dict = {
         "workspace": {"working_dir": workspace_dir},
         "agent": agent,
         "initial_message": {"content": [{"text": initial_message}]},
-    })
+    }
+
+    # Forward user secrets so the spawned conversation can access them.
+    secrets = _build_secrets_payload(agent_url, api_key)
+    if secrets:
+        payload["secrets"] = secrets
+
+    # Forward MCP server configuration so MCP tools are available.
+    mcp_config = _get_mcp_config(agent_url, api_key)
+    if mcp_config:
+        payload["mcp_config"] = mcp_config
+
+    result = _oh_request(agent_url, api_key, "POST", "/api/conversations", payload)
     return result["id"]
 
 


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

Both `slack-channel-monitor` and `github-repo-monitor` scripts dispatch new OpenHands conversations via `POST /api/conversations`, but were only passing `workspace`, `agent`, and `initial_message`. The spawned conversations had **no access** to the user's secrets (GITHUB_TOKEN, SLACK_BOT_TOKEN, etc.) or MCP server configurations, making the spawned agent unable to use tools or authenticate with external services.

The agent-canvas frontend correctly builds `LookupSecret` references and forwards `mcp_config` when creating conversations (see `buildStartConversationRequest` in `agent-server-adapter.ts`), but the monitor scripts were not doing the same.

## Summary

- Extract `_fetch_settings()` from `_get_agent_dict()` for reuse across both settings and MCP config retrieval
- Add `_list_secret_names()` / `_build_secrets_payload()` to build `LookupSecret` references for all user secrets, matching the agent-canvas pattern
- Add `_get_mcp_config()` to extract MCP server configuration from user settings
- Update `create_conversation()` in both scripts to include `secrets` and `mcp_config` in the conversation creation payload

## Issue Number

N/A

## How to Test

1. Set up the local OpenHands automation stack with the Slack or GitHub monitor automation
2. Configure user secrets (e.g., `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`) in OpenHands Settings → Secrets
3. Configure MCP servers in OpenHands Settings → Agent
4. Trigger a conversation via the monitor (send a trigger phrase in Slack or post a trigger comment on GitHub)
5. Verify the spawned conversation has access to the user's secrets and MCP tools

Alternatively, verify the code changes by inspection:
- Both scripts now call `GET /api/settings/secrets` to list user secrets and build `LookupSecret` references
- Both scripts now extract `mcp_config` from `agent_settings` and include it in the payload
- The `LookupSecret` pattern matches what agent-canvas uses (`kind: "LookupSecret"`, `url: "/api/settings/secrets/{name}"`, `headers: {"X-Session-API-Key": ...}`)
- All 38 existing unit tests for `github-repo-monitor` pass unchanged

## Notes

- Changes are backward-compatible: if no secrets or MCP config exist, the payload is unchanged
- The `_fetch_settings` extraction is a minor refactor that avoids duplicating the settings fetch logic

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6a057393-620f-46e7-acee-f67009ec15f5)