### PR TITLE
feat(code-review): flag unnecessary comments

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -57,6 +57,12 @@ Identify:
 - Code that could be 3 lines instead of 10
 - Poor naming that obscures intent
 - Missing inline documentation for non-obvious logic
+- **Unnecessary comments**: flag and suggest removing comments that add noise rather than value. A 3-line change should not produce 19 lines of comments. Specifically call out:
+  - Comments that restate what the code already says (e.g. `# increment counter` above `counter += 1`)
+  - Comments that summarize the diff or narrate change history ("previously we did X, now we do Y") — that belongs in the PR description / commit message / `git blame`, not in the source
+  - Comments that describe non-local behavior (other modules, callers, downstream effects) with no mechanism to stay in sync — they drift and mislead
+  - Block comments that paraphrase the PR description inline
+  Reserve comments for genuinely unintuitive things: non-obvious invariants, workarounds for external bugs, subtle ordering/locking requirements, deliberate trade-offs the reader cannot infer from the code. When in doubt, prefer restructuring or renaming over commenting.
 
 3. **Pragmatic Problem Analysis**
 "Theory and practice sometimes clash. Theory loses. Every single time."


### PR DESCRIPTION
## Why

Requested in [this comment](https://github.com/OpenHands/software-agent-sdk/issues/3498#issuecomment-4632788586) on OpenHands/software-agent-sdk#3498.

That issue calls out PRs where a 3-line code change ships with ~19 lines of narrative comments — restating the code, summarizing the diff, or describing non-local behavior. The reporter asked that the `code-review` skill explicitly suggest removing those comments when it reviews a PR.

## Summary

In `skills/code-review/SKILL.md`, extend scenario **2. Complexity and "Good Taste" Assessment** with an `Unnecessary comments` sub-checklist that tells the reviewer to flag and suggest removal of:

- Comments that restate what the code already says.
- Comments that narrate the diff / change history ("previously we did X, now we do Y") — that belongs in the PR description / commit message / `git blame`.
- Comments that describe non-local behavior (other modules, callers, downstream effects) with no mechanism to stay in sync.
- Block comments that paraphrase the PR description inline.

…and reserves comments for genuinely unintuitive things (invariants, workarounds, ordering/locking, deliberate trade-offs). Includes the "3-line change should not produce 19 lines of comments" callback from #3498.

Placed under scenario 2 (rather than a new scenario) to avoid renumbering the rest of the framework — it's a natural fit alongside the existing "Missing inline documentation for non-obvious logic" bullet, which it complements.

## How to Test

Documentation-only change to a skill prompt. Verified by:

- Re-reading `skills/code-review/SKILL.md` to confirm the new bullet is consistent in tone and indentation with the existing list under scenario 2.
- No code paths exercised; nothing to run.

## Related

- OpenHands/software-agent-sdk#3498 — original issue about verbose PR comments.
- OpenHands/software-agent-sdk#3502 — sibling PR that added a comments policy to the SDK's `AGENTS.md`.
- OpenHands/software-agent-sdk#3530 — sibling PR adding the same policy to the SDK system prompt.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini in response to https://github.com/OpenHands/software-agent-sdk/issues/3498#issuecomment-4632788586._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/76c596c9-973a-4a62-8024-6346320e6e5a)