### PR TITLE
feat(npm): publish the whole repo in the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 
 # uv lock file (no application code in this repo)
 uv.lock
+
+# npm pack artifacts (also keeps stray tarballs out of the published package)
+*.tgz

--- a/README.md
+++ b/README.md
@@ -45,19 +45,17 @@ React logo components are isolated behind a separate export so data-only consume
 import { INTEGRATION_LOGOS } from "@openhands/extensions/integrations/logos";
 ```
 
-The package ships the entire repository (everything except the `.gitignore`'d and npm-default-ignored files), so consumers can read the raw `skills/`, `plugins/`, and `marketplaces/` trees — and any other repo file — directly from the installed package. The catalog data and content trees are exposed as resolvable subpaths (use `import.meta.resolve` / `require.resolve` to locate them on disk, or import JSON manifests with an import attribute):
+The package ships the whole repo, so the `skills/`, `plugins/`, and `marketplaces/` trees are available from the installed package. Resolve content files to a path, or import JSON manifests directly:
 
 ```js
-// Locate skill/plugin files on disk
+// .md / .py / etc.: resolve to a path, then read with fs
 const skillPath = import.meta.resolve("@openhands/extensions/skills/code-review/SKILL.md");
-const pluginManifest = import.meta.resolve("@openhands/extensions/plugins/pr-review/.plugin/plugin.json");
 
-// Load a marketplace manifest as JSON
+// .json: import directly
 import marketplace from "@openhands/extensions/marketplaces/openhands-extensions.json" with { type: "json" };
-import largeCodebase from "@openhands/extensions/marketplaces/large-codebase.json" with { type: "json" };
 ```
 
-> **Note:** The tarball contains only regular files — symlinks are never published (npm-packlist drops them). The repo's vendor-alias symlinks (`.claude-plugin`/`.codex-plugin` → `.plugin`) and the symlinked root `.plugin/marketplace.json` are therefore not shipped; consumers read the canonical real files instead (each extension's `.plugin/plugin.json`, and the marketplace manifests under `marketplaces/`).
+Symlinks are never published, so the repo's `.claude-plugin`/`.codex-plugin` aliases don't ship; read the canonical files instead (each extension's `.plugin/plugin.json`, manifests under `marketplaces/`).
 
 See [`integrations/README.md`](integrations/README.md), [`automations/README.md`](automations/README.md), and [`MIGRATION.md`](MIGRATION.md) for catalog-specific details.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ React logo components are isolated behind a separate export so data-only consume
 import { INTEGRATION_LOGOS } from "@openhands/extensions/integrations/logos";
 ```
 
+The package ships the entire repository (everything except the `.gitignore`'d and npm-default-ignored files), so consumers can read the raw `skills/`, `plugins/`, and `marketplaces/` trees — and any other repo file — directly from the installed package. The catalog data and content trees are exposed as resolvable subpaths (use `import.meta.resolve` / `require.resolve` to locate them on disk, or import JSON manifests with an import attribute):
+
+```js
+// Locate skill/plugin files on disk
+const skillPath = import.meta.resolve("@openhands/extensions/skills/code-review/SKILL.md");
+const pluginManifest = import.meta.resolve("@openhands/extensions/plugins/pr-review/.plugin/plugin.json");
+
+// Load a marketplace manifest as JSON
+import marketplace from "@openhands/extensions/marketplaces/openhands-extensions.json" with { type: "json" };
+import largeCodebase from "@openhands/extensions/marketplaces/large-codebase.json" with { type: "json" };
+```
+
+> **Note:** The tarball contains only regular files — symlinks are never published (npm-packlist drops them). The repo's vendor-alias symlinks (`.claude-plugin`/`.codex-plugin` → `.plugin`) and the symlinked root `.plugin/marketplace.json` are therefore not shipped; consumers read the canonical real files instead (each extension's `.plugin/plugin.json`, and the marketplace manifests under `marketplaces/`).
+
 See [`integrations/README.md`](integrations/README.md), [`automations/README.md`](automations/README.md), and [`MIGRATION.md`](MIGRATION.md) for catalog-specific details.
 
 ## Extensions Catalog

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ const skillPath = import.meta.resolve("@openhands/extensions/skills/code-review/
 import marketplace from "@openhands/extensions/marketplaces/openhands-extensions.json" with { type: "json" };
 ```
 
-Symlinks are never published, so the repo's `.claude-plugin`/`.codex-plugin` aliases don't ship; read the canonical files instead (each extension's `.plugin/plugin.json`, manifests under `marketplaces/`).
-
 See [`integrations/README.md`](integrations/README.md), [`automations/README.md`](automations/README.md), and [`MIGRATION.md`](MIGRATION.md) for catalog-specific details.
 
 ## Extensions Catalog

--- a/package.json
+++ b/package.json
@@ -19,15 +19,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "index.js",
-    "index.d.ts",
-    "automations",
-    "integrations",
-    "LICENSE",
-    "MIGRATION.md",
-    "README.md"
-  ],
   "exports": {
     ".": {
       "types": "./index.d.ts",
@@ -51,6 +42,9 @@
       "default": "./integrations/logos.js"
     },
     "./integrations/catalog/*.json": "./integrations/catalog/*.json",
+    "./skills/*": "./skills/*",
+    "./plugins/*": "./plugins/*",
+    "./marketplaces/*.json": "./marketplaces/*.json",
     "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [x] A human has tested these changes.

---

## Why

The npm package only shipped the automations and integrations catalogs, so consumers couldn't read the skills, plugins, or marketplace content from the installed package.

I want the package to carry the whole repo so all the extension content is available to downstream consumers.

## Summary

- Drop the `files` allowlist so npm publishes the entire repo (minus `.gitignore`'d + npm-default cruft).
- Add `skills/*`, `plugins/*`, and `marketplaces/*.json` to `exports` so the content resolves via the package specifier.
- Ignore `*.tgz` so stray `npm pack` artifacts can't get published.

## Issue Number

## How to Test

Run `npm pack --dry-run` from the repo root. The tarball now includes the `skills/`, `plugins/`, and `marketplaces/` trees and excludes `.git/`, `node_modules/`, symlinks, and ignored files (408 files, ~542 KB).

`node --input-type=module -e 'import.meta.resolve("@openhands/extensions/skills/code-review/SKILL.md")'` resolves the new subpaths.

## Notes

This flips packaging from an allowlist to a denylist, so new root files publish by default now. Add anything that shouldn't ship to `.gitignore`.

Symlinks are never published (npm-packlist drops them), so the repo's vendor-alias symlinks and the symlinked root `.plugin/marketplace.json` don't ship - consumers read the canonical real files instead.