### PR TITLE
chore: rename GitHub PR review automation

### DIFF
--- a/automations/catalog/github-pr-reviewer.json
+++ b/automations/catalog/github-pr-reviewer.json
@@ -1,6 +1,6 @@
 {
   "id": "github-pr-reviewer",
-  "name": "GitHub PR review copilot",
+  "name": "GitHub PR Review Agent",
   "category": "Code review",
   "description": "Watch pull requests, inspect the diff, and leave a concise review with risks and suggested follow-ups.",
   "requiredIntegrationIds": [


### PR DESCRIPTION
## Summary
- rename the `github-pr-reviewer` automation from `GitHub PR review copilot` to `GitHub PR Review Agent`
- avoid referring to Microsoft GitHub Copilot when this automation is its own OpenHands review automation

## Why
`GitHub Copilot` is already a distinct Microsoft/GitHub product, so using “copilot” here is confusing and misleading. `GitHub PR Review Agent` is clearer and product-neutral.

## Testing
- `uv run --group test pytest tests/test_catalogs.py -q`

_This PR was created by an AI agent (OpenHands) on behalf of Engel Nyst._