### PR TITLE
fix(ci): drop component prefix from release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
     ".": {
       "release-type": "node",
       "changelog-type": "github",
+      "include-component-in-tag": false,
       "skip-changelog": true,
       "extra-files": [
         { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" }


### PR DESCRIPTION
<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [ ] A human has tested these changes.

---

## Why

The `release` workflow has been failing on `main` since release-please was added (#303). In manifest mode the `node` release-type derives a non-empty component (`extensions`, from `package.json`) and `include-component-in-tag` defaults to `true`, so release-please produced `extensions-v*` tags.

That broke two things: the run died in `generate-notes` looking for a non-existent `extensions-v0.0.1` previous tag, and the eventual release tag wouldn't have matched the `npm-publish` `v*` trigger anyway.

## Summary

- Set `include-component-in-tag: false` so release tags are plain `v*`.

## Issue Number

## How to Test

I verified with a release-please dry-run against this branch (`v0.0.1` baseline tag already pushed to `171a997`):

```
npx release-please@17.3.0 release-pr --repo-url=OpenHands/extensions \
  --target-branch=jl/release-please-component-tag-fix --dry-run --token=$(gh auth token)
```

It now produces a clean `0.1.0` release PR (no `Invalid previous_tag parameter`), with `Full Changelog: v0.0.1...v0.1.0`.

## Notes

Depends on the `v0.0.1` tag I pushed at `171a997` (HEAD before #303 merged), which seeds `generate-notes`' previous tag. Once this merges, the push to `main` should cut the `0.1.0` release PR.
