### PR TITLE
docs: scope bot-token guidance to trust boundary

### DIFF
--- a/plugins/pr-review/README.md
+++ b/plugins/pr-review/README.md
@@ -69,7 +69,7 @@ Add the following secrets in your repository settings (**Settings → Secrets an
 | `GITHUB_TOKEN` | Auto | Provided automatically by GitHub Actions |
 | `LMNR_SKILLS_API_KEY` | No | Laminar API key (org-level secret; mapped to `LMNR_PROJECT_API_KEY` env var in workflows) |
 
-**Note**: For repositories that need to post review comments from a bot account, use `ALLHANDS_BOT_GITHUB_PAT` instead of `GITHUB_TOKEN`.
+**Note**: To post review comments from a bot account instead of `GITHUB_TOKEN`, use a bot token scoped to the repository's trust boundary. On **public** repositories, use `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` — a fine-grained token limited to public repositories. On **private** repositories, use a bot token scoped to that repository. Never give a public repository a token that can reach private repositories.
 
 ### 3. Customize the Workflow (Optional)
 

--- a/plugins/vulnerability-remediation/README.md
+++ b/plugins/vulnerability-remediation/README.md
@@ -90,11 +90,13 @@ on:
 
 ### Optional: Use a Bot Account
 
-For better PR attribution, use a bot PAT:
+For better PR attribution, use a bot PAT scoped to the repository's trust boundary. On **public** repositories, use the public-scoped token:
 
 ```yaml
-github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT || secrets.GITHUB_TOKEN }}
+github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC || secrets.GITHUB_TOKEN }}
 ```
+
+On **private** repositories, use a bot token scoped to that repository instead. Never give a public repository a token that can reach private repositories.
 
 ## Usage
 


### PR DESCRIPTION
## Why

The pr-review and vulnerability-remediation plugin READMEs are the canonical guidance other repos copy. They recommend a single broad bot secret (`ALLHANDS_BOT_GITHUB_PAT`) for posting comments / opening PRs, with no distinction between public and private repos. That guidance drives the trust-boundary problem tracked in [evaluation#428](https://github.com/OpenHands/evaluation/issues/428) / [#478](https://github.com/OpenHands/evaluation/issues/478): a public repo ends up wired to a credential that can also reach private repos.

## Summary

- Replace `ALLHANDS_BOT_GITHUB_PAT` in both plugin READMEs with trust-boundary guidance.
- Recommend `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` (fine-grained, public-repos-only) for public repositories.
- For private repositories, recommend a token scoped to that repository — stated generically, no private secret name in a public repo.
- Add the rule: never give a public repository a token that can reach private repositories.

Docs-only; no workflow or code changes.

## How to test

- `grep -rn ALLHANDS_BOT_GITHUB_PAT plugins/` returns nothing.
- Rendered READMEs read correctly and the YAML snippet uses `OPENHANDS_BOT_GITHUB_PAT_PUBLIC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)