### PR TITLE
chore: rename GitHub review automation to code review agent

### DIFF
--- a/automations/catalog/github-pr-reviewer.json
+++ b/automations/catalog/github-pr-reviewer.json
@@ -1,6 +1,6 @@
 {
   "id": "github-pr-reviewer",
-  "name": "GitHub PR Review Agent",
+  "name": "GitHub Code Review Agent",
   "category": "Code review",
   "description": "Watch pull requests, inspect the diff, and leave a concise review with risks and suggested follow-ups.",
   "requiredIntegrationIds": [


### PR DESCRIPTION
## Summary
- rename the `github-pr-reviewer` automation from `GitHub PR Review Agent` to `GitHub Code Review Agent`
- make the name clearer and less tied to only pull-request wording

## Why
`GitHub Copilot` is a distinct Microsoft/GitHub product, so we should avoid that name. After the first rename, `PR Review Agent` still felt narrower than the actual role. `GitHub Code Review Agent` is clearer and more accurate.

## Testing
- `uv run --group test pytest tests/test_catalogs.py -q`

_This PR was created by an AI agent (OpenHands) on behalf of Engel Nyst._