### PR TITLE
fix: pin lmnr below incompatible release (fixes qa-changes)

### DIFF
--- a/plugins/qa-changes/action.yml
+++ b/plugins/qa-changes/action.yml
@@ -160,7 +160,7 @@ runs:
         # so we enforce the time limit via the coreutils timeout command.
         TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
         timeout "${TIMEOUT_SECONDS}" \
-          uv run --no-project --with openhands-sdk --with openhands-tools --with lmnr \
+          uv run --no-project --with openhands-sdk --with openhands-tools --with 'lmnr<0.7.53' \
             python ../extensions/plugins/qa-changes/scripts/agent_script.py
 
     - name: Upload logs as artifact


### PR DESCRIPTION
## Summary

Pins the QA Changes composite action bootstrap to `lmnr<0.7.53`:

```bash
uv run --no-project --with openhands-sdk --with openhands-tools --with 'lmnr<0.7.53' \
  python ../extensions/plugins/qa-changes/scripts/agent_script.py
```

## Why

`lmnr 0.7.53` no longer accepts the `rollout_entrypoint` keyword in `lmnr.observe(...)`, while current released OpenHands SDK wrappers still forward `rollout_entrypoint` when observability is enabled. The QA Changes action bootstraps with unpinned `--with lmnr`, so it can pick up `0.7.53` and fail before QA starts with:

```text
observe() got an unexpected keyword argument 'rollout_entrypoint'
```

Pinning below `0.7.53` restores the compatible `lmnr.observe` signature for the QA harness.

## Validation

- Parsed `plugins/qa-changes/action.yml` with PyYAML and verified the pin is present.
- Reproduced the compatible bootstrap shape with SDK `1.28.0` and `lmnr<0.7.53`:

```bash
OPENHANDS_SUPPRESS_BANNER=1 LMNR_PROJECT_API_KEY=dummy \
uv run --no-project \
  --with openhands-sdk==1.28.0 \
  --with openhands-tools==1.28.0 \
  --with 'lmnr<0.7.53' \
  python - <<'PY'
import importlib.metadata as md
from openhands.sdk.observability.laminar import observe

@observe(name='repro')
def f():
    return 'ok'

print('lmnr', md.version('lmnr'), f())
PY
```

Output used `lmnr 0.7.52` and returned `ok` without the `rollout_entrypoint` TypeError.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/aa3d3e7a-4bec-4725-85cd-045150670b20)